### PR TITLE
Remove deprecated arithmetic notations

### DIFF
--- a/algebra/Expon.v
+++ b/algebra/Expon.v
@@ -501,13 +501,13 @@ Proof.
   simpl in |- *.
   rational.
  rewrite Znat.inj_S.
- replace (Zsucc (Z_of_nat n)) with (1 + Z_of_nat n)%Z.
+ replace (Z.succ (Z_of_nat n)) with (1 + Z_of_nat n)%Z.
   rewrite Zopp_plus_distr.
   rewrite Zplus_comm.
-  unfold Zopp at 2 in |- *.
+  unfold Z.opp at 2 in |- *.
   rewrite Zplus_assoc.
   reflexivity.
- unfold Zsucc in |- *.
+ unfold Z.succ in |- *.
  apply Zplus_comm.
 Qed.
 
@@ -544,7 +544,7 @@ Proof.
    algebra.
   algebra.
  intros.
- rewrite Zopp_involutive.
+ rewrite Z.opp_involutive.
  astepl (x[^]n).
  astepl ((x[^]n) [/]OneNZ).
  apply eq_div.
@@ -569,7 +569,7 @@ Proof.
   astepr ((x[//]Hx) [^^] (m) [*] (([1][/] (x[//]Hx) [^^] (m) [//]zexp_resp_ap_zero x m Hx) [*]x)).
   rational.
  rewrite Zopp_plus_distr.
- rewrite Zopp_involutive.
+ rewrite Z.opp_involutive.
  reflexivity.
 Qed.
 
@@ -700,10 +700,10 @@ Proof.
  intros x m H Hx Hneg.
  pattern m in |- *.
  rewrite ->  Zeven.Zeven_div2.
-  astepl (([--]x[//]Hneg) [^^] (2) [//]zexp_resp_ap_zero [--]x 2 Hneg) [^^] (Zeven.Zdiv2 m).
-  astepl ([--]x[*][--]x[//]mult_resp_ap_zero _ _ _ Hneg Hneg) [^^] (Zeven.Zdiv2 m).
-  astepl (x[*]x[//]mult_resp_ap_zero _ _ _ Hx Hx) [^^] (Zeven.Zdiv2 m).
-  astepl ((x[//]Hx) [^^] (2) [//]zexp_resp_ap_zero x 2 Hx) [^^] (Zeven.Zdiv2 m).
+  astepl (([--]x[//]Hneg) [^^] (2) [//]zexp_resp_ap_zero [--]x 2 Hneg) [^^] (Z.div2 m).
+  astepl ([--]x[*][--]x[//]mult_resp_ap_zero _ _ _ Hneg Hneg) [^^] (Z.div2 m).
+  astepl (x[*]x[//]mult_resp_ap_zero _ _ _ Hx Hx) [^^] (Z.div2 m).
+  astepl ((x[//]Hx) [^^] (2) [//]zexp_resp_ap_zero x 2 Hx) [^^] (Z.div2 m).
   algebra.
  assumption.
 Qed.

--- a/coq_reals/Rreals.v
+++ b/coq_reals/Rreals.v
@@ -451,8 +451,8 @@ Proof.
   change (e / 2 = e * / (0 + 1 + 1)).
   field.
  intro x.
- exists (Zabs_nat (up x)).
- unfold Zabs_nat.
+ exists (Z.abs_nat (up x)).
+ unfold Z.abs_nat.
  elim (archimed x).
  destruct (up x).
    simpl; intros; lra.

--- a/liouville/Liouville.v
+++ b/liouville/Liouville.v
@@ -236,7 +236,7 @@ Proof.
  unfold inject_Z.
  rewrite <- inj_Q_One.
  apply inj_Q_leEq.
- unfold Zabs.
+ unfold Z.abs.
  destruct p.
    destruct Hap; reflexivity.
   simpl; unfold Qle; simpl; intuition.
@@ -248,10 +248,10 @@ Lemma Liouville_lemma5 : forall (p : Z_as_CRing) (q : positive), (zx2qx P) ! (p#
 Proof.
  intros p q Hap.
  set (n := ZX_deg P).
- assert (Zpos q=Zabs q); [reflexivity|].
+ assert (Zpos q=Z.abs q); [reflexivity|].
  rewrite H; clear H.
  rewrite <- nexp_ring_hom.
- assert (((Zabs q):Q_as_CRing)[^]n [=] Zabs ((q:Z_as_CRing)[^]n)).
+ assert (((Z.abs q):Q_as_CRing)[^]n [=] Z.abs ((q:Z_as_CRing)[^]n)).
   generalize n; clear; induction n; [reflexivity|].
   rewrite <- nexp_Sn.
   rewrite <- nexp_Sn.
@@ -346,7 +346,7 @@ Proof.
  rewrite <- (rh_pres_unit _ _ inj_Q_rh).
  apply inj_Q_leEq.
  simpl; unfold Qle; simpl; rewrite Pmult_1_r.
- unfold Zle; simpl.
+ unfold Z.le; simpl.
  case q; intros; discriminate.
 Qed.
 

--- a/liouville/QX_extract_roots.v
+++ b/liouville/QX_extract_roots.v
@@ -93,7 +93,7 @@ Proof.
  assert (forall x y : Q_as_CRing, {x = y} + {x <> y}).
   clear; intros x y.
   destruct x; destruct y; simpl.
-  case (Z_eq_dec Qnum Qnum0); case (Z_eq_dec Qden Qden0); intros H1 H2.
+  case (Z.eq_dec Qnum Qnum0); case (Z.eq_dec Qden Qden0); intros H1 H2.
      left; f_equal; [assumption|injection H1; tauto].
     right; intro H3; injection H3; intros; destruct H1; f_equal; assumption.
    right; intro H3; injection H3; intros; destruct H2; assumption.

--- a/liouville/Q_can.v
+++ b/liouville/Q_can.v
@@ -26,7 +26,7 @@ Section Q_can.
 
 Lemma Q_dec : forall x y : Q_as_CRing, (x [=] y) or (x [#] y).
 Proof. intros x y; case (Qeq_dec x y); [left|right]; assumption. Qed.
-Definition Q_can_num (q : Q_as_CRing) : Z_as_CRing := Zdiv (Qnum q) (Zgcd (Qnum q) (Qden q)).
+Definition Q_can_num (q : Q_as_CRing) : Z_as_CRing := Z.div (Qnum q) (Zgcd (Qnum q) (Qden q)).
 
 Lemma Q_can_num_spec : forall q q', q [=] q' -> Q_can_num q = Q_can_num q'.
 Proof.
@@ -45,17 +45,17 @@ Proof.
    try (intro H; destruct (Zgcd_zero _ _ H); discriminate).
  rewrite Zmult_comm, (Zmult_comm _ q'n).
  rewrite <- (Zabs_Zsgn qn) at 1; rewrite <- (Zabs_Zsgn q'n) at 2.
- rewrite (Zmult_comm (Zabs qn)), (Zmult_comm (Zabs q'n)).
+ rewrite (Zmult_comm (Z.abs qn)), (Zmult_comm (Z.abs q'n)).
  rewrite <- Zmult_assoc, <- Zmult_assoc.
  rewrite Zgcd_lin, Zgcd_lin.
  rewrite Heq.
  rewrite (Zmult_comm qn q'n).
- cut (Zsgn qn = Zsgn q'n).
+ cut (Z.sgn qn = Z.sgn q'n).
   intro H; rewrite H; reflexivity.
  destruct qn; destruct q'n; reflexivity||discriminate.
 Qed.
 
-Definition Q_can_den (q : Q_as_CRing) : Z_as_CRing := Zdiv (Qden q) (Zgcd (Qnum q) (Qden q)).
+Definition Q_can_den (q : Q_as_CRing) : Z_as_CRing := Z.div (Qden q) (Zgcd (Qnum q) (Qden q)).
 
 Lemma Q_can_den_spec : forall q q', q [=] q' -> Q_can_den q = Q_can_den q'.
 Proof.
@@ -74,7 +74,7 @@ Proof.
    try (intro H; destruct (Zgcd_zero _ _ H); discriminate).
  rewrite Zmult_comm, (Zmult_comm _ q'd).
  rewrite <- (Zabs_Zsgn qd) at 1; rewrite <- (Zabs_Zsgn q'd) at 2.
- rewrite (Zmult_comm (Zabs qd)), (Zmult_comm (Zabs q'd)).
+ rewrite (Zmult_comm (Z.abs qd)), (Zmult_comm (Z.abs q'd)).
  rewrite <- Zmult_assoc, <- Zmult_assoc.
  rewrite Zgcd_lin, Zgcd_lin.
  rewrite (Zmult_comm qd q'n), (Zmult_comm q'd qn).

--- a/liouville/Zlcm.v
+++ b/liouville/Zlcm.v
@@ -24,28 +24,28 @@ Section Zgcd_lin.
 
 Lemma Z_dec : forall x y : Z_as_CRing, x [=] y or x [#] y.
 Proof.
- intros x y; case (Z_eq_dec x y).
+ intros x y; case (Z.eq_dec x y).
   left; assumption.
  right; assumption.
 Qed.
 
-Lemma Zgcd_lin : forall a b c, (Zabs c * Zgcd a b = Zgcd (c * a) (c * b))%Z.
+Lemma Zgcd_lin : forall a b c, (Z.abs c * Zgcd a b = Zgcd (c * a) (c * b))%Z.
 Proof.
  intros a b c.
- case (Z_eq_dec a 0).
+ case (Z.eq_dec a 0).
   intro H; rewrite H; rewrite Zmult_0_r, Zgcd_zero_lft, Zgcd_zero_lft; apply Zabs_mult_compat.
- intro Ha; case (Z_eq_dec b 0).
+ intro Ha; case (Z.eq_dec b 0).
   intro H; rewrite H; rewrite Zmult_0_r, Zgcd_zero_rht, Zgcd_zero_rht; apply Zabs_mult_compat.
- intro Hb; case (Z_eq_dec c 0).
+ intro Hb; case (Z.eq_dec c 0).
   intro H; rewrite H; rewrite Zmult_0_l, Zmult_0_l, Zmult_0_l, Zgcd_zero_lft; reflexivity.
  intro Hc; apply Zdivides_antisymm.
-    rewrite <- (Zmult_0_r (Zabs c)).
+    rewrite <- (Zmult_0_r (Z.abs c)).
     apply Zmult_pos_mon_lt_lft.
-     apply Zlt_gt.
+     apply Z.lt_gt.
      apply Zgcd_pos.
      left; assumption.
     destruct c; [destruct Hc| |]; reflexivity.
-   apply Zlt_gt.
+   apply Z.lt_gt.
    apply Zgcd_pos.
    left.
    intro H0; destruct (Zmult_zero_div _ _ H0).
@@ -60,14 +60,14 @@ Proof.
    apply Zdivides_abs_elim_lft.
    apply Zdivides_ref.
   apply Zgcd_is_divisor_rht.
- cut (forall c : positive, Zdivides (Zgcd (c * a) (c * b)) (Zabs c * Zgcd a b)).
+ cut (forall c : positive, Zdivides (Zgcd (c * a) (c * b)) (Z.abs c * Zgcd a b)).
   intro H; case c.
     simpl; rewrite Zgcd_zero_lft; apply Zdivides_ref.
    apply H.
   intro p; rewrite Zgcd_abs.
   rewrite <- Zabs_mult_compat, <- Zabs_mult_compat.
-  simpl (Zabs (Zneg p)).
-  assert ((p:Z) = Zabs p).
+  simpl (Z.abs (Zneg p)).
+  assert ((p:Z) = Z.abs p).
    reflexivity.
   rewrite H0; clear H0.
   rewrite Zabs_mult_compat, Zabs_mult_compat.
@@ -76,7 +76,7 @@ Proof.
  clear c Hc; intro c.
  rewrite (Zgcd_lin_comb a b).
  rewrite Zmult_plus_distr_r.
- simpl (Zabs c).
+ simpl (Z.abs c).
  rewrite Zmult_assoc, Zmult_assoc.
  rewrite (Zmult_comm c (Zgcd_coeff_a a b)).
  rewrite (Zmult_comm c (Zgcd_coeff_b a b)).
@@ -90,13 +90,13 @@ Qed.
 
 End Zgcd_lin.
 
-Definition Zlcm (a b : Z_as_CRing) : Z_as_CRing := Zdiv (a [*] b) (Zgcd a b).
+Definition Zlcm (a b : Z_as_CRing) : Z_as_CRing := Z.div (a [*] b) (Zgcd a b).
 
 Lemma Zlcm_specl : forall a b : Z_as_CRing, Zdivides a (Zlcm a b).
 Proof.
  intros a b.
  unfold Zlcm.
- case (Z_eq_dec (Zgcd a b) ([0]:Z_as_CRing)).
+ case (Z.eq_dec (Zgcd a b) ([0]:Z_as_CRing)).
   intro H; rewrite H; simpl.
   rewrite Zdiv_0_r.
   apply Zdivides_zero_rht.
@@ -111,7 +111,7 @@ Lemma Zlcm_specr : forall a b : Z_as_CRing, Zdivides b (Zlcm a b).
 Proof.
  intros a b.
  unfold Zlcm.
- case (Z_eq_dec (Zgcd a b) ([0]:Z_as_CRing)).
+ case (Z.eq_dec (Zgcd a b) ([0]:Z_as_CRing)).
   intro H; rewrite H; simpl.
   rewrite Zdiv_0_r.
   apply Zdivides_zero_rht.
@@ -126,17 +126,17 @@ Qed.
 Lemma Zlcm_spec : forall a b c : Z_as_CRing, Zdivides a c -> Zdivides b c -> Zdivides (Zlcm a b) c.
 Proof.
  intros a b c Hac Hbc; unfold Zlcm; simpl.
- case (Z_eq_dec (Zgcd a b) ([0]:Z_as_CRing)).
+ case (Z.eq_dec (Zgcd a b) ([0]:Z_as_CRing)).
   intro H; rewrite H; simpl.
   destruct (Zgcd_zero _ _ H).
   rewrite H0 in Hac; clear H H0 H1.
   rewrite Zdiv_0_r; assumption.
- case (Z_eq_dec c ([0]:Z_as_CRing)).
+ case (Z.eq_dec c ([0]:Z_as_CRing)).
   intro Hc; rewrite Hc.
   intro Hap; apply Zdivides_zero_rht.
  intros Hc Hap.
  apply Zdivides_abs_intro_rht.
- rewrite <- (Zmult_1_r (Zabs c)).
+ rewrite <- (Zmult_1_r (Z.abs c)).
  rewrite <- (Zgcd_div_gcd_1 a b); [|assumption].
  rewrite Zgcd_lin.
  apply Zdiv_gcd_elim.
@@ -174,7 +174,7 @@ Qed.
 Lemma Zlcm_zero : forall p q, Zlcm p q [=] [0] -> p [=] [0] or q [=] [0].
 Proof.
  intros p q; unfold Zlcm; intro Heq.
- case (Z_eq_dec p ([0]:Z_as_CRing)).
+ case (Z.eq_dec p ([0]:Z_as_CRing)).
   left; assumption.
  intro Happ; right.
  simpl in *.
@@ -228,14 +228,14 @@ Qed.
 Lemma Zdivides_spec : forall (a b : Z), Zdivides a b -> (a * (b / a) = b)%Z.
 Proof.
  intros a b Hdiv.
- case (Z_eq_dec a 0).
+ case (Z.eq_dec a 0).
   intro H; rewrite H; simpl.
   symmetry; apply Zdivides_zero_lft; rewrite <- H; assumption.
  intro  Hap.
  rewrite <- Z_div_exact_full_2.
    reflexivity.
   assumption.
- case (Z_eq_dec a 0).
+ case (Z.eq_dec a 0).
   intro H; rewrite H; simpl; apply Zmod_0_r.
  intro H; clear H.
  apply Zmod0_Zdivides; assumption.

--- a/liouville/nat_Q_lists.v
+++ b/liouville/nat_Q_lists.v
@@ -63,10 +63,10 @@ Definition nat_prod_to_Q (pq : nat * nat) : list Q_as_CRing :=
   end.
 
 Definition list_Q (a b : Z_as_CRing) : list Q_as_CRing :=
-  flat_map nat_prod_to_Q (list_nat_prod (Zabs_nat a) (Zabs_nat b)).
+  flat_map nat_prod_to_Q (list_nat_prod (Z.abs_nat a) (Z.abs_nat b)).
 
-Lemma list_Q_spec_pos : forall a b c d, Zabs_nat c <= Zabs_nat a ->
-  Zabs_nat (Zpos d) <= Zabs_nat b -> In (Qmake c d) (list_Q a b).
+Lemma list_Q_spec_pos : forall a b c d, Z.abs_nat c <= Z.abs_nat a ->
+  Z.abs_nat (Zpos d) <= Z.abs_nat b -> In (Qmake c d) (list_Q a b).
 Proof.
  intros a b c d Hca Hdb.
  case (Qeq_dec (c#d)%Q [0]).
@@ -89,16 +89,16 @@ Proof.
   apply nat_of_P_inj; symmetry; assumption.
  unfold list_Q.
  rewrite -> in_flat_map.
- exists (Zabs_nat c, Zabs_nat d).
+ exists (Z.abs_nat c, Z.abs_nat d).
  split.
   apply list_nat_prod_spec; assumption.
  simpl.
  case (ZL4 d).
  intros d' Hd'.
- unfold Zabs_nat at 1 in Hdb.
+ unfold Z.abs_nat at 1 in Hdb.
  rewrite Hd'.
  rewrite Hd' in Hdb.
- case_eq (Zabs_nat c).
+ case_eq (Z.abs_nat c).
   intro Heq.
   destruct H.
   destruct c.
@@ -135,14 +135,14 @@ Proof.
  symmetry; assumption.
 Qed.
 
-Lemma list_Q_spec_neg : forall a b c d, Zabs_nat c <= Zabs_nat a ->
-  Zabs_nat (Zneg d) <= Zabs_nat b -> In (Qmake c d) (list_Q a b).
+Lemma list_Q_spec_neg : forall a b c d, Z.abs_nat c <= Z.abs_nat a ->
+  Z.abs_nat (Zneg d) <= Z.abs_nat b -> In (Qmake c d) (list_Q a b).
 Proof.
  intros a b c d.
  apply list_Q_spec_pos.
 Qed.
 
-Lemma list_Q_spec_zero : forall a b d, nat_of_P d <= Zabs_nat b ->
+Lemma list_Q_spec_zero : forall a b d, nat_of_P d <= Z.abs_nat b ->
   In (Qmake Z0 d) (list_Q a b).
 Proof.
  intros a b d Hle.
@@ -163,7 +163,7 @@ Proof.
 Qed.
 
 Lemma div_imp_leq : forall a b : Z_as_CRing,
-  b [#] [0] -> Zdivides a b -> Zabs_nat a <= Zabs_nat b.
+  b [#] [0] -> Zdivides a b -> Z.abs_nat a <= Z.abs_nat b.
 Proof.
  intros a b Hap Hdiv.
  destruct Hdiv.
@@ -177,20 +177,20 @@ Proof.
   destruct (ZL4 p).
   rewrite H0.
   simpl.
-  rewrite <- (plus_0_r (Zabs_nat a)) at 1.
+  rewrite <- (plus_0_r (Z.abs_nat a)) at 1.
   apply plus_le_compat_l.
   apply le_O_n.
  simpl.
  destruct (ZL4 p).
  rewrite H0.
  simpl.
- rewrite <- (plus_0_r (Zabs_nat a)) at 1.
+ rewrite <- (plus_0_r (Z.abs_nat a)) at 1.
  apply plus_le_compat_l.
  apply le_O_n.
 Qed.
 
 Lemma list_Q_spec : forall (a b : Z_as_CRing) q, a [#] [0] -> b [#] [0] ->
-  Zdivides (Q_can_num q) a -> Zdivides (Zabs_nat (Q_can_den_pos_val q)) b ->
+  Zdivides (Q_can_num q) a -> Zdivides (Z.abs_nat (Q_can_den_pos_val q)) b ->
   In (Q_can q) (list_Q a b).
 Proof.
  intros a b q Hapa Hapb Ha Hb.
@@ -199,7 +199,7 @@ Proof.
    apply list_Q_spec_zero.
    revert Hb; generalize (Q_can_den_pos_val (0#qd)%Q).
    intros p Hdiv.
-   assert (nat_of_P p = Zabs_nat p).
+   assert (nat_of_P p = Z.abs_nat p).
     reflexivity.
    rewrite H; apply div_imp_leq.
     assumption.

--- a/logic/CLogic.v
+++ b/logic/CLogic.v
@@ -623,7 +623,7 @@ Proof.
   apply H1.
   assumption.
  rewrite Znat.inj_S.
- unfold Zsucc in |- *.
+ unfold Z.succ in |- *.
  rewrite Zopp_plus_distr.
  reflexivity.
 Qed.
@@ -1278,25 +1278,25 @@ Lemma toCProp_Zlt : forall x y : Z, (x < y)%Z -> Zlts x y.
 Proof.
  intros x y H.
  unfold Zlts in |- *.
- unfold Zlt in H.
+ unfold Z.lt in H.
  auto.
 Qed.
 
 Lemma CZlt_to : forall x y : Z, Zlts x y -> (x < y)%Z.
 Proof.
  intros x y H.
- unfold Zlt in |- *.
+ unfold Z.lt in |- *.
  inversion H.
  auto.
 Qed.
 
-Lemma Zsgn_1 : forall x : Z, {Zsgn x = 0%Z} + {Zsgn x = 1%Z} + {Zsgn x = (-1)%Z}.
+Lemma Zsgn_1 : forall x : Z, {Z.sgn x = 0%Z} + {Z.sgn x = 1%Z} + {Z.sgn x = (-1)%Z}.
 Proof.
  intro x.
  case x.
    left.
    left.
-   unfold Zsgn in |- *.
+   unfold Z.sgn in |- *.
    reflexivity.
   intro p.
   simpl in |- *.
@@ -1309,7 +1309,7 @@ Proof.
  reflexivity.
 Qed.
 
-Lemma Zsgn_2 : forall x : Z, Zsgn x = 0%Z -> x = 0%Z.
+Lemma Zsgn_2 : forall x : Z, Z.sgn x = 0%Z -> x = 0%Z.
 Proof.
  intro x.
  case x.
@@ -1321,7 +1321,7 @@ Proof.
  inversion H.
 Qed.
 
-Lemma Zsgn_3 : forall x : Z, x <> 0%Z -> Zsgn x <> 0%Z.
+Lemma Zsgn_3 : forall x : Z, x <> 0%Z -> Z.sgn x <> 0%Z.
 Proof.
  intro x.
  case x.
@@ -1362,39 +1362,39 @@ Proof.
  cut (P_of_succ_nat (nat_of_P p) = P_of_succ_nat (S x)).
   intro H1.
   rewrite P_of_succ_nat_o_nat_of_P_eq_succ in H1.
-  cut (Ppred (Psucc p) = Ppred (P_of_succ_nat (S x))).
+  cut (Pos.pred (Pos.succ p) = Pos.pred (P_of_succ_nat (S x))).
    intro H2.
-   rewrite Ppred_succ in H2.
+   rewrite Pos.pred_succ in H2.
    simpl in H2.
-   rewrite Ppred_succ in H2.
+   rewrite Pos.pred_succ in H2.
    auto.
-  apply f_equal with (A := positive) (B := positive) (f := Ppred).
+  apply f_equal with (A := positive) (B := positive) (f := Pos.pred).
   assumption.
  apply f_equal with (f := P_of_succ_nat).
  assumption.
 Qed.
 
-Theorem Zsgn_4 : forall a : Z, a = (Zsgn a * Zabs_nat a)%Z.
+Theorem Zsgn_4 : forall a : Z, a = (Z.sgn a * Z.abs_nat a)%Z.
 Proof.
  intro a.
  case a.
    simpl in |- *.
    reflexivity.
   intro p.
-  unfold Zsgn in |- *.
-  unfold Zabs_nat in |- *.
+  unfold Z.sgn in |- *.
+  unfold Z.abs_nat in |- *.
   rewrite Zmult_1_l.
   symmetry  in |- *.
   apply ZL9.
  intro p.
- unfold Zsgn in |- *.
- unfold Zabs_nat in |- *.
+ unfold Z.sgn in |- *.
+ unfold Z.abs_nat in |- *.
  rewrite ZL9.
  constructor.
 Qed.
 
 Theorem Zsgn_5 : forall a b x y : Z, x <> 0%Z -> y <> 0%Z ->
- (Zsgn a * x)%Z = (Zsgn b * y)%Z -> (Zsgn a * y)%Z = (Zsgn b * x)%Z.
+ (Z.sgn a * x)%Z = (Z.sgn b * y)%Z -> (Z.sgn a * y)%Z = (Z.sgn b * x)%Z.
 Proof.
  intros a b x y H H0.
  case a.
@@ -1402,27 +1402,27 @@ Proof.
      simpl in |- *.
      trivial.
     intro p.
-    unfold Zsgn in |- *.
+    unfold Z.sgn in |- *.
     intro H1.
     rewrite Zmult_1_l in H1.
     simpl in H1.
     elim H0.
     auto.
    intro p.
-   unfold Zsgn in |- *.
+   unfold Z.sgn in |- *.
    intro H1.
    elim H0.
-   apply Zopp_inj.
+   apply Z.opp_inj.
    simpl in |- *.
    transitivity (-1 * y)%Z; auto.
   intro p.
-  unfold Zsgn at 1 in |- *.
-  unfold Zsgn at 2 in |- *.
+  unfold Z.sgn at 1 in |- *.
+  unfold Z.sgn at 2 in |- *.
   intro H1.
   transitivity y.
    rewrite Zmult_1_l.
    reflexivity.
-  transitivity (Zsgn b * (Zsgn b * y))%Z.
+  transitivity (Z.sgn b * (Z.sgn b * y))%Z.
    case (Zsgn_1 b).
     intro H2.
     case H2.
@@ -1444,19 +1444,19 @@ Proof.
   rewrite H1.
   reflexivity.
  intro p.
- unfold Zsgn at 1 in |- *.
- unfold Zsgn at 2 in |- *.
+ unfold Z.sgn at 1 in |- *.
+ unfold Z.sgn at 2 in |- *.
  intro H1.
- transitivity (Zsgn b * (-1 * (Zsgn b * y)))%Z.
+ transitivity (Z.sgn b * (-1 * (Z.sgn b * y)))%Z.
   case (Zsgn_1 b).
    intro H2.
    case H2.
     intro H3.
     elim H.
-    apply Zopp_inj.
+    apply Z.opp_inj.
     transitivity (-1 * x)%Z.
      ring.
-    unfold Zopp in |- *.
+    unfold Z.opp in |- *.
     rewrite H3 in H1.
     transitivity (0 * y)%Z; auto.
    intro H3.
@@ -1473,7 +1473,7 @@ Qed.
 Lemma nat_nat_pos : forall m n : nat, ((m + 1) * (n + 1) > 0)%Z.
 Proof.
  intros m n.
- apply Zlt_gt.
+ apply Z.lt_gt.
  cut (Z_of_nat m + 1 > 0)%Z.
   intro H.
   cut (0 < Z_of_nat n + 1)%Z.
@@ -1482,13 +1482,13 @@ Proof.
     rewrite Zmult_0_r.
     auto.
    apply Zlt_reg_mult_l; auto.
-  change (0 < Zsucc (Z_of_nat n))%Z in |- *.
+  change (0 < Z.succ (Z_of_nat n))%Z in |- *.
   apply Zle_lt_succ.
   change (Z_of_nat 0 <= Z_of_nat n)%Z in |- *.
   apply Znat.inj_le.
   apply le_O_n.
- apply Zlt_gt.
- change (0 < Zsucc (Z_of_nat m))%Z in |- *.
+ apply Z.lt_gt.
+ change (0 < Z.succ (Z_of_nat m))%Z in |- *.
  apply Zle_lt_succ.
  change (Z_of_nat 0 <= Z_of_nat m)%Z in |- *.
  apply Znat.inj_le.
@@ -1503,7 +1503,7 @@ Proof.
  omega.
 Qed.
 
-Lemma absolu_1 : forall x : Z, Zabs_nat x = 0 -> x = 0%Z.
+Lemma absolu_1 : forall x : Z, Z.abs_nat x = 0 -> x = 0%Z.
 Proof.
  intros x H.
  case (dec_eq x 0).
@@ -1517,13 +1517,13 @@ Proof.
    intros H3 H4.
    auto.
   intro H2.
-  cut (exists h : nat, Zabs_nat x = S h).
+  cut (exists h : nat, Z.abs_nat x = S h).
    intro H3.
    case H3.
    rewrite H.
    exact O_S.
   change (x < 0)%Z in H2.
-  set (H3 := Zlt_gt _ _ H2) in *.
+  set (H3 := Z.lt_gt _ _ H2) in *.
   elim (Zcompare_Gt_spec _ _ H3).
   intros x0 H5.
   cut (exists q : positive, x = Zneg q).
@@ -1531,7 +1531,7 @@ Proof.
    case H6.
    intros x1 H7.
    rewrite H7.
-   unfold Zabs_nat in |- *.
+   unfold Z.abs_nat in |- *.
    generalize x1.
    exact ZL4.
   cut (x = (- Zpos x0)%Z).
@@ -1539,10 +1539,10 @@ Proof.
    intro H6.
    exists x0.
    assumption.
-  rewrite <- (Zopp_involutive x).
-  exact (f_equal Zopp H5).
+  rewrite <- (Z.opp_involutive x).
+  exact (f_equal Z.opp H5).
  intro H2.
- cut (exists h : nat, Zabs_nat x = S h).
+ cut (exists h : nat, Z.abs_nat x = S h).
   intro H3.
   case H3.
   rewrite H.
@@ -1552,12 +1552,12 @@ Proof.
  rewrite Zplus_0_r.
  intros x0 H4.
  rewrite H4.
- unfold Zabs_nat in |- *.
+ unfold Z.abs_nat in |- *.
  generalize x0.
  exact ZL4.
 Qed.
 
-Lemma absolu_2 : forall x : Z, x <> 0%Z -> Zabs_nat x <> 0.
+Lemma absolu_2 : forall x : Z, x <> 0%Z -> Z.abs_nat x <> 0.
 Proof.
  intros x H.
  intro H0.
@@ -1597,12 +1597,12 @@ Lemma Zgt_mult_reg_absorb_l : forall a x y : Z,
 Proof.
  intros a x y H H0.
  cut (- a < - (0))%Z.
-  rewrite <- (Zopp_involutive a) in H.
-  rewrite <- (Zopp_involutive 0) in H.
+  rewrite <- (Z.opp_involutive a) in H.
+  rewrite <- (Z.opp_involutive 0) in H.
   simpl in |- *.
   intro H1.
-  rewrite <- (Zopp_involutive x).
-  rewrite <- (Zopp_involutive y).
+  rewrite <- (Z.opp_involutive x).
+  rewrite <- (Z.opp_involutive y).
   apply Zlt_opp.
   apply Zgt_mult_conv_absorb_l with (a := (- a)%Z) (x := (- x)%Z).
    assumption.
@@ -1611,9 +1611,9 @@ Proof.
   apply Zlt_opp.
   rewrite <- Zopp_mult_distr_r.
   rewrite <- Zopp_mult_distr_r.
-  apply Zgt_lt.
+  apply Z.gt_lt.
   apply Zlt_opp.
-  apply Zgt_lt.
+  apply Z.gt_lt.
   assumption.
  omega.
 Qed.

--- a/logic/CornBasics.v
+++ b/logic/CornBasics.v
@@ -330,7 +330,7 @@ Proof.
    reflexivity.
   intros n H1.
   simpl in |- *.
-  rewrite Ppred_succ.
+  rewrite Pos.pred_succ.
   reflexivity.
  exists (pred (nat_of_P p)).
  apply S_pred with 0.
@@ -501,7 +501,7 @@ Proof.
   apply H1.
   assumption.
  rewrite Znat.inj_S.
- unfold Zsucc in |- *.
+ unfold Z.succ in |- *.
  rewrite Zopp_plus_distr.
  reflexivity.
 Qed.
@@ -631,14 +631,14 @@ Lemma Zlt_reg_mult_l : forall x y z : Z,
 Proof.
  intros x y z H H0.
  case (Zcompare_Gt_spec x 0).
-  unfold Zgt in H.
+  unfold Z.gt in H.
   assumption.
  intros x0 H1.
  cut (x = Zpos x0).
   intro H2.
   rewrite H2.
-  unfold Zlt in H0.
-  unfold Zlt in |- *.
+  unfold Z.lt in H0.
+  unfold Z.lt in |- *.
   cut ((Zpos x0 * y ?= Zpos x0 * z)%Z = (y ?= z)%Z).
    intro H3.
    exact (trans_eq H3 H0).
@@ -663,7 +663,7 @@ Proof.
    exact (trans_eq H0 H1).
   exact (Zcompare_opp y x).
  apply sym_eq.
- exact (Zlt_gt x y H).
+ exact (Z.lt_gt x y H).
 Qed.
 
 Lemma Zlt_conv_mult_l : forall x y z : Z,
@@ -685,8 +685,8 @@ Proof.
        intro H6.
        rewrite H6 in H4.
        assumption.
-      exact (Zopp_involutive (x * z)).
-     exact (Zopp_involutive (x * y)).
+      exact (Z.opp_involutive (x * z)).
+     exact (Z.opp_involutive (x * y)).
     cut ((- (- x * y))%Z = (- - (x * y))%Z).
      intro H4.
      rewrite H4 in H3.
@@ -696,11 +696,11 @@ Proof.
       assumption.
      cut ((- x * z)%Z = (- (x * z))%Z).
       intro H5.
-      exact (f_equal Zopp H5).
+      exact (f_equal Z.opp H5).
      exact (Zopp_mult_distr_l_reverse x z).
     cut ((- x * y)%Z = (- (x * y))%Z).
      intro H4.
-     exact (f_equal Zopp H4).
+     exact (f_equal Z.opp H4).
     exact (Zopp_mult_distr_l_reverse x y).
    exact (Zlt_opp (- x * y) (- x * z) H2).
   exact (Zlt_reg_mult_l (- x) y z H1 H0).
@@ -722,7 +722,7 @@ Proof.
     assumption.
    exact (sym_eq H2).
   exact (Zorder.Zlt_not_eq y x H0).
- exact (Zgt_lt x y H).
+ exact (Z.gt_lt x y H).
 Qed.
 
 Lemma Zmult_absorb : forall x y z : Z,
@@ -758,7 +758,7 @@ Proof.
     assumption.
    exact (Zorder.Zlt_not_eq (x * y) (x * z) H4).
   apply Zlt_reg_mult_l.
-   exact (Zlt_gt 0 x H3).
+   exact (Z.lt_gt 0 x H3).
   assumption.
  intro H2.
  apply False_ind.
@@ -793,7 +793,7 @@ Proof.
    assumption.
   exact (Zorder.Zlt_not_eq (x * z) (x * y) H4).
  apply Zlt_reg_mult_l.
-  exact (Zlt_gt 0 x H3).
+  exact (Z.lt_gt 0 x H3).
  auto.
 Qed.
 
@@ -884,10 +884,10 @@ both n and n+1 for the 2n+1 case, while still maintaining efficency.
 
 Fixpoint positive_rect2_helper
  (P : positive -> Type)
- (c1 : forall p : positive, P (Psucc p) -> P p -> P (xI p))
+ (c1 : forall p : positive, P (Pos.succ p) -> P p -> P (xI p))
  (c2 : forall p : positive, P p -> P (xO p))
  (c3 : P 1%positive)
- (b : bool) (p : positive) {struct p} : P (if b then Psucc p else p) :=
+ (b : bool) (p : positive) {struct p} : P (if b then Pos.succ p else p) :=
  match p with
  | xH    => match b with true => c2 _ c3 | false => c3 end
  | xO p' => match b with
@@ -902,14 +902,14 @@ Fixpoint positive_rect2_helper
 
 Definition positive_rect2
  (P : positive -> Type)
- (c1 : forall p : positive, P (Psucc p) -> P p -> P (xI p))
+ (c1 : forall p : positive, P (Pos.succ p) -> P p -> P (xI p))
  (c2 : forall p : positive, P p -> P (xO p))
  (c3 : P 1%positive) (p : positive) : P p :=
 positive_rect2_helper P c1 c2 c3 false p.
 
 Lemma positive_rect2_helper_bool : forall P c1 c2 c3 p,
 positive_rect2_helper P c1 c2 c3 true p =
-positive_rect2_helper P c1 c2 c3 false (Psucc p).
+positive_rect2_helper P c1 c2 c3 false (Pos.succ p).
 Proof.
  intros P c1 c2 c3.
  induction p; try reflexivity.
@@ -920,7 +920,7 @@ Qed.
 
 Lemma positive_rect2_red1 : forall P c1 c2 c3 p,
 positive_rect2 P c1 c2 c3 (xI p) =
-c1 p (positive_rect2 P c1 c2 c3 (Psucc p)) (positive_rect2 P c1 c2 c3 p).
+c1 p (positive_rect2 P c1 c2 c3 (Pos.succ p)) (positive_rect2 P c1 c2 c3 p).
 Proof.
  intros P c1 c2 c3 p.
  unfold positive_rect2.

--- a/metric2/Compact.v
+++ b/metric2/Compact.v
@@ -650,7 +650,7 @@ Proof.
   apply Hq.
  change (q==k^(P_of_succ_nat n)*d1).
  rewrite Zpos_P_of_succ_nat.
- unfold Zsucc.
+ unfold Z.succ.
  rewrite -> Qpower_plus;[|apply Qpos_nonzero].
  autorewrite with QposElim in Hq0.
  ring [Hq0].
@@ -658,7 +658,7 @@ Qed.
 
 Definition CompactTotallyBoundedIndex (e d1 d2:Qpos) : nat :=
 let (n,d):=((1+(1#4))*d1 + d2)/e/(1-(1#4)) in
- match Zsucc (Zdiv n d) with
+ match Z.succ (Z.div n d) with
 | Zpos p => div2 (S (Z_to_nat (log_sup_correct1 p)))
 | _ => O
 end.
@@ -682,7 +682,7 @@ Proof.
  rewrite <- Qmult_assoc.
  rewrite -> Qmult_comm.
  apply Qle_shift_div_r.
-  induction (let (n, d) := a * / e * / b in match Zsucc (n / d) with | Z0 => 0%nat
+  induction (let (n, d) := a * / e * / b in match Z.succ (n / d) with | Z0 => 0%nat
     | Zpos p => div2 (S (Z_to_nat (z:=log_sup p) (log_sup_correct1 p))) | Zneg _ => 0%nat end).
    constructor.
   change (S n) with (1+n)%nat.
@@ -709,10 +709,10 @@ Proof.
  destruct z as [[|n|n] d].
    elim (Qlt_not_le _ _ Hz).
    discriminate.
-  apply Qle_trans with (Zsucc (n/d)).
+  apply Qle_trans with (Z.succ (n/d)).
    rewrite -> Qmake_Qdiv.
    apply Qle_shift_div_r; auto with *.
-   unfold Zsucc, Qle.
+   unfold Z.succ, Qle.
    simpl.
    rewrite Zpos_mult_morphism.
    ring_simplify.
@@ -720,7 +720,7 @@ Proof.
    replace LHS with (d * (n / d) + n mod d)%Z by (apply Z_div_mod_eq; auto with * ).
    apply Zplus_le_compat_l.
    destruct (Z_mod_lt n d); auto with *.
-  generalize (Zsucc (n/d)).
+  generalize (Z.succ (n/d)).
   intros z.
   clear -z.
   destruct z.
@@ -752,7 +752,7 @@ Proof.
       assert (H:(0 <= y - z)%Z) by auto with *.
       destruct (y -z)%Z; try discriminate.
        simpl.
-       change 1%Z with (Zsucc 0)%Z.
+       change 1%Z with (Z.succ 0)%Z.
        apply Zlt_le_succ.
        apply Zpower_pos_pos; constructor.
       elim H; reflexivity.
@@ -1509,7 +1509,7 @@ Proof.
    rewrite He.
    unfold Qle; simpl.
    rewrite Zpos_mult_morphism.
-   apply Zle_trans with (en * ed)%Z; auto with *.
+   apply Z.le_trans with (en * ed)%Z; auto with *.
    apply Zmult_le_compat_l; auto with *.
    rewrite (anti_convert_pred_convert ed).
    do 2 rewrite <- POS_anti_convert.
@@ -1547,7 +1547,7 @@ Proof.
   rewrite Hd.
   unfold Qle; simpl.
   rewrite Zpos_mult_morphism.
-  apply Zle_trans with (dn * dd)%Z; auto with *.
+  apply Z.le_trans with (dn * dd)%Z; auto with *.
   apply Zmult_le_compat_l; auto with *.
   rewrite (anti_convert_pred_convert dd).
   do 2 rewrite <- POS_anti_convert.

--- a/model/Zmod/Cmod.v
+++ b/model/Zmod/Cmod.v
@@ -64,7 +64,7 @@ Proof.
   intuition.
  cut (Zneg p < 0)%Z.
   intuition.
- unfold Zlt.
+ unfold Z.lt.
  intuition.
 Qed.
 

--- a/model/Zmod/ZBasics.v
+++ b/model/Zmod/ZBasics.v
@@ -251,24 +251,24 @@ Proof.
  auto with zarith.
 Qed.
 
-Definition Zlt_irref : forall a : Z, ~ (a < a)%Z := Zlt_irrefl.
+Definition Zlt_irref : forall a : Z, ~ (a < a)%Z := Z.lt_irrefl.
 
 Lemma Zgt_irref : forall a : Z, ~ (a > a)%Z.
 Proof.
  intro a.
  intro Hlt.
- generalize (Zgt_lt a a Hlt).
+ generalize (Z.gt_lt a a Hlt).
  apply Zlt_irref.
 Qed.
 
 Lemma Zlt_NEG_0 : forall p : positive, (Zneg p < 0)%Z.
 Proof.
- intro p; unfold Zlt in |- *; simpl in |- *; reflexivity.
+ intro p; unfold Z.lt in |- *; simpl in |- *; reflexivity.
 Qed.
 
 Lemma Zgt_0_NEG : forall p : positive, (0 > Zneg p)%Z.
 Proof.
- intro p; unfold Zgt in |- *; simpl in |- *; reflexivity.
+ intro p; unfold Z.gt in |- *; simpl in |- *; reflexivity.
 Qed.
 
 Lemma Zle_NEG_0 : forall p : positive, (Zneg p <= 0)%Z.
@@ -295,12 +295,12 @@ Qed.
 
 Lemma Zlt_0_POS : forall p : positive, (0 < Zpos p)%Z.
 Proof.
- intro p; unfold Zlt in |- *; simpl in |- *; reflexivity.
+ intro p; unfold Z.lt in |- *; simpl in |- *; reflexivity.
 Qed.
 
 Lemma Zgt_POS_0 : forall p : positive, (Zpos p > 0)%Z.
 Proof.
- intro p; unfold Zgt in |- *; simpl in |- *; reflexivity.
+ intro p; unfold Z.gt in |- *; simpl in |- *; reflexivity.
 Qed.
 
 Lemma Zle_0_POS : forall p : positive, (0 <= Zpos p)%Z.
@@ -327,7 +327,7 @@ Qed.
 
 Lemma Zle_neg_pos : forall p q : positive, (Zneg p <= Zpos q)%Z.
 Proof.
- intros; unfold Zle in |- *; simpl in |- *; discriminate.
+ intros; unfold Z.le in |- *; simpl in |- *; discriminate.
 Qed.
 
 Lemma ZPOS_neq_ZERO : forall p : positive, Zpos p <> 0%Z.
@@ -445,7 +445,7 @@ Qed.
 Lemma Zdiv_pos_pos : forall a b : Z, (a * b > 0)%Z -> (a > 0)%Z -> (b > 0)%Z.
 Proof.
  intros a b; induction  a as [| p| p]; [ induction  b as [| p| p] | induction  b as [| p0| p0]
-   | induction  b as [| p0| p0] ]; unfold Zlt, Zgt in |- *;
+   | induction  b as [| p0| p0] ]; unfold Z.lt, Z.gt in |- *;
      simpl in |- *; intros; try discriminate; auto.
 Qed.
 
@@ -453,14 +453,14 @@ Lemma Zdiv_pos_nonneg :
  forall a b : Z, (a * b > 0)%Z -> (a >= 0)%Z -> (b > 0)%Z.
 Proof.
  intros a b; induction  a as [| p| p]; [ induction  b as [| p| p] | induction  b as [| p0| p0]
-   | induction  b as [| p0| p0] ]; unfold Zlt, Zgt, Zle, Zge in |- *;
+   | induction  b as [| p0| p0] ]; unfold Z.lt, Z.gt, Z.le, Z.ge in |- *;
      simpl in |- *; intros H0 H1; (try discriminate; auto); ( try elim H1; auto).
 Qed.
 
 Lemma Zdiv_pos_neg : forall a b : Z, (a * b > 0)%Z -> (a < 0)%Z -> (b < 0)%Z.
 Proof.
  intros a b; induction  a as [| p| p]; [ induction  b as [| p| p] | induction  b as [| p0| p0]
-   | induction  b as [| p0| p0] ]; unfold Zlt, Zgt in |- *;
+   | induction  b as [| p0| p0] ]; unfold Z.lt, Z.gt in |- *;
      simpl in |- *; intros; try discriminate; auto.
 Qed.
 
@@ -468,14 +468,14 @@ Lemma Zdiv_pos_nonpos :
  forall a b : Z, (a * b > 0)%Z -> (a <= 0)%Z -> (b < 0)%Z.
 Proof.
  intros a b; induction  a as [| p| p]; [ induction  b as [| p| p] | induction  b as [| p0| p0]
-   | induction  b as [| p0| p0] ]; unfold Zlt, Zgt, Zle, Zge in |- *;
+   | induction  b as [| p0| p0] ]; unfold Z.lt, Z.gt, Z.le, Z.ge in |- *;
      simpl in |- *; intros H0 H1; (try discriminate; auto); ( try elim H1; auto).
 Qed.
 
 Lemma Zdiv_neg_pos : forall a b : Z, (a * b < 0)%Z -> (a > 0)%Z -> (b < 0)%Z.
 Proof.
  intros a b; induction  a as [| p| p]; [ induction  b as [| p| p] | induction  b as [| p0| p0]
-   | induction  b as [| p0| p0] ]; unfold Zlt, Zgt in |- *;
+   | induction  b as [| p0| p0] ]; unfold Z.lt, Z.gt in |- *;
      simpl in |- *; intros; try discriminate; auto.
 Qed.
 
@@ -483,14 +483,14 @@ Lemma Zdiv_neg_nonneg :
  forall a b : Z, (a * b < 0)%Z -> (a >= 0)%Z -> (b < 0)%Z.
 Proof.
  intros a b; induction  a as [| p| p]; [ induction  b as [| p| p] | induction  b as [| p0| p0]
-   | induction  b as [| p0| p0] ]; unfold Zlt, Zgt, Zle, Zge in |- *;
+   | induction  b as [| p0| p0] ]; unfold Z.lt, Z.gt, Z.le, Z.ge in |- *;
      simpl in |- *; intros H0 H1; (try discriminate; auto); ( try elim H1; auto).
 Qed.
 
 Lemma Zdiv_neg_neg : forall a b : Z, (a * b < 0)%Z -> (a < 0)%Z -> (b > 0)%Z.
 Proof.
  intros a b; induction  a as [| p| p]; [ induction  b as [| p| p] | induction  b as [| p0| p0]
-   | induction  b as [| p0| p0] ]; unfold Zlt, Zgt in |- *;
+   | induction  b as [| p0| p0] ]; unfold Z.lt, Z.gt in |- *;
      simpl in |- *; intros; try discriminate; auto.
 Qed.
 
@@ -498,7 +498,7 @@ Lemma Zdiv_neg_nonpos :
  forall a b : Z, (a * b < 0)%Z -> (a <= 0)%Z -> (b > 0)%Z.
 Proof.
  intros a b; induction  a as [| p| p]; [ induction  b as [| p| p] | induction  b as [| p0| p0]
-   | induction  b as [| p0| p0] ]; unfold Zlt, Zgt, Zle, Zge in |- *;
+   | induction  b as [| p0| p0] ]; unfold Z.lt, Z.gt, Z.le, Z.ge in |- *;
      simpl in |- *; intros H0 H1; (try discriminate; auto); ( try elim H1; auto).
 Qed.
 
@@ -525,11 +525,11 @@ Opaque Zplus.
 End zineq.
 
 
-Hint Resolve Zlt_gt: zarith.
-Hint Resolve Zgt_lt: zarith.
-Hint Resolve Zle_ge: zarith.
-Hint Resolve Zge_le: zarith.
-Hint Resolve Zlt_irrefl: zarith.
+Hint Resolve Z.lt_gt: zarith.
+Hint Resolve Z.gt_lt: zarith.
+Hint Resolve Z.le_ge: zarith.
+Hint Resolve Z.ge_le: zarith.
+Hint Resolve Z.lt_irrefl: zarith.
 
 Hint Resolve Zle_antisymm: zarith.
 Hint Resolve Zlt_irref: zarith.
@@ -577,24 +577,24 @@ Hint Resolve Zdiv_neg_nonneg: zarith.
 Section zabs.
 
 
-Lemma Zabs_idemp : forall a : Z, Zabs (Zabs a) = Zabs a.
+Lemma Zabs_idemp : forall a : Z, Z.abs (Z.abs a) = Z.abs a.
 Proof.
  intro a; case a; auto.
 Qed.
 
-Lemma Zabs_nonneg : forall (a : Z) (p : positive), Zabs a <> Zneg p.
+Lemma Zabs_nonneg : forall (a : Z) (p : positive), Z.abs a <> Zneg p.
 Proof.
  intros; case a; intros; discriminate.
 Qed.
 
-Lemma Zabs_geq_zero : forall a : Z, (0 <= Zabs a)%Z.
+Lemma Zabs_geq_zero : forall a : Z, (0 <= Z.abs a)%Z.
 Proof.
  intro a.
- case a; unfold Zabs in |- *; auto with zarith.
+ case a; unfold Z.abs in |- *; auto with zarith.
 Qed.
 
 
-Lemma Zabs_elim_nonneg : forall a : Z, (0 <= a)%Z -> Zabs a = a.
+Lemma Zabs_elim_nonneg : forall a : Z, (0 <= a)%Z -> Z.abs a = a.
 Proof.
  intro a.
  case a; auto.
@@ -602,7 +602,7 @@ Proof.
  apply Zgt_0_NEG.
 Qed.
 
-Lemma Zabs_zero : forall a : Z, Zabs a = 0%Z -> a = 0%Z.
+Lemma Zabs_zero : forall a : Z, Z.abs a = 0%Z -> a = 0%Z.
 Proof.
  intro a.
  case a.
@@ -611,63 +611,63 @@ Proof.
  intros; discriminate.
 Qed.
 
-Lemma Zabs_Zopp : forall a : Z, Zabs (- a) = Zabs a.
+Lemma Zabs_Zopp : forall a : Z, Z.abs (- a) = Z.abs a.
 Proof.
  intro a.
  case a; auto with zarith.
 Qed.
 
-Lemma Zabs_geq : forall a : Z, (a <= Zabs a)%Z.
+Lemma Zabs_geq : forall a : Z, (a <= Z.abs a)%Z.
 Proof.
  intro a.
- unfold Zabs in |- *.
+ unfold Z.abs in |- *.
  case a; auto with zarith.
  Qed.
- Lemma Zabs_Zopp_geq : forall a : Z, (- a <= Zabs a)%Z.
+ Lemma Zabs_Zopp_geq : forall a : Z, (- a <= Z.abs a)%Z.
  intro a.
  rewrite <- Zabs_Zopp.
  apply Zabs_geq.
  Qed.
- Lemma Zabs_Zminus_symm : forall a b : Z, Zabs (a - b) = Zabs (b - a).
+ Lemma Zabs_Zminus_symm : forall a b : Z, Z.abs (a - b) = Z.abs (b - a).
  intros a b.
  replace (a - b)%Z with (- (b - a))%Z; auto with zarith.
  apply Zabs_Zopp.
 Qed.
 
-Lemma Zabs_lt_pos : forall a b : Z, (Zabs a < b)%Z -> (0 < b)%Z.
+Lemma Zabs_lt_pos : forall a b : Z, (Z.abs a < b)%Z -> (0 < b)%Z.
 Proof.
  intros a b Hab.
- unfold Zlt in |- *.
+ unfold Z.lt in |- *.
  elim (Zcompare_Gt_Lt_antisym b 0).
  intros H1 H2.
  apply H1.
  fold (b > 0)%Z in |- *.
- apply (Zgt_le_trans b (Zabs a) 0); auto with zarith.
+ apply (Zgt_le_trans b (Z.abs a) 0); auto with zarith.
 Qed.
 
-Lemma Zabs_le_pos : forall a b : Z, (Zabs a <= b)%Z -> (0 <= b)%Z.
+Lemma Zabs_le_pos : forall a b : Z, (Z.abs a <= b)%Z -> (0 <= b)%Z.
 Proof.
  intros a b Hab.
- apply (Zle_trans 0 (Zabs a) b).
+ apply (Z.le_trans 0 (Z.abs a) b).
   auto with zarith.
  assumption.
 Qed.
 
 Lemma Zabs_lt_elim :
- forall a b : Z, (a < b)%Z -> (- a < b)%Z -> (Zabs a < b)%Z.
+ forall a b : Z, (a < b)%Z -> (- a < b)%Z -> (Z.abs a < b)%Z.
 Proof.
  intros a b.
  case a; auto with zarith.
 Qed.
 
 Lemma Zabs_le_elim :
- forall a b : Z, (a <= b)%Z -> (- a <= b)%Z -> (Zabs a <= b)%Z.
+ forall a b : Z, (a <= b)%Z -> (- a <= b)%Z -> (Z.abs a <= b)%Z.
 Proof.
  intros a b.
  case a; auto with zarith.
 Qed.
 
-Lemma Zabs_mult_compat : forall a b : Z, (Zabs a * Zabs b)%Z = Zabs (a * b).
+Lemma Zabs_mult_compat : forall a b : Z, (Z.abs a * Z.abs b)%Z = Z.abs (a * b).
 Proof.
  intros a b.
  case a; case b; intros; auto with zarith.
@@ -679,33 +679,33 @@ Qed.
 Let case_POS :
   forall p q r : positive,
   (Zpos q + Zneg p)%Z = Zpos r ->
-  (Zabs (Zpos q + Zneg p) <= Zabs (Zpos q) + Zabs (Zneg p))%Z.
+  (Z.abs (Zpos q + Zneg p) <= Z.abs (Zpos q) + Z.abs (Zneg p))%Z.
 Proof.
  intros p q r Hr.
  rewrite Hr.
  simpl in |- *.
  rewrite <- Hr.
  fold (Zpos q + Zpos p)%Z in |- *.
- unfold Zle in |- *.
+ unfold Z.le in |- *.
  rewrite (Zcompare_plus_compat (Zneg p) (Zpos p) (Zpos q)).
  apply (ZBasics.Zle_neg_pos p).
  Defined.
  Let case_NEG : forall p q r : positive, (Zpos q + Zneg p)%Z = Zneg r ->
-   (Zabs (Zpos q + Zneg p) <= Zabs (Zpos q) + Zabs (Zneg p))%Z.
+   (Z.abs (Zpos q + Zneg p) <= Z.abs (Zpos q) + Z.abs (Zneg p))%Z.
  intros p q r Hr.
- rewrite <- (Zopp_involutive (Zpos q + Zneg p)) in Hr.
- rewrite <- (Zopp_involutive (Zneg r)) in Hr.
- generalize (Zopp_inj (- (Zpos q + Zneg p)) (- Zneg r) Hr).
- intro Hr'. rewrite Zopp_plus_distr in Hr'. unfold Zopp in Hr'.
- rewrite <- (Zabs_Zopp (Zpos q + Zneg p)). rewrite Zopp_plus_distr. unfold Zopp in |- *.
- rewrite <- (Zabs_Zopp (Zpos q)). unfold Zopp in |- *.
- rewrite <- (Zabs_Zopp (Zneg p)). unfold Zopp in |- *.
+ rewrite <- (Z.opp_involutive (Zpos q + Zneg p)) in Hr.
+ rewrite <- (Z.opp_involutive (Zneg r)) in Hr.
+ generalize (Z.opp_inj (- (Zpos q + Zneg p)) (- Zneg r) Hr).
+ intro Hr'. rewrite Zopp_plus_distr in Hr'. unfold Z.opp in Hr'.
+ rewrite <- (Zabs_Zopp (Zpos q + Zneg p)). rewrite Zopp_plus_distr. unfold Z.opp in |- *.
+ rewrite <- (Zabs_Zopp (Zpos q)). unfold Z.opp in |- *.
+ rewrite <- (Zabs_Zopp (Zneg p)). unfold Z.opp in |- *.
  rewrite (Zplus_comm (Zneg q) (Zpos p)).
- rewrite (Zplus_comm (Zabs (Zneg q)) (Zabs (Zpos p))).
+ rewrite (Zplus_comm (Z.abs (Zneg q)) (Z.abs (Zpos p))).
  rewrite Zplus_comm in Hr'.
  apply (case_POS _ _ _ Hr').
  Defined.
- Lemma Zabs_triangle : forall a b : Z, (Zabs (a + b) <= Zabs a + Zabs b)%Z.
+ Lemma Zabs_triangle : forall a b : Z, (Z.abs (a + b) <= Z.abs a + Z.abs b)%Z.
  intros a b.
  case a; case b; auto with zarith.
   intros p q.
@@ -716,7 +716,7 @@ Proof.
    intros p0 case_POS0 case_NEG0. apply (case_NEG0 p0). reflexivity.
    intros p q.
    rewrite (Zplus_comm (Zneg q) (Zpos p)).
-   rewrite (Zplus_comm (Zabs (Zneg q)) (Zabs (Zpos p))).
+   rewrite (Zplus_comm (Z.abs (Zneg q)) (Z.abs (Zpos p))).
    generalize (case_POS q p) (case_NEG q p).
    case (Zpos p + Zneg q)%Z.
      auto with zarith.
@@ -724,15 +724,15 @@ Proof.
      intros p0 case_POS0 case_NEG0. apply (case_NEG0 p0). reflexivity.
      Qed.
      (* triangle inequality with Zminus *)
-     Lemma Zabs_Zminus_triangle : forall a b : Z, (Zabs (Zabs a - Zabs b) <= Zabs (a - b))%Z.
- assert (case : forall a b : Z, (Zabs a - Zabs b <= Zabs (a - b))%Z).
+     Lemma Zabs_Zminus_triangle : forall a b : Z, (Z.abs (Z.abs a - Z.abs b) <= Z.abs (a - b))%Z.
+ assert (case : forall a b : Z, (Z.abs a - Z.abs b <= Z.abs (a - b))%Z).
   intros a b.
-  unfold Zle in |- *.
+  unfold Z.le in |- *.
   unfold Zminus in |- *.
-  rewrite <- (Zcompare_plus_compat (Zabs a + - Zabs b) (Zabs (a + - b)) (Zabs b)) .
-  rewrite (Zplus_comm (Zabs a) (- Zabs b)).
+  rewrite <- (Zcompare_plus_compat (Z.abs a + - Z.abs b) (Z.abs (a + - b)) (Z.abs b)) .
+  rewrite (Zplus_comm (Z.abs a) (- Z.abs b)).
   rewrite Zplus_assoc.
-  rewrite (Zplus_comm (Zabs b) (- Zabs b)).
+  rewrite (Zplus_comm (Z.abs b) (- Z.abs b)).
   rewrite Zplus_opp_l.
   rewrite Zplus_0_l.
   assert (l : forall a b : Z, a = (b + (a - b))%Z).
@@ -745,7 +745,7 @@ Proof.
  intros a b.
  apply Zabs_le_elim.
   apply case.
- replace (- (Zabs a - Zabs b))%Z with (Zabs b - Zabs a)%Z; auto with zarith.
+ replace (- (Z.abs a - Z.abs b))%Z with (Z.abs b - Z.abs a)%Z; auto with zarith.
  rewrite Zabs_Zminus_symm.
  apply case.
 Qed.
@@ -779,31 +779,31 @@ Hint Resolve Zabs_Zminus_triangle: zarith.
 
 Section zsign.
 
-Lemma Zsgn_mult_compat : forall a b : Z, (Zsgn a * Zsgn b)%Z = Zsgn (a * b).
+Lemma Zsgn_mult_compat : forall a b : Z, (Z.sgn a * Z.sgn b)%Z = Z.sgn (a * b).
 Proof.
  intros a b.
  case a; case b; intros; auto with zarith.
 Qed.
 
-Lemma Zmult_sgn_abs : forall a : Z, (Zsgn a * Zabs a)%Z = a.
+Lemma Zmult_sgn_abs : forall a : Z, (Z.sgn a * Z.abs a)%Z = a.
 Proof.
  intro a.
  case a; intros; auto with zarith.
 Qed.
 
-Lemma Zmult_sgn_eq_abs : forall a : Z, Zabs a = (Zsgn a * a)%Z.
+Lemma Zmult_sgn_eq_abs : forall a : Z, Z.abs a = (Z.sgn a * a)%Z.
 Proof.
  intro a.
  case a; intros; auto with zarith.
 Qed.
 
-Lemma Zsgn_plus_l : forall a b : Z, Zsgn a = Zsgn b -> Zsgn (a + b) = Zsgn a.
+Lemma Zsgn_plus_l : forall a b : Z, Z.sgn a = Z.sgn b -> Z.sgn (a + b) = Z.sgn a.
 Proof.
  intros a b.
  case a; case b; simpl in |- *; auto; intros; try discriminate.
 Qed.
 
-Lemma Zsgn_plus_r : forall a b : Z, Zsgn a = Zsgn b -> Zsgn (a + b) = Zsgn b.
+Lemma Zsgn_plus_r : forall a b : Z, Z.sgn a = Z.sgn b -> Z.sgn (a + b) = Z.sgn b.
 Proof.
  intros.
  rewrite Zplus_comm.
@@ -811,25 +811,25 @@ Proof.
  auto.
 Qed.
 
-Lemma Zsgn_opp : forall z : Z, Zsgn (- z) = (- Zsgn z)%Z.
+Lemma Zsgn_opp : forall z : Z, Z.sgn (- z) = (- Z.sgn z)%Z.
 Proof.
  intro z.
  case z; simpl in |- *; auto.
 Qed.
 
-Lemma Zsgn_ZERO : forall z : Z, Zsgn z = 0%Z -> z = 0%Z.
+Lemma Zsgn_ZERO : forall z : Z, Z.sgn z = 0%Z -> z = 0%Z.
 Proof.
  intros z.
  case z; simpl in |- *; intros; auto; try discriminate.
 Qed.
 
-Lemma Zsgn_pos : forall z : Z, Zsgn z = 1%Z -> (z > 0)%Z.
+Lemma Zsgn_pos : forall z : Z, Z.sgn z = 1%Z -> (z > 0)%Z.
 Proof.
  intros z.
  case z; simpl in |- *; intros; auto with zarith; try discriminate.
 Qed.
 
-Lemma Zsgn_neg : forall z : Z, Zsgn z = (-1)%Z -> (z < 0)%Z.
+Lemma Zsgn_neg : forall z : Z, Z.sgn z = (-1)%Z -> (z < 0)%Z.
 Proof.
  intros z.
  case z; simpl in |- *; intros; auto with zarith; try discriminate.

--- a/model/Zmod/ZDivides.v
+++ b/model/Zmod/ZDivides.v
@@ -260,7 +260,7 @@ Lemma Zdivides_opp_intro_lft :
  forall a b : Z, Zdivides (- a) b -> Zdivides a b.
 Proof.
  intros a b H.
- rewrite <- (Zopp_involutive a).
+ rewrite <- (Z.opp_involutive a).
  apply (Zdivides_opp_elim_lft _ _ H).
 Qed.
 
@@ -268,7 +268,7 @@ Lemma Zdivides_opp_intro_rht :
  forall a b : Z, Zdivides a (- b) -> Zdivides a b.
 Proof.
  intros a b H.
- rewrite <- (Zopp_involutive b).
+ rewrite <- (Z.opp_involutive b).
  apply (Zdivides_opp_elim_rht _ _ H).
 Qed.
 
@@ -346,7 +346,7 @@ Lemma Zdivides_mult_rr :
 Qed.
 
 Lemma Zdivides_abs_elim_lft :
- forall a b : Z, Zdivides a b -> Zdivides (Zabs a) b.
+ forall a b : Z, Zdivides a b -> Zdivides (Z.abs a) b.
 Proof.
  intros a b.
  case a; simpl in |- *; auto.
@@ -356,7 +356,7 @@ Proof.
 Qed.
 
 Lemma Zdivides_abs_elim_rht :
- forall a b : Z, Zdivides a b -> Zdivides a (Zabs b).
+ forall a b : Z, Zdivides a b -> Zdivides a (Z.abs b).
 Proof.
  intros a b.
  case b; simpl in |- *; auto.
@@ -366,7 +366,7 @@ Proof.
 Qed.
 
 Lemma Zdivides_abs_elim :
- forall a b : Z, Zdivides a b -> Zdivides (Zabs a) (Zabs b).
+ forall a b : Z, Zdivides a b -> Zdivides (Z.abs a) (Z.abs b).
 Proof.
  intros.
  apply Zdivides_abs_elim_lft.
@@ -375,7 +375,7 @@ Proof.
 Qed.
 
 Lemma Zdivides_abs_intro_lft :
- forall a b : Z, Zdivides (Zabs a) b -> Zdivides a b.
+ forall a b : Z, Zdivides (Z.abs a) b -> Zdivides a b.
 Proof.
  intros a b.
  case a; simpl in |- *; auto.
@@ -383,7 +383,7 @@ Proof.
 Qed.
 
 Lemma Zdivides_abs_intro_rht :
- forall a b : Z, Zdivides a (Zabs b) -> Zdivides a b.
+ forall a b : Z, Zdivides a (Z.abs b) -> Zdivides a b.
 Proof.
  intros a b.
  case b; simpl in |- *; auto.
@@ -391,7 +391,7 @@ Proof.
 Qed.
 
 Lemma Zdivides_abs_intro :
- forall a b : Z, Zdivides (Zabs a) (Zabs b) -> Zdivides a b.
+ forall a b : Z, Zdivides (Z.abs a) (Z.abs b) -> Zdivides a b.
 Proof.
  intros.
  apply Zdivides_abs_intro_lft.
@@ -415,7 +415,7 @@ Proof.
 Qed.
 
 Lemma Zdivisor_small :
- forall a b : Z, Zdivides b a -> (Zabs a < b)%Z -> a = 0%Z.
+ forall a b : Z, Zdivides b a -> (Z.abs a < b)%Z -> a = 0%Z.
 Proof.
  intros a b Hdiv Hlt.
  generalize (Zdivides_abs_elim_rht _ _ Hdiv); intro Hdivabs.
@@ -424,23 +424,23 @@ Proof.
    auto.
   intros p Hp.
   assert (Hfalse : (b < b)%Z).
-   apply (Zle_lt_trans b (Zabs a) b).
-    apply Zge_le.
-    apply (Zdivisor_pos_le (Zabs a) b).
+   apply (Z.le_lt_trans b (Z.abs a) b).
+    apply Z.ge_le.
+    apply (Zdivisor_pos_le (Z.abs a) b).
      rewrite <- Hp; simpl in |- *; auto with zarith.
     assumption.
    assumption.
-  elim (Zlt_irrefl b Hfalse).
+  elim (Z.lt_irrefl b Hfalse).
  intros p Hp.
  assert (Hfalse : (b < b)%Z).
-  apply (Zle_lt_trans b (Zabs a) b).
-   apply Zge_le.
-   apply (Zdivisor_pos_le (Zabs a) b).
+  apply (Z.le_lt_trans b (Z.abs a) b).
+   apply Z.ge_le.
+   apply (Zdivisor_pos_le (Z.abs a) b).
     rewrite <- Hp; simpl in |- *.
     auto with zarith.
    assumption.
   assumption.
- elim (Zlt_irrefl b Hfalse).
+ elim (Z.lt_irrefl b Hfalse).
 Qed.
 
 Lemma Zmodeq_small :
@@ -484,7 +484,7 @@ Proof.
  rewrite Hq1 in Hq2.
  assert (Hb0 : b <> 0%Z).
   assert (Hbpos : (0 < b)%Z).
-   apply (Zle_lt_trans 0 r1 b).
+   apply (Z.le_lt_trans 0 r1 b).
     tauto.
    tauto.
   auto with zarith.
@@ -497,10 +497,10 @@ Lemma Zmod0_Zopp :
  forall a b : Z, b <> 0%Z -> (a mod b)%Z = 0%Z -> (a mod - b)%Z = 0%Z.
 Proof.
  intros a b.
- generalize (Z_mod_lt (Zabs a) (Zabs b)).
+ generalize (Z_mod_lt (Z.abs a) (Z.abs b)).
  case a.
-   case b; unfold Zabs, Zopp, Zmod, Zdiv_eucl in |- *; auto with zarith.
-  case b; unfold Zabs, Zopp, Zmod, Zdiv_eucl in |- *.
+   case b; unfold Z.abs, Z.opp, Zmod, Z.div_eucl in |- *; auto with zarith.
+  case b; unfold Z.abs, Z.opp, Zmod, Z.div_eucl in |- *.
     auto with zarith.
    intros p q.
    elim (Zdiv_eucl_POS q (Zpos p)); intros Q R.
@@ -515,7 +515,7 @@ Proof.
    auto with zarith.
   intro r'; intros H0 H1 H2.
   elim H0; auto with zarith.
- case b; unfold Zabs, Zopp, Zmod, Zdiv_eucl in |- *.
+ case b; unfold Z.abs, Z.opp, Zmod, Z.div_eucl in |- *.
    auto with zarith.
   intros p q.
   elim (Zdiv_eucl_POS q (Zpos p)); intros Q R.
@@ -529,21 +529,21 @@ Lemma Zdiv_Zopp :
  forall a b : Z, (a mod b)%Z = 0%Z -> (a / - b)%Z = (- (a / b))%Z.
 Proof.
  intros a b.
- unfold Zmod, Zdiv, Zdiv_eucl in |- *.
+ unfold Zmod, Z.div, Z.div_eucl in |- *.
  case a.
    auto.
   intro A.
-  case b; unfold Zopp in |- *.
+  case b; unfold Z.opp in |- *.
     auto.
    intro B.
    elim (Zdiv_eucl_POS A (Zpos B)); intros q r.
    intro Hr; rewrite Hr; auto.
   intro B.
   generalize (Z_mod_lt (Zpos A) (Zpos B)).
-  unfold Zmod, Zdiv_eucl in |- *.
+  unfold Zmod, Z.div_eucl in |- *.
   elim (Zdiv_eucl_POS A (Zpos B)); intros q r.
   case r.
-    intros _ HR; fold (- q)%Z in |- *; fold (- - q)%Z in |- *; rewrite Zopp_involutive; auto.
+    intros _ HR; fold (- q)%Z in |- *; fold (- - q)%Z in |- *; rewrite Z.opp_involutive; auto.
    intros R Hlt HR.
    assert (H : Zpos R = Zpos B).
     rewrite <- (Zplus_0_r (Zpos B)); rewrite <- HR; rewrite Zplus_assoc; fold (- Zpos B)%Z in |- *.
@@ -553,14 +553,14 @@ Proof.
   intros R Hlt HR.
   elim Hlt; auto with zarith; intro Hfalse; elim Hfalse; auto with zarith.
  intro A.
- case b; unfold Zopp in |- *.
+ case b; unfold Z.opp in |- *.
    auto.
   intro B.
   generalize (Z_mod_lt (Zpos A) (Zpos B)).
-  unfold Zmod, Zdiv_eucl in |- *.
+  unfold Zmod, Z.div_eucl in |- *.
   elim (Zdiv_eucl_POS A (Zpos B)); intros q r.
   case r.
-    intros _ HR; fold (- q)%Z in |- *; fold (- - q)%Z in |- *; rewrite Zopp_involutive; auto.
+    intros _ HR; fold (- q)%Z in |- *; fold (- - q)%Z in |- *; rewrite Z.opp_involutive; auto.
    intros R Hlt HR.
    assert (H : Zpos R = Zpos B).
     rewrite <- (Zplus_0_r (Zpos R)); rewrite <- HR; unfold Zminus in |- *;
@@ -571,7 +571,7 @@ Proof.
   elim Hlt; auto with zarith; intro Hfalse; elim Hfalse; auto with zarith.
  intro B.
  generalize (Z_mod_lt (Zpos A) (Zpos B)).
- unfold Zmod, Zdiv_eucl in |- *.
+ unfold Zmod, Z.div_eucl in |- *.
  elim (Zdiv_eucl_POS A (Zpos B)); intros q r.
  case r.
    intros _ HR; fold (- q)%Z in |- *; auto.
@@ -621,7 +621,7 @@ Proof.
   intro; discriminate.
  apply H.
   auto with zarith.
- rewrite <- (Zopp_involutive (Zpos p)).
+ rewrite <- (Z.opp_involutive (Zpos p)).
  apply Zdivides_opp_elim_lft.
  assumption.
 Qed.
@@ -640,7 +640,7 @@ Proof.
  apply Zdivides_opp_elim_lft.
  apply H.
   auto with zarith.
- rewrite <- (Zopp_involutive (Zpos p)).
+ rewrite <- (Z.opp_involutive (Zpos p)).
  apply Zmod0_Zopp.
   simpl in |- *; intros; discriminate.
  assumption.
@@ -687,7 +687,7 @@ Proof.
  fold (- Zpos p)%Z in |- *.
  rewrite Zdiv_Zopp.
   cut ((- Zpos p * b / Zpos p)%Z = (- b)%Z); auto with zarith.
-  unfold Zopp in |- *; fold (- b)%Z in |- *.
+  unfold Z.opp in |- *; fold (- b)%Z in |- *.
   apply (Zdiv_quotient_unique (Zneg p * b) (Zpos p) (Zneg p * b / Zpos p)
     ((Zneg p * b) mod Zpos p) (- b) 0).
      rewrite (Zmult_comm (Zneg p * b / Zpos p) (Zpos p)).
@@ -731,7 +731,7 @@ Proof.
  intro Hxy; rewrite Hxy; auto.
 Qed.
 
-Lemma Zabs_div_lft : forall a : Z, (Zabs a / a)%Z = Zsgn a.
+Lemma Zabs_div_lft : forall a : Z, (Z.abs a / a)%Z = Z.sgn a.
 Proof.
  intro a.
  rewrite Zmult_sgn_eq_abs.
@@ -740,12 +740,12 @@ Proof.
   apply Zdiv_mult_cancel_rht.
 Qed.
 
-Lemma Zabs_div_rht : forall a : Z, (a / Zabs a)%Z = Zsgn a.
+Lemma Zabs_div_rht : forall a : Z, (a / Z.abs a)%Z = Z.sgn a.
 Proof.
  intro a.
- set (A := Zabs a).
- set (sa := Zsgn a).
- replace a with (Zabs a * Zsgn a)%Z.
+ set (A := Z.abs a).
+ set (sa := Z.sgn a).
+ replace a with (Z.abs a * Z.sgn a)%Z.
   unfold sa in |- *; clear sa.
   case (Zdec A).
    unfold A in |- *; intro HA.
@@ -766,7 +766,7 @@ Proof.
  fold (- Zpos A)%Z in |- *.
  rewrite Zdiv_Zopp.
   simpl in |- *.
-  replace (Zpos A) with (Zabs (Zneg A)); auto.
+  replace (Zpos A) with (Z.abs (Zneg A)); auto.
   rewrite Zabs_div_rht.
   auto.
  replace (- Zpos A)%Z with (-1 * Zpos A)%Z; auto with zarith.

--- a/model/Zmod/ZGcd.v
+++ b/model/Zmod/ZGcd.v
@@ -359,7 +359,7 @@ Proof.
     assert (Heq : Zpos a = Zpos b).
      apply Zle_antisymm.
       intro H; rewrite H in Hegal; discriminate.
-     apply Zle_ge; intro H; rewrite H in Hegal; discriminate.
+     apply Z.le_ge; intro H; rewrite H in Hegal; discriminate.
     inversion Heq.
     tauto.
    intro Hlt.
@@ -383,8 +383,8 @@ Proof.
     unfold Zminus in |- *; simpl in |- *.
     rewrite Zplus_0_r.
     reflexivity.
-   apply (Zdiv_lt_POS b a); apply Zgt_lt; assumption.
-  apply (Zmod_lt_POS b a); apply Zgt_lt; assumption.
+   apply (Zdiv_lt_POS b a); apply Z.gt_lt; assumption.
+  apply (Zmod_lt_POS b a); apply Z.gt_lt; assumption.
  auto.
 Qed.
 
@@ -515,13 +515,13 @@ Definition Zgcd_coeff_b (a b : Z) :=
 
 
 Lemma Zgcd_duv_zero_rht :
- forall a : Z, Zgcd_duv a 0 = (Zabs a, (Zsgn a, 0%Z)).
+ forall a : Z, Zgcd_duv a 0 = (Z.abs a, (Z.sgn a, 0%Z)).
 Proof.
  intro a.
  case a; auto with zarith.
 Qed.
 
-Lemma Zgcd_zero_rht : forall a : Z, Zgcd a 0 = Zabs a.
+Lemma Zgcd_zero_rht : forall a : Z, Zgcd a 0 = Z.abs a.
 Proof.
  intro a.
  unfold Zgcd in |- *.
@@ -529,7 +529,7 @@ Proof.
  reflexivity.
 Qed.
 
-Lemma Zgcd_coeff_a_zero_rht : forall a : Z, Zgcd_coeff_a a 0 = Zsgn a.
+Lemma Zgcd_coeff_a_zero_rht : forall a : Z, Zgcd_coeff_a a 0 = Z.sgn a.
 Proof.
  intro a.
  unfold Zgcd_coeff_a in |- *.
@@ -551,7 +551,7 @@ Lemma Zgcd_duv_Zopp_l :
  (let (d, uv) := Zgcd_duv a b in let (u, v) := uv in (d, ((- u)%Z, v))).
 Proof.
  intros a b.
- case a; case b; intros; simpl in |- *; repeat rewrite Zopp_involutive; reflexivity.
+ case a; case b; intros; simpl in |- *; repeat rewrite Z.opp_involutive; reflexivity.
 Qed.
 
 Lemma Zgcd_Zopp_l : forall a b : Z, Zgcd (- a) b = Zgcd a b.
@@ -586,7 +586,7 @@ Lemma Zgcd_duv_Zopp_r :
  (let (d, uv) := Zgcd_duv a b in let (u, v) := uv in (d, (u, (- v)%Z))).
 Proof.
  intros a b.
- case a; case b; intros; simpl in |- *; repeat rewrite Zopp_involutive; reflexivity.
+ case a; case b; intros; simpl in |- *; repeat rewrite Z.opp_involutive; reflexivity.
 Qed.
 
 Lemma Zgcd_Zopp_r : forall a b : Z, Zgcd a (- b) = Zgcd a b.
@@ -618,16 +618,16 @@ Qed.
 Lemma Zgcd_duv_abs :
  forall a b : Z,
  Zgcd_duv a b =
- (let (d, uv) := Zgcd_duv (Zabs a) (Zabs b) in
-  let (u, v) := uv in (d, ((Zsgn a * u)%Z, (Zsgn b * v)%Z))).
+ (let (d, uv) := Zgcd_duv (Z.abs a) (Z.abs b) in
+  let (u, v) := uv in (d, ((Z.sgn a * u)%Z, (Z.sgn b * v)%Z))).
 Proof.
  intros a b.
- case a; case b; intros; unfold Zabs, Zsgn, Zgcd_duv in |- *;
+ case a; case b; intros; unfold Z.abs, Z.sgn, Zgcd_duv in |- *;
    repeat (fold (- (1))%Z in |- *; rewrite <- Zopp_mult_distr_l);
      repeat rewrite Zmult_1_l; reflexivity.
 Qed.
 
-Lemma Zgcd_abs : forall a b : Z, Zgcd a b = Zgcd (Zabs a) (Zabs b).
+Lemma Zgcd_abs : forall a b : Z, Zgcd a b = Zgcd (Z.abs a) (Z.abs b).
 Proof.
  intros a b.
  case a; case b; auto with zarith.
@@ -635,23 +635,23 @@ Qed.
 
 Lemma Zgcd_coeff_a_abs :
  forall a b : Z,
- Zgcd_coeff_a a b = (Zsgn a * Zgcd_coeff_a (Zabs a) (Zabs b))%Z.
+ Zgcd_coeff_a a b = (Z.sgn a * Zgcd_coeff_a (Z.abs a) (Z.abs b))%Z.
 Proof.
  intros.
  unfold Zgcd_coeff_a in |- *.
  rewrite Zgcd_duv_abs.
- elim (Zgcd_duv (Zabs a) (Zabs b)); intros d uv; elim uv; intros u v.
+ elim (Zgcd_duv (Z.abs a) (Z.abs b)); intros d uv; elim uv; intros u v.
  reflexivity.
 Qed.
 
 Lemma Zgcd_coeff_b_abs :
  forall a b : Z,
- Zgcd_coeff_b a b = (Zsgn b * Zgcd_coeff_b (Zabs a) (Zabs b))%Z.
+ Zgcd_coeff_b a b = (Z.sgn b * Zgcd_coeff_b (Z.abs a) (Z.abs b))%Z.
 Proof.
  intros.
  unfold Zgcd_coeff_b in |- *.
  rewrite Zgcd_duv_abs.
- elim (Zgcd_duv (Zabs a) (Zabs b)); intros d uv; elim uv; intros u v.
+ elim (Zgcd_duv (Z.abs a) (Z.abs b)); intros d uv; elim uv; intros u v.
  reflexivity.
 Qed.
 
@@ -680,21 +680,21 @@ Qed.
 Let Zgcd_duv_rec_subcase :
   forall (a : Z) (pb : positive),
   Zgcd_duv a (Zpos pb) =
-  (let (d, uv) := Zgcd_duv (Zpos pb) (Zabs a mod Zpos pb) in
-   let (u, v) := uv in (d, ((Zsgn a * v)%Z, (u - Zabs a / Zpos pb * v)%Z))).
+  (let (d, uv) := Zgcd_duv (Zpos pb) (Z.abs a mod Zpos pb) in
+   let (u, v) := uv in (d, ((Z.sgn a * v)%Z, (u - Z.abs a / Zpos pb * v)%Z))).
 Proof.
  intros a pb.
  case a.
    unfold Zgcd_duv in |- *; simpl in |- *; reflexivity.
   intro pa.
-  unfold Zabs, Zsgn in |- *.
+  unfold Z.abs, Z.sgn in |- *.
   rewrite Zgcd_duv_rec_subsubcase.
   elim (Zgcd_duv (Zpos pb) (Zpos pa mod Zpos pb)); intros d uv; elim uv; intros u v.
   rewrite Zmult_1_l.
   reflexivity.
  intro pa.
  rewrite (Zgcd_duv_abs (Zneg pa) (Zpos pb)).
- unfold Zabs, Zsgn in |- *.
+ unfold Z.abs, Z.sgn in |- *.
  rewrite Zgcd_duv_rec_subsubcase.
  elim (Zgcd_duv (Zpos pb) (Zpos pa mod Zpos pb)); intros d uv; elim uv; intros u v.
  rewrite Zmult_1_l.
@@ -705,9 +705,9 @@ Lemma Zgcd_duv_rec :
  forall a b : Z,
  b <> 0%Z ->
  Zgcd_duv a b =
- (let (d, uv) := Zgcd_duv b (Zabs a mod Zabs b) in
+ (let (d, uv) := Zgcd_duv b (Z.abs a mod Z.abs b) in
   let (u, v) := uv in
-  (d, ((Zsgn a * v)%Z, (u - Zsgn b * (Zabs a / Zabs b) * v)%Z))).
+  (d, ((Z.sgn a * v)%Z, (u - Z.sgn b * (Z.abs a / Z.abs b) * v)%Z))).
 Proof.
  intros a b Hb.
  set (B := b) in *.
@@ -720,8 +720,8 @@ Proof.
    intros pb HB'.
    rewrite HB'.
    rewrite Zgcd_duv_rec_subcase.
-   unfold Zabs, Zsgn in |- *. fold (Zabs a) in |- *. fold (Zsgn a) in |- *.
-   elim (Zgcd_duv (Zpos pb) (Zabs a mod Zpos pb)); intros d uv; elim uv; intros u v.
+   unfold Z.abs, Z.sgn in |- *. fold (Z.abs a) in |- *. fold (Z.sgn a) in |- *.
+   elim (Zgcd_duv (Zpos pb) (Z.abs a mod Zpos pb)); intros d uv; elim uv; intros u v.
    rewrite Zmult_1_l.
    reflexivity.
   intros pb HB'.
@@ -730,8 +730,8 @@ Proof.
   rewrite Zgcd_duv_Zopp_r.
   rewrite Zgcd_duv_Zopp_l.
   rewrite Zgcd_duv_rec_subcase.
-  unfold Zopp, Zabs, Zsgn in |- *. fold (Zabs a) in |- *. fold (Zsgn a) in |- *.
-  elim (Zgcd_duv (Zpos pb) (Zabs a mod Zpos pb)); intros d uv; elim uv; intros u v.
+  unfold Z.opp, Z.abs, Z.sgn in |- *. fold (Z.abs a) in |- *. fold (Z.sgn a) in |- *.
+  elim (Zgcd_duv (Zpos pb) (Z.abs a mod Zpos pb)); intros d uv; elim uv; intros u v.
   fold (- u)%Z in |- *.
   rewrite Zopp_mult_distr_l_reverse.
   unfold Zminus in |- *.
@@ -741,12 +741,12 @@ Proof.
 Qed.
 
 Lemma Zgcd_rec :
- forall a b : Z, b <> 0%Z -> Zgcd a b = Zgcd b (Zabs a mod Zabs b).
+ forall a b : Z, b <> 0%Z -> Zgcd a b = Zgcd b (Z.abs a mod Z.abs b).
 Proof.
  intros a b Hb.
  unfold Zgcd in |- *.
  rewrite Zgcd_duv_rec.
-  elim (Zgcd_duv b (Zabs a mod Zabs b)); intros d uv; elim uv; intros u v.
+  elim (Zgcd_duv b (Z.abs a mod Z.abs b)); intros d uv; elim uv; intros u v.
   reflexivity.
  exact Hb.
 Qed.
@@ -754,13 +754,13 @@ Qed.
 Lemma Zgcd_coeff_a_rec :
  forall a b : Z,
  b <> 0%Z ->
- Zgcd_coeff_a a b = (Zsgn a * Zgcd_coeff_b b (Zabs a mod Zabs b))%Z.
+ Zgcd_coeff_a a b = (Z.sgn a * Zgcd_coeff_b b (Z.abs a mod Z.abs b))%Z.
 Proof.
  intros a b Hb.
  unfold Zgcd_coeff_a in |- *.
  unfold Zgcd_coeff_b in |- *.
  rewrite Zgcd_duv_rec.
-  elim (Zgcd_duv b (Zabs a mod Zabs b)); intros d uv; elim uv; intros u v.
+  elim (Zgcd_duv b (Z.abs a mod Z.abs b)); intros d uv; elim uv; intros u v.
   reflexivity.
  exact Hb.
 Qed.
@@ -769,21 +769,21 @@ Lemma Zgcd_coeff_b_rec :
  forall a b : Z,
  b <> 0%Z ->
  Zgcd_coeff_b a b =
- (Zgcd_coeff_a b (Zabs a mod Zabs b) -
-  Zsgn b * (Zabs a / Zabs b) * Zgcd_coeff_b b (Zabs a mod Zabs b))%Z.
+ (Zgcd_coeff_a b (Z.abs a mod Z.abs b) -
+  Z.sgn b * (Z.abs a / Z.abs b) * Zgcd_coeff_b b (Z.abs a mod Z.abs b))%Z.
 Proof.
  intros a b Hb.
  unfold Zgcd_coeff_a in |- *.
  unfold Zgcd_coeff_b in |- *.
  rewrite Zgcd_duv_rec.
-  elim (Zgcd_duv b (Zabs a mod Zabs b)); intros d uv; elim uv; intros u v.
+  elim (Zgcd_duv b (Z.abs a mod Z.abs b)); intros d uv; elim uv; intros u v.
   reflexivity.
  exact Hb.
 Qed.
 
 Lemma Zgcd_duv_divisor :
  forall a b : Z,
- a <> 0%Z -> Zdivides b a -> Zgcd_duv a b = (Zabs b, (0%Z, Zsgn b)).
+ a <> 0%Z -> Zdivides b a -> Zgcd_duv a b = (Z.abs b, (0%Z, Z.sgn b)).
 Proof.
  intros a b Ha.
  case b.
@@ -794,7 +794,7 @@ Proof.
   intros pb Hdiv.
   simpl in |- *.
   rewrite Zgcd_duv_rec_subcase.
-  replace (Zabs a mod Zpos pb)%Z with 0%Z.
+  replace (Z.abs a mod Zpos pb)%Z with 0%Z.
    rewrite Zgcd_duv_zero_rht.
    rewrite Zmult_0_r.
    rewrite Zmult_0_r.
@@ -807,7 +807,7 @@ Proof.
  fold (- Zpos pb)%Z in |- *.
  rewrite Zgcd_duv_Zopp_r.
  rewrite Zgcd_duv_rec_subcase.
- replace (Zabs a mod Zpos pb)%Z with 0%Z.
+ replace (Z.abs a mod Zpos pb)%Z with 0%Z.
   rewrite Zgcd_duv_zero_rht.
   rewrite Zmult_0_r.
   rewrite Zmult_0_r.
@@ -818,7 +818,7 @@ Proof.
 Qed.
 
 Lemma Zgcd_divisor :
- forall a b : Z, a <> 0%Z -> Zdivides b a -> Zgcd a b = Zabs b.
+ forall a b : Z, a <> 0%Z -> Zdivides b a -> Zgcd a b = Z.abs b.
 Proof.
  intros.
  unfold Zgcd in |- *.
@@ -834,7 +834,7 @@ Proof.
 Qed.
 
 Lemma Zgcd_coeff_b_divisor :
- forall a b : Z, a <> 0%Z -> Zdivides b a -> Zgcd_coeff_b a b = Zsgn b.
+ forall a b : Z, a <> 0%Z -> Zdivides b a -> Zgcd_coeff_b a b = Z.sgn b.
 Proof.
  intros.
  unfold Zgcd_coeff_b in |- *.
@@ -843,7 +843,7 @@ Qed.
 
 Lemma Zgcd_duv_symm :
  forall a b : Z,
- Zabs a <> Zabs b ->
+ Z.abs a <> Z.abs b ->
  Zgcd_duv a b = (Zgcd b a, (Zgcd_coeff_b b a, Zgcd_coeff_a b a)).
 Proof.
  intros a b.
@@ -862,7 +862,7 @@ Proof.
 Qed.
 
 Lemma Zgcd_coeff_a_symm :
- forall a b : Z, Zabs a <> Zabs b -> Zgcd_coeff_a a b = Zgcd_coeff_b b a.
+ forall a b : Z, Z.abs a <> Z.abs b -> Zgcd_coeff_a a b = Zgcd_coeff_b b a.
 Proof.
  intros a b Hneq.
  unfold Zgcd_coeff_a, Zgcd_coeff_b in |- *.
@@ -871,7 +871,7 @@ Proof.
 Qed.
 
 Lemma Zgcd_coeff_b_symm :
- forall a b : Z, Zabs a <> Zabs b -> Zgcd_coeff_b a b = Zgcd_coeff_a b a.
+ forall a b : Z, Z.abs a <> Z.abs b -> Zgcd_coeff_b a b = Zgcd_coeff_a b a.
 Proof.
  intros a b Hneq.
  unfold Zgcd_coeff_a, Zgcd_coeff_b in |- *.
@@ -1080,13 +1080,13 @@ Proof.
   rewrite Z_mod_same.
    rewrite Zgcd_zero_rht.
    auto with zarith.
-  replace (Zabs a) with a.
+  replace (Z.abs a) with a.
    assumption.
   symmetry  in |- *; auto with zarith.
  auto with zarith.
 Qed.
 
-Lemma Zgcd_zero_lft : forall a : Z, Zgcd 0 a = Zabs a.
+Lemma Zgcd_zero_lft : forall a : Z, Zgcd 0 a = Z.abs a.
 Proof.
  intro a.
  rewrite Zgcd_symm.
@@ -1131,9 +1131,9 @@ Proof.
  case (Zdec a).
   intro H0; rewrite H0; repeat rewrite Zgcd_zero_lft; auto with zarith.
  intro H0.
- replace (Zgcd a b) with (Zabs (Zgcd a b)).
+ replace (Zgcd a b) with (Z.abs (Zgcd a b)).
   rewrite Zgcd_abs.
-  replace (Zabs (Zabs (Zgcd a b))) with (Zgcd a b).
+  replace (Z.abs (Z.abs (Zgcd a b))) with (Zgcd a b).
    apply Zgcd_divisor.
     auto with zarith.
    apply Zdivides_abs_elim_rht.
@@ -1156,7 +1156,7 @@ Lemma Zgcd_gcd_lr : forall a b : Z, Zgcd (Zgcd a b) b = Zgcd a b.
  intros a b; rewrite (Zgcd_symm a b); rewrite (Zgcd_symm (Zgcd b a) b); apply Zgcd_gcd_rl.
 Qed.
 
-Lemma Zgcd_mult_elim_ll : forall a b : Z, Zgcd (b * a) a = Zabs a.
+Lemma Zgcd_mult_elim_ll : forall a b : Z, Zgcd (b * a) a = Z.abs a.
 Proof.
  intros a b.
  elim (Zdec (b * a)).
@@ -1164,21 +1164,21 @@ Proof.
  intro Hab; apply Zgcd_divisor; auto with zarith.
 Qed.
 
-Lemma Zgcd_mult_elim_lr : forall a b : Z, Zgcd (a * b) a = Zabs a.
+Lemma Zgcd_mult_elim_lr : forall a b : Z, Zgcd (a * b) a = Z.abs a.
 Proof.
  intros.
  rewrite Zmult_comm.
  apply Zgcd_mult_elim_ll.
 Qed.
 
-Lemma Zgcd_mult_elim_rl : forall a b : Z, Zgcd a (b * a) = Zabs a.
+Lemma Zgcd_mult_elim_rl : forall a b : Z, Zgcd a (b * a) = Z.abs a.
 Proof.
  intros.
  rewrite Zgcd_symm.
  apply Zgcd_mult_elim_ll.
 Qed.
 
-Lemma Zgcd_mult_elim_rr : forall a b : Z, Zgcd a (a * b) = Zabs a.
+Lemma Zgcd_mult_elim_rr : forall a b : Z, Zgcd a (a * b) = Z.abs a.
 Proof.
  intros.
  rewrite Zmult_comm.
@@ -1310,7 +1310,7 @@ Lemma Zgcd_div_gcd_1 :
 Proof.
  intros a b Hab.
  apply Zdivides_antisymm; auto with zarith.
-  apply Zlt_gt.
+  apply Z.lt_gt.
   apply Zgcd_pos.
   generalize (Zgcd_nonzero a b); intro Hnz; elim Hnz; auto.
    intro Ha; left; intro Hfalse; generalize (Zgcd_div_mult_lft a b);
@@ -1469,7 +1469,7 @@ Proof.
 Qed.
 
 Lemma Zrelprime_nonzero_rht :
- forall a b : Z, Zrelprime a b -> Zabs a <> 1%Z -> b <> 0%Z.
+ forall a b : Z, Zrelprime a b -> Z.abs a <> 1%Z -> b <> 0%Z.
 Proof.
  intros a b H Ha.
  intro Hfalse.
@@ -1480,7 +1480,7 @@ Proof.
 Qed.
 
 Lemma Zrelprime_nonzero_lft :
- forall a b : Z, Zrelprime a b -> Zabs b <> 1%Z -> a <> 0%Z.
+ forall a b : Z, Zrelprime a b -> Z.abs b <> 1%Z -> a <> 0%Z.
 Proof.
  intros.
  apply (Zrelprime_nonzero_rht b a).
@@ -1515,12 +1515,12 @@ Lemma Zrelprime_div_mult_intro :
  forall a b c : Z, Zrelprime a b -> Zdivides a (b * c) -> Zdivides a c.
 Proof.
  intros a b c Hab Hdiv.
- case (Zdec (Zabs a - 1)).
+ case (Zdec (Z.abs a - 1)).
   intro H1.
-  exists (c * Zsgn a)%Z.
+  exists (c * Z.sgn a)%Z.
   rewrite <- Zmult_assoc.
-  replace (Zsgn a * a)%Z with (Zabs a); auto with zarith.
-  replace (Zabs a) with 1%Z; auto with zarith.
+  replace (Z.sgn a * a)%Z with (Z.abs a); auto with zarith.
+  replace (Z.abs a) with 1%Z; auto with zarith.
  intro Hn1.
  unfold Zrelprime in Hab.
  generalize (Zgcd_lin_comb a b).
@@ -1548,8 +1548,8 @@ Proof.
  intros a b x y Hab Heq.
  case (Zdec a).
   intro Ha; rewrite Ha in Hab; unfold Zrelprime in Hab; rewrite Zgcd_zero_lft in Hab.
-  exists (Zsgn b * x)%Z; rewrite Zmult_comm; rewrite Zmult_assoc;
-    rewrite (Zmult_comm b (Zsgn b)); rewrite <- Zmult_sgn_eq_abs; rewrite Hab; apply Zmult_1_l.
+  exists (Z.sgn b * x)%Z; rewrite Zmult_comm; rewrite Zmult_assoc;
+    rewrite (Zmult_comm b (Z.sgn b)); rewrite <- Zmult_sgn_eq_abs; rewrite Hab; apply Zmult_1_l.
  intro Ha.
  apply (Zmult_div_simpl_3 a x y b Heq Ha).
  apply (Zrelprime_div_mult_intro a b y Hab).
@@ -1584,11 +1584,11 @@ Proof.
       rewrite H2; rewrite Zgcd_one_lft; auto with zarith.
  intros Hab0 Hrelprime.
  apply Zdivides_antisymm.
-    apply Zlt_gt; apply Zgcd_pos; auto.
+    apply Z.lt_gt; apply Zgcd_pos; auto.
    rewrite <- (Zmult_0_r (Zgcd a c)).
    apply Zmult_pos_mon_lt_lft.
-    apply Zlt_gt; apply Zgcd_pos; left; rewrite Zmult_comm in Hab0; auto with zarith.
-   apply Zlt_gt; apply Zgcd_pos; left; auto with zarith.
+    apply Z.lt_gt; apply Zgcd_pos; left; rewrite Zmult_comm in Hab0; auto with zarith.
+   apply Z.lt_gt; apply Zgcd_pos; left; auto with zarith.
   rewrite (Zgcd_lin_comb a c); rewrite (Zgcd_lin_comb b c).
   repeat rewrite Zmult_plus_distr_r; repeat rewrite Zmult_plus_distr_l.
   apply Zdivides_plus_elim; apply Zdivides_plus_elim; auto with zarith.
@@ -1617,7 +1617,7 @@ Proof.
    set (s := Zgcd_coeff_b b c) in *.
  intros Hla Hlb.
  apply Zdivides_antisymm.
-    apply Zlt_gt; apply Zgcd_pos.
+    apply Z.lt_gt; apply Zgcd_pos.
     case (Zdec c); auto.
     intro Hc0.
     left.
@@ -1691,7 +1691,7 @@ Proof.
      intro HDp; rewrite HDp in HDlt; elim (Zlt_irref _ HDlt).
     auto with zarith.
    unfold d in |- *; auto with zarith.
-  apply (Zle_lt_trans d (Zpos x) (Zpos p)); unfold d in |- *; auto with zarith.
+  apply (Z.le_lt_trans d (Zpos x) (Zpos p)); unfold d in |- *; auto with zarith.
  unfold d in |- *; apply Zgcd_pos; auto with zarith.
 Qed.
 

--- a/model/Zmod/ZMod.v
+++ b/model/Zmod/ZMod.v
@@ -115,7 +115,7 @@ Proof.
   replace (b mod m)%Z with (b - m * (b / m))%Z.
    replace ((a + b) mod m)%Z with (a + b - m * ((a + b) / m))%Z.
     unfold Zminus in |- *; repeat rewrite Zplus_assoc.
-    repeat rewrite Zopp_plus_distr; repeat rewrite Zopp_involutive.
+    repeat rewrite Zopp_plus_distr; repeat rewrite Z.opp_involutive.
     rewrite (Zplus_comm (a + b) (- (m * ((a + b) / m)))).
     repeat rewrite <- Zplus_assoc.
     apply Zdivides_plus_elim.
@@ -215,7 +215,7 @@ Proof.
     unfold Zminus in |- *; repeat rewrite Zplus_assoc.
     repeat rewrite Zmult_plus_distr_l.
     repeat rewrite Zmult_plus_distr_r.
-    repeat rewrite Zopp_plus_distr; repeat rewrite Zopp_involutive.
+    repeat rewrite Zopp_plus_distr; repeat rewrite Z.opp_involutive.
     rewrite (Zplus_comm (a * b)).
     repeat rewrite <- Zplus_assoc.
     apply Zdivides_plus_elim.
@@ -223,7 +223,7 @@ Proof.
     repeat rewrite Zplus_assoc.
     rewrite Zplus_opp_r.
     repeat rewrite Zopp_mult_distr_l_reverse; repeat rewrite Zopp_mult_distr_r;
-      repeat rewrite Zopp_involutive.
+      repeat rewrite Z.opp_involutive.
     simpl in |- *.
     apply Zdivides_plus_elim; auto with zarith.
    generalize (Z_div_mod_eq (a * b) m Hm); auto with zarith.
@@ -581,8 +581,8 @@ Qed.
 Lemma Zmodeq_opp_intro : forall a b : Z, Zmodeq (- a) (- b) -> Zmodeq a b.
 Proof.
  intros a b H.
- rewrite <- (Zopp_involutive a).
- rewrite <- (Zopp_involutive b).
+ rewrite <- (Z.opp_involutive a).
+ rewrite <- (Z.opp_involutive b).
  apply (Zmodeq_opp_elim _ _ H).
 Qed.
 

--- a/model/Zmod/Zm.v
+++ b/model/Zmod/Zm.v
@@ -340,7 +340,7 @@ Hypothesis Hnontriv: ~(m=xH).
 
 Lemma m_gt_1: m>1.
 Proof.
- unfold Zgt.
+ unfold Z.gt.
  generalize Hnontriv.
  case m; simpl; intros; auto.
  elim Hnontriv0; auto.
@@ -548,7 +548,7 @@ Qed.
 
 Lemma p_gt_1: m>1.
 Proof.
- unfold Zgt.
+ unfold Z.gt.
  generalize p_not_1.
  case m; simpl; intro H; auto.
  elim H; auto.
@@ -577,9 +577,9 @@ Proof.
   split.
    elim (Zlt_asymmetric (Zmod x m) 0).
     intro Hfalse; elim Hx; elim Hfalse; clear Hfalse; intro Hfalse.
-     elim H; apply Zlt_gt; auto.
+     elim H; apply Z.lt_gt; auto.
     simpl; rewrite <-Hfalse; auto with zarith.
-   apply Zgt_lt.
+   apply Z.gt_lt.
   assumption.
  exact p_gt_0.
 Qed.

--- a/model/reals/CRreal.v
+++ b/model/reals/CRreal.v
@@ -188,14 +188,14 @@ Proof.
  simpl.
  rewrite -> Qle_minus_iff.
  replace RHS with
-   ((approximate (nring (R:=CRasCRing) a) ((1 # 2) * q)%Qpos + 1) + - ((Psucc (P_of_succ_nat a) # d)%Qpos- 1%Q))%Q by (simpl; ring).
+   ((approximate (nring (R:=CRasCRing) a) ((1 # 2) * q)%Qpos + 1) + - ((Pos.succ (P_of_succ_nat a) # d)%Qpos- 1%Q))%Q by (simpl; ring).
  rewrite<- Qle_minus_iff.
  eapply Qle_trans;[|apply IHa].
  generalize (P_of_succ_nat a).
  intros p.
  rewrite -> Qle_minus_iff.
  autorewrite with QposElim.
- replace RHS with (((p#d) + 1) + - (Psucc p # d)) by ring.
+ replace RHS with (((p#d) + 1) + - (Pos.succ p # d)) by ring.
  rewrite <- Qle_minus_iff.
  unfold Qle.
  simpl.

--- a/model/setoids/Zfinsetoid.v
+++ b/model/setoids/Zfinsetoid.v
@@ -43,8 +43,8 @@ Set Automatic Introduction.
 
 Record ZF (n:Z):Set:=
 {ZF_crr:> Z ;
-ZF_prf0: (Zlt  ZF_crr n);
-ZF_prf1: (Zle 0 ZF_crr)
+ZF_prf0: (Z.lt  ZF_crr n);
+ZF_prf1: (Z.le 0 ZF_crr)
 }.
 
 Definition ZFeq (n : Z) : ZF n -> ZF n -> Prop.
@@ -98,7 +98,7 @@ Proof.
  intros x0 H0 H0' x1 H1 H1' H2 z.
  case z.
  intros x2 H H'.
- set (H5 := Z_eq_dec x2 x1) in *.
+ set (H5 := Z.eq_dec x2 x1) in *.
  elim H5.
   clear H5.
   intro H5.

--- a/model/setoids/Zsetoid.v
+++ b/model/setoids/Zsetoid.v
@@ -123,16 +123,16 @@ Qed.
 Taking the opposite of an integer is a setoid function.
 *)
 
-Lemma Zopp_wd : fun_wd (S1:=Z_as_CSetoid) (S2:=Z_as_CSetoid) Zopp.
+Lemma Zopp_wd : fun_wd (S1:=Z_as_CSetoid) (S2:=Z_as_CSetoid) Z.opp.
 Proof.
  red in |- *.
  simpl in |- *.
  intros x y H.
- apply (f_equal Zopp H).
+ apply (f_equal Z.opp H).
 Qed.
 
 Lemma Zopp_strext :
- fun_strext (S1:=Z_as_CSetoid) (S2:=Z_as_CSetoid) Zopp.
+ fun_strext (S1:=Z_as_CSetoid) (S2:=Z_as_CSetoid) Z.opp.
 Proof.
  red in |- *.
  simpl in |- *.
@@ -140,11 +140,11 @@ Proof.
  intros x y H.
  intro H0.
  apply H.
- exact (f_equal Zopp H0).
+ exact (f_equal Z.opp H0).
 Qed.
 
 Definition Zopp_is_fun :=
-  Build_CSetoid_fun Z_as_CSetoid Z_as_CSetoid Zopp Zopp_strext.
+  Build_CSetoid_fun Z_as_CSetoid Z_as_CSetoid Z.opp Zopp_strext.
 Canonical Structure Zopp_is_fun.
 
 (**

--- a/model/structures/Qpossec.v
+++ b/model/structures/Qpossec.v
@@ -118,10 +118,10 @@ Qed.
 Arguments QposAsmkQpos [a].
 (* end hide *)
 
-Lemma positive_Z (z: Z): Zlt 0 z -> sig (fun p: positive => Zpos p = z).
+Lemma positive_Z (z: Z): Z.lt 0 z -> sig (fun p: positive => Zpos p = z).
  destruct z; intros.
    intros.
-   elim (Zlt_irrefl _ H).
+   elim (Z.lt_irrefl _ H).
   exists p.
   reflexivity.
  exfalso.
@@ -137,7 +137,7 @@ Defined.
 
 Lemma Zlt_uniq (a b: Z) (p q: (a < b)%Z): p = q.
 Proof.
- unfold Zlt in *. destruct p. intros.
+ unfold Z.lt in *. destruct p. intros.
  apply (Eqdep_dec.K_dec_set comparison_eq_dec).
  reflexivity.
 Qed.
@@ -405,7 +405,7 @@ Proof.
  generalize (QposRed_prf p (Qpos_prf p)).
  generalize (QposRed_prf q (Qpos_prf q)).
  rewrite (Qred_complete p q H).
- unfold Qlt, Zlt.
+ unfold Qlt, Z.lt.
  intros A B.
  assert (X:forall x y : comparison, x = y \/ x <> y).
   decide equality.

--- a/model/structures/Qsec.v
+++ b/model/structures/Qsec.v
@@ -161,7 +161,7 @@ Proof.
 Qed.
 
 Lemma nonZero : forall x : Q, ~(x==0) ->
-  ~(Qmake (Zsgn (Qnum x) * Qden x)%Z (posZ (Qnum x))==0).
+  ~(Qmake (Z.sgn (Qnum x) * Qden x)%Z (posZ (Qnum x))==0).
 Proof.
  intro x.
  unfold Qeq in |- *.
@@ -172,13 +172,13 @@ Proof.
  repeat rewrite Zmult_1_r.
  simpl in |- *.
  intro H.
- cut (Zsgn (Qnum x) <> 0%Z).
+ cut (Z.sgn (Qnum x) <> 0%Z).
   intro H0.
   cut (Zpos (Qden x) <> 0%Z).
    intro H1.
    intro H2.
    elim H0.
-   exact (Zmult_integral_l (Qden x) (Zsgn (Qnum x)) H1 H2).
+   exact (Zmult_integral_l (Qden x) (Z.sgn (Qnum x)) H1 H2).
   apply Zgt_not_eq.
   auto with zarith.
  apply Zsgn_3.
@@ -300,23 +300,23 @@ Proof.
  intro x.
  case x.
  intros p q.
- exists (P_of_succ_nat (Zabs_nat p)).
+ exists (P_of_succ_nat (Z.abs_nat p)).
  red in |- *.
  unfold Qnum at 1 in |- *.
  unfold Qden in |- *.
  apply toCProp_Zlt.
  simpl in |- *.
  rewrite Zmult_1_r.
- apply Zlt_le_trans with (P_of_succ_nat (Zabs_nat p) * 1)%Z.
+ apply Z.lt_le_trans with (P_of_succ_nat (Z.abs_nat p) * 1)%Z.
   rewrite Zmult_1_r.
   case p; simpl in |- *; auto with zarith.
    intros; rewrite P_of_succ_nat_o_nat_of_P_eq_succ; rewrite Pplus_one_succ_r.
    change (p0 < p0 + 1)%Z in |- *.
    auto with zarith.
-  intros; unfold Zlt in |- *; auto.
- change (P_of_succ_nat (Zabs_nat p) * 1%positive <= P_of_succ_nat (Zabs_nat p) * q)%Z in |- *.
+  intros; unfold Z.lt in |- *; auto.
+ change (P_of_succ_nat (Z.abs_nat p) * 1%positive <= P_of_succ_nat (Z.abs_nat p) * q)%Z in |- *.
  apply Zmult_le_compat_l.
-  change (Zsucc 0 <= q)%Z in |- *.
+  change (Z.succ 0 <= q)%Z in |- *.
   apply Zgt_le_succ.
   auto with zarith.
  auto with zarith.

--- a/model/structures/Zsec.v
+++ b/model/structures/Zsec.v
@@ -84,7 +84,7 @@ Lemma ap_Z_cotransitive0 : forall x y : Z,
 Proof.
  intros x y X z.
  unfold ap_Z in |- *.
- case (Z_eq_dec x z).
+ case (Z.eq_dec x z).
   intro e.
   right.
   rewrite <- e.
@@ -101,7 +101,7 @@ Proof.
  split.
   unfold ap_Z in |- *.
   intro H.
-  case (Z_eq_dec x y).
+  case (Z.eq_dec x y).
    intro e.
    assumption.
   contradiction.
@@ -113,7 +113,7 @@ Proof.
  apply ap_Z_symmetric0.
  red in |- *.
  apply Zorder.Zlt_not_eq.
- apply Zgt_lt.
+ apply Z.gt_lt.
  exact (Zorder.Zgt_pos_0 1).
 Qed.
 
@@ -138,7 +138,7 @@ Proof.
  intros x1 x2 y1 y2 H.
  unfold ap_Z in |- *.
  unfold ap_Z in H.
- case (Z_eq_dec x1 x2).
+ case (Z.eq_dec x1 x2).
   intro e.
   right.
   red in |- *.
@@ -158,7 +158,7 @@ Lemma Zmult_strext0 : forall x1 x2 y1 y2 : Z,
 Proof.
  unfold ap_Z in |- *.
  intros x1 x2 y1 y2 H.
- case (Z_eq_dec x1 x2).
+ case (Z.eq_dec x1 x2).
   intro e.
   right.
   red in |- *.
@@ -275,12 +275,12 @@ Proof.
  simple induction x; intros; reflexivity || inversion H.
 Qed.
 
-Lemma posZ_Zsgn : forall x : Z, x <> 0%Z -> (Zsgn x * posZ x)%Z = x.
+Lemma posZ_Zsgn : forall x : Z, x <> 0%Z -> (Z.sgn x * posZ x)%Z = x.
 Proof.
  simple induction x; intros; reflexivity.
 Qed.
 
-Lemma posZ_Zsgn2 : forall x : Z, x <> 0%Z -> (Zsgn x * x)%Z = posZ x.
+Lemma posZ_Zsgn2 : forall x : Z, x <> 0%Z -> (Z.sgn x * x)%Z = posZ x.
 Proof.
  simple induction x; intros; [ elim H | simpl in |- * | simpl in |- * ]; reflexivity.
 Qed.
@@ -299,16 +299,16 @@ Proof.
    rewrite H1 in H.
    simpl in H.
    simpl in |- *.
-   apply Zgt_lt.
+   apply Z.gt_lt.
    cut (a * 0 > a * p)%Z.
     intro.
     rewrite Zmult_0_r in H3.
     assumption.
    apply Zlt_conv_mult_l.
-    apply Zgt_lt.
+    apply Z.gt_lt.
     cut (- (0) > - - a)%Z.
      simpl in |- *.
-     rewrite Zopp_involutive.
+     rewrite Z.opp_involutive.
      trivial.
     apply Zlt_opp.
     apply Zmult_gt_0_lt_0_reg_r with (n := n).
@@ -317,11 +317,11 @@ Proof.
     cut (- (a * n) > - (0))%Z.
      simpl in |- *.
      intro.
-     apply Zgt_lt.
+     apply Z.gt_lt.
      trivial.
     apply Zlt_opp.
     assumption.
-   apply Zgt_lt.
+   apply Z.gt_lt.
    auto with zarith.
   apply Zmult_integral_l with (n := n).
    apply Zgt_not_eq.
@@ -338,10 +338,10 @@ Proof.
     intro.
     cut (b * p * (a * n) > c * n * (b * m))%Z.
      intro.
-     apply Zgt_lt.
+     apply Z.gt_lt.
      apply Zgt_mult_reg_absorb_l with (a := n).
       auto with zarith.
-     apply Zlt_gt.
+     apply Z.lt_gt.
      apply Zgt_mult_conv_absorb_l with (a := b).
       assumption.
      replace (b * (n * (a * p)))%Z with (b * p * (a * n))%Z by  ring.
@@ -349,10 +349,10 @@ Proof.
     rewrite <- H0.
     auto.
    apply Zlt_conv_mult_l;trivial.
-  apply Zgt_lt.
+  apply Z.gt_lt.
   replace 0%Z with (b * 0)%Z by  ring.
   apply Zlt_conv_mult_l; trivial.
-  apply Zgt_lt.
+  apply Z.gt_lt.
   auto with zarith.
  (* y>0 *)
  intro.
@@ -362,13 +362,13 @@ Proof.
    intro.
    cut (b * p * (a * n) < c * n * (b * m))%Z.
     intro.
-    apply Zgt_lt.
+    apply Z.gt_lt.
     apply Zgt_mult_reg_absorb_l with (a := n).
      auto with zarith.
     apply Zgt_mult_reg_absorb_l with (a := b).
-     apply Zlt_gt.
+     apply Z.lt_gt.
      assumption.
-    apply Zlt_gt.
+    apply Z.lt_gt.
     replace (b * (n * (a * p)))%Z with (b * p * (a * n))%Z by  ring.
     replace (b * (n * (c * m)))%Z with (c * n * (b * m))%Z by  ring; auto.
    rewrite <- H0.

--- a/model/totalorder/ZMinMax.v
+++ b/model/totalorder/ZMinMax.v
@@ -43,123 +43,123 @@ Proof.
  intros.
  split.
   intros H; rewrite H.
-  firstorder using Zle_refl.
+  firstorder using Z.le_refl.
  firstorder using Zle_antisym.
 Qed.
 
-Definition Zmonotone : (Z -> Z) -> Prop := Default.monotone Zle.
-Definition Zantitone : (Z -> Z) -> Prop := Default.antitone Zle.
+Definition Zmonotone : (Z -> Z) -> Prop := Default.monotone Z.le.
+Definition Zantitone : (Z -> Z) -> Prop := Default.antitone Z.le.
 
 Definition ZTotalOrder : TotalOrder.
- apply makeTotalOrder with Z (@eq Z) Zle Zmonotone Zantitone Zmin Zmax; try solve [auto with *].
+ apply makeTotalOrder with Z (@eq Z) Z.le Zmonotone Zantitone Z.min Z.max; try solve [auto with *].
 Proof.
      apply Zle_total.
     firstorder using PartialOrder.Default.monotone_def.
     firstorder using PartialOrder.Default.antitone_def.
-    intros. apply Zmin_case_strong; auto with *.
-    intros. apply Zmin_case_strong; auto with *.
-   intros. apply Zmax_case_strong; auto with *.
-  intros. apply Zmax_case_strong; auto with *.
+    intros. apply Z.min_case_strong; auto with *.
+    intros. apply Z.min_case_strong; auto with *.
+   intros. apply Z.max_case_strong; auto with *.
+  intros. apply Z.max_case_strong; auto with *.
 Defined.
 
 Let Zto := ZTotalOrder.
 
-Definition Zmin_lb_l : forall x y : Z, Zmin x y <= x := @meet_lb_l Zto.
-Definition Zmin_lb_r : forall x y : Z, Zmin x y <= y := @meet_lb_r Zto.
-Definition Zmin_glb : forall x y z : Z, z <= x -> z <= y -> z <= (Zmin x y) :=
+Definition Zmin_lb_l : forall x y : Z, Z.min x y <= x := @meet_lb_l Zto.
+Definition Zmin_lb_r : forall x y : Z, Z.min x y <= y := @meet_lb_r Zto.
+Definition Zmin_glb : forall x y z : Z, z <= x -> z <= y -> z <= (Z.min x y) :=
  @meet_glb Zto.
-Definition Zmin_comm : forall x y : Z, Zmin x y = Zmin y x := @meet_comm Zto.
-Definition Zmin_assoc : forall x y z : Z, Zmin x (Zmin y z) = Zmin (Zmin x y) z:=
+Definition Zmin_comm : forall x y : Z, Z.min x y = Z.min y x := @meet_comm Zto.
+Definition Zmin_assoc : forall x y z : Z, Z.min x (Z.min y z) = Z.min (Z.min x y) z:=
  @meet_assoc Zto.
-Definition Zmin_idem : forall x : Z, Zmin x x = x := @meet_idem Zto.
-Definition Zle_min_l : forall x y : Z, x <= y <-> Zmin x y = x := @le_meet_l Zto.
-Definition Zle_min_r : forall x y : Z, y <= x <-> Zmin x y = y := @le_meet_r Zto.
-Definition Zmin_irred : forall x y: Z, {Zmin x y = x} + {Zmin x y = y} := @meet_irred Zto.
-Definition Zmin_monotone_r : forall a : Z, Zmonotone (Zmin a) :=
+Definition Zmin_idem : forall x : Z, Z.min x x = x := @meet_idem Zto.
+Definition Zle_min_l : forall x y : Z, x <= y <-> Z.min x y = x := @le_meet_l Zto.
+Definition Zle_min_r : forall x y : Z, y <= x <-> Z.min x y = y := @le_meet_r Zto.
+Definition Zmin_irred : forall x y: Z, {Z.min x y = x} + {Z.min x y = y} := @meet_irred Zto.
+Definition Zmin_monotone_r : forall a : Z, Zmonotone (Z.min a) :=
  @meet_monotone_r Zto.
-Definition Zmin_monotone_l : forall a : Z, Zmonotone (fun x => Zmin x a) :=
+Definition Zmin_monotone_l : forall a : Z, Zmonotone (fun x => Z.min x a) :=
  @meet_monotone_l Zto.
-Definition Zmin_le_compat : forall w x y z : Z, w <= y -> x <= z -> Zmin w x <= Zmin y z :=
+Definition Zmin_le_compat : forall w x y z : Z, w <= y -> x <= z -> Z.min w x <= Z.min y z :=
  @meet_le_compat Zto.
 
-Definition Zmax_ub_l : forall x y : Z, x <= Zmax x y := @join_ub_l Zto.
-Definition Zmax_ub_r : forall x y : Z, y <= Zmax x y := @join_ub_r Zto.
-Definition Zmax_glb : forall x y z : Z, x <= z -> y <= z -> (Zmax x y) <= z :=
+Definition Zmax_ub_l : forall x y : Z, x <= Z.max x y := @join_ub_l Zto.
+Definition Zmax_ub_r : forall x y : Z, y <= Z.max x y := @join_ub_r Zto.
+Definition Zmax_glb : forall x y z : Z, x <= z -> y <= z -> (Z.max x y) <= z :=
  @join_lub Zto.
-Definition Zmax_comm : forall x y : Z, Zmax x y = Zmax y x := @join_comm Zto.
-Definition Zmax_assoc : forall x y z : Z, Zmax x (Zmax y z) = Zmax (Zmax x y) z:=
+Definition Zmax_comm : forall x y : Z, Z.max x y = Z.max y x := @join_comm Zto.
+Definition Zmax_assoc : forall x y z : Z, Z.max x (Z.max y z) = Z.max (Z.max x y) z:=
  @join_assoc Zto.
-Definition Zmax_idem : forall x : Z, Zmax x x = x := @join_idem Zto.
-Definition Zle_max_l : forall x y : Z, y <= x <-> Zmax x y = x := @le_join_l Zto.
-Definition Zle_max_r : forall x y : Z, x <= y <-> Zmax x y = y := @le_join_r Zto.
-Definition Zmax_irred : forall x y: Z, {Zmax x y = x} + {Zmax x y = y} := @join_irred Zto.
-Definition Zmax_monotone_r : forall a : Z, Zmonotone (Zmax a) :=
+Definition Zmax_idem : forall x : Z, Z.max x x = x := @join_idem Zto.
+Definition Zle_max_l : forall x y : Z, y <= x <-> Z.max x y = x := @le_join_l Zto.
+Definition Zle_max_r : forall x y : Z, x <= y <-> Z.max x y = y := @le_join_r Zto.
+Definition Zmax_irred : forall x y: Z, {Z.max x y = x} + {Z.max x y = y} := @join_irred Zto.
+Definition Zmax_monotone_r : forall a : Z, Zmonotone (Z.max a) :=
  @join_monotone_r Zto.
-Definition Zmax_monotone_l : forall a : Z, Zmonotone (fun x => Zmax x a) :=
+Definition Zmax_monotone_l : forall a : Z, Zmonotone (fun x => Z.max x a) :=
  @join_monotone_l Zto.
-Definition Zmax_le_compat : forall w x y z : Z, w <= y -> x <= z -> Zmax w x <= Zmax y z :=
+Definition Zmax_le_compat : forall w x y z : Z, w <= y -> x <= z -> Z.max w x <= Z.max y z :=
  @join_le_compat Zto.
 
-Definition Zmin_max_absorb_l_l : forall x y : Z, Zmin x (Zmax x y) = x :=
+Definition Zmin_max_absorb_l_l : forall x y : Z, Z.min x (Z.max x y) = x :=
  @meet_join_absorb_l_l Zto.
-Definition Zmax_min_absorb_l_l : forall x y : Z, Zmax x (Zmin x y) = x :=
+Definition Zmax_min_absorb_l_l : forall x y : Z, Z.max x (Z.min x y) = x :=
  @join_meet_absorb_l_l Zto.
-Definition Zmin_max_absorb_l_r : forall x y : Z, Zmin x (Zmax y x) = x :=
+Definition Zmin_max_absorb_l_r : forall x y : Z, Z.min x (Z.max y x) = x :=
  @meet_join_absorb_l_r Zto.
-Definition Zmax_min_absorb_l_r : forall x y : Z, Zmax x (Zmin y x) = x :=
+Definition Zmax_min_absorb_l_r : forall x y : Z, Z.max x (Z.min y x) = x :=
  @join_meet_absorb_l_r Zto.
-Definition Zmin_max_absorb_r_l : forall x y : Z, Zmin (Zmax x y) x = x :=
+Definition Zmin_max_absorb_r_l : forall x y : Z, Z.min (Z.max x y) x = x :=
  @meet_join_absorb_r_l Zto.
-Definition Zmax_min_absorb_r_l : forall x y : Z, Zmax (Zmin x y) x = x :=
+Definition Zmax_min_absorb_r_l : forall x y : Z, Z.max (Z.min x y) x = x :=
  @join_meet_absorb_r_l Zto.
-Definition Zmin_max_absorb_r_r : forall x y : Z, Zmin (Zmax y x) x = x :=
+Definition Zmin_max_absorb_r_r : forall x y : Z, Z.min (Z.max y x) x = x :=
  @meet_join_absorb_r_r Zto.
-Definition Zmax_min_absorb_r_r : forall x y : Z, Zmax (Zmin y x) x = x :=
+Definition Zmax_min_absorb_r_r : forall x y : Z, Z.max (Z.min y x) x = x :=
  @join_meet_absorb_r_r Zto.
 
 Definition Zmax_min_distr_r : forall x y z : Z,
- Zmax x (Zmin y z) = Zmin (Zmax x y) (Zmax x z) :=
+ Z.max x (Z.min y z) = Z.min (Z.max x y) (Z.max x z) :=
  @join_meet_distr_r Zto.
 Definition Zmax_min_distr_l : forall x y z : Z,
- Zmax (Zmin y z) x = Zmin (Zmax y x) (Zmax z x) :=
+ Z.max (Z.min y z) x = Z.min (Z.max y x) (Z.max z x) :=
  @join_meet_distr_l Zto.
 Definition Zmin_max_distr_r : forall x y z : Z,
- Zmin x (Zmax y z) = Zmax (Zmin x y) (Zmin x z) :=
+ Z.min x (Z.max y z) = Z.max (Z.min x y) (Z.min x z) :=
  @meet_join_distr_r Zto.
 Definition Zmin_max_distr_l : forall x y z : Z,
- Zmin (Zmax y z) x = Zmax (Zmin y x) (Zmin z x) :=
+ Z.min (Z.max y z) x = Z.max (Z.min y x) (Z.min z x) :=
  @meet_join_distr_l Zto.
 
 (*I don't know who wants modularity laws, but here they are *)
 Definition Zmax_min_modular_r : forall x y z : Z,
- Zmax x (Zmin y (Zmax x z)) = Zmin (Zmax x y) (Zmax x z) :=
+ Z.max x (Z.min y (Z.max x z)) = Z.min (Z.max x y) (Z.max x z) :=
  @join_meet_modular_r Zto.
 Definition Zmax_min_modular_l : forall x y z : Z,
- Zmax (Zmin (Zmax x z) y) z = Zmin (Zmax x z) (Zmax y z) :=
+ Z.max (Z.min (Z.max x z) y) z = Z.min (Z.max x z) (Z.max y z) :=
  @join_meet_modular_l Zto.
 Definition Zmin_max_modular_r : forall x y z : Z,
- Zmin x (Zmax y (Zmin x z)) = Zmax (Zmin x y) (Zmin x z) :=
+ Z.min x (Z.max y (Z.min x z)) = Z.max (Z.min x y) (Z.min x z) :=
  @meet_join_modular_r Zto.
 Definition Zmin_max_modular_l : forall x y z : Z,
- Zmin (Zmax (Zmin x z) y) z = Zmax (Zmin x z) (Zmin y z) :=
+ Z.min (Z.max (Z.min x z) y) z = Z.max (Z.min x z) (Z.min y z) :=
  @meet_join_modular_l Zto.
 
-Definition Zmin_max_disassoc : forall x y z : Z, Zmin (Zmax x y) z <= Zmax x (Zmin y z) :=
+Definition Zmin_max_disassoc : forall x y z : Z, Z.min (Z.max x y) z <= Z.max x (Z.min y z) :=
  @meet_join_disassoc Zto.
 
-Lemma Zsucc_monotone : Zmonotone Zsucc.
+Lemma Zsucc_monotone : Zmonotone Z.succ.
 Proof.
  unfold Zmonotone, Default.monotone.
  auto with *.
 Qed.
 Definition Zsucc_min_distr : forall x y : Z,
- Zsucc (Zmin x y) = Zmin (Zsucc x ) (Zsucc y) :=
+ Z.succ (Z.min x y) = Z.min (Z.succ x ) (Z.succ y) :=
  @monotone_meet_distr Zto _ Zsucc_monotone.
 Definition Zsucc_max_distr : forall x y : Z,
- Zsucc (Zmax x y) = Zmax (Zsucc x ) (Zsucc y) :=
+ Z.succ (Z.max x y) = Z.max (Z.succ x ) (Z.succ y) :=
  @monotone_join_distr Zto _ Zsucc_monotone.
 
-Lemma Zpred_monotone : Zmonotone Zpred.
+Lemma Zpred_monotone : Zmonotone Z.pred.
 Proof.
  unfold Zmonotone, Default.monotone.
  intros x y H.
@@ -168,10 +168,10 @@ Proof.
   auto with zarith. 
 Qed.
 Definition Zpred_min_distr : forall x y : Z,
- Zpred (Zmin x y) = Zmin (Zpred x ) (Zpred y) :=
+ Z.pred (Z.min x y) = Z.min (Z.pred x ) (Z.pred y) :=
  @monotone_meet_distr Zto _ Zpred_monotone.
 Definition Zpred_max_distr : forall x y : Z,
- Zpred (Zmax x y) = Zmax (Zpred x ) (Zpred y) :=
+ Z.pred (Z.max x y) = Z.max (Z.pred x ) (Z.pred y) :=
  @monotone_join_distr Zto _ Zpred_monotone.
 
 Lemma Zplus_monotone_r : forall a, Zmonotone (Zplus a).
@@ -183,38 +183,38 @@ Proof.
  unfold Zmonotone, Default.monotone.
  auto with *.
 Qed.
-Definition Zmin_plus_distr_r : forall x y z : Z, x + Zmin y z = Zmin (x+y) (x+z)  :=
+Definition Zmin_plus_distr_r : forall x y z : Z, x + Z.min y z = Z.min (x+y) (x+z)  :=
  fun a => @monotone_meet_distr Zto _ (Zplus_monotone_r a).
-Definition Zmin_plus_distr_l : forall x y z : Z, Zmin y z + x = Zmin (y+x) (z+x) :=
+Definition Zmin_plus_distr_l : forall x y z : Z, Z.min y z + x = Z.min (y+x) (z+x) :=
  fun a => @monotone_meet_distr Zto _ (Zplus_monotone_l a).
-Definition Zmax_plus_distr_r : forall x y z : Z, x + Zmax y z = Zmax (x+y) (x+z)  :=
+Definition Zmax_plus_distr_r : forall x y z : Z, x + Z.max y z = Z.max (x+y) (x+z)  :=
  fun a => @monotone_join_distr Zto _ (Zplus_monotone_r a).
-Definition Zmax_plus_distr_l : forall x y z : Z, Zmax y z + x = Zmax (y+x) (z+x) :=
+Definition Zmax_plus_distr_l : forall x y z : Z, Z.max y z + x = Z.max (y+x) (z+x) :=
  fun a => @monotone_join_distr Zto _ (Zplus_monotone_l a).
-Definition Zmin_minus_distr_l : forall x y z : Z, Zmin y z - x = Zmin (y-x) (z-x) :=
+Definition Zmin_minus_distr_l : forall x y z : Z, Z.min y z - x = Z.min (y-x) (z-x) :=
  (fun x => Zmin_plus_distr_l (-x)).
-Definition Zmax_minus_distr_l : forall x y z : Z, Zmax y z - x = Zmax (y-x) (z-x) :=
+Definition Zmax_minus_distr_l : forall x y z : Z, Z.max y z - x = Z.max (y-x) (z-x) :=
  (fun x => Zmax_plus_distr_l (-x)).
 
 Lemma Zopp_le_compat : forall x y : Z, x <= y -> -y <= -x.
 Proof.
  auto with *.
 Qed.
-Definition Zmin_max_de_morgan : forall x y : Z, -(Zmin x y) = Zmax (-x) (-y) :=
+Definition Zmin_max_de_morgan : forall x y : Z, -(Z.min x y) = Z.max (-x) (-y) :=
  @antitone_meet_join_distr Zto _ Zopp_le_compat.
-Definition Zmax_min_de_morgan : forall x y : Z, -(Zmax x y) = Zmin (-x) (-y) :=
+Definition Zmax_min_de_morgan : forall x y : Z, -(Z.max x y) = Z.min (-x) (-y) :=
  @antitone_join_meet_distr Zto _ Zopp_le_compat.
 
 Lemma Zminus_antitone : forall a : Z, Zantitone (fun x => a - x).
 Proof.
  change (forall a x y : Z, x <= y -> a + - y <= a + - x).
  intros.
- apply Zplus_le_compat; firstorder using Zle_refl Zopp_le_compat.
+ apply Zplus_le_compat; firstorder using Z.le_refl Zopp_le_compat.
 Qed.
 
-Definition Zminus_min_max_antidistr_r : forall x y z : Z, x - Zmin y z = Zmax (x-y) (x-z) :=
+Definition Zminus_min_max_antidistr_r : forall x y z : Z, x - Z.min y z = Z.max (x-y) (x-z) :=
  fun a => @antitone_meet_join_distr Zto _ (Zminus_antitone a).
-Definition Zminus_max_min_antidistr_r : forall x y z : Z, x - Zmax y z = Zmin (x-y) (x-z) :=
+Definition Zminus_max_min_antidistr_r : forall x y z : Z, x - Z.max y z = Z.min (x-y) (x-z) :=
  fun a => @antitone_join_meet_distr Zto _ (Zminus_antitone a).
 
 End ZTotalOrder.

--- a/reals/Q_in_CReals.v
+++ b/reals/Q_in_CReals.v
@@ -285,7 +285,7 @@ Proof.
      apply False_rect.
      generalize H.
      change (~ (0 < 0)%Z) in |- *.
-     apply Zlt_irrefl.
+     apply Z.lt_irrefl.
     intros.
     simpl in |- *.
     astepl (nring (R:=R1) 0).
@@ -799,7 +799,7 @@ Proof.
  induction n.
   apply inj_Q_One.
  rewrite inj_S.
- unfold Zsucc.
+ unfold Z.succ.
  stepr (inj_Q (q^n*q)%Q).
   apply inj_Q_wd.
   simpl.

--- a/reals/fast/CRAlternatingSum.v
+++ b/reals/fast/CRAlternatingSum.v
@@ -482,7 +482,7 @@ Proof.
    rewrite inj_S in X.
    rstepr ([--][--]('(((- (1)) ^ n * Str_nth n (tl seq))%Q))%CR).
    apply inv_resp_AbsSmall.
-   stepr (' ((- (1)) ^ Zsucc n * Str_nth (S n) seq)%Q)%CR;[assumption|].
+   stepr (' ((- (1)) ^ Z.succ n * Str_nth (S n) seq)%Q)%CR;[assumption|].
    simpl.
    change ((' ( (- (1)) ^ (n+1) * Str_nth n (tl seq))%Q == - ' ((- (1)) ^ n * Str_nth n (tl seq))%Q)%CR).
    rewrite -> Qpower_plus;[|discriminate].
@@ -508,7 +508,7 @@ Proof.
   intros i; simpl.
   change (Qpower_positive (- (1)) (P_of_succ_nat i)) with ((-(1))^ S i).
   rewrite inj_S.
-  unfold Zsucc.
+  unfold Z.succ.
   rewrite -> Qpower_plus;[|discriminate].
   ring.
  apply cg_minus_wd;[rewrite -> IR_Sum0_as_CR|reflexivity].

--- a/reals/fast/CRArith.v
+++ b/reals/fast/CRArith.v
@@ -713,7 +713,7 @@ Proof.
   apply CRle_Qle. simpl.
   destruct (decide ((ε : Q) ≤ 1)).
    rewrite Z.nat_of_Z_nonneg.
-    rewrite Zopp_involutive.
+    rewrite Z.opp_involutive.
     apply Qdlog2_spec.
     now destruct ε.
    apply Z.opp_nonneg_nonpos.

--- a/reals/fast/CRGeometricSum.v
+++ b/reals/fast/CRGeometricSum.v
@@ -73,7 +73,7 @@ Local Coercion Is_true : bool >-> Sortclass.
 Lemma err_prop_prop : forall e s, err_prop e s <-> err_bound s <= e.
 Proof.
  intros e s.
- unfold err_prop, err_bound, Qcompare, Qle, Zle.
+ unfold err_prop, err_bound, Qcompare, Qle, Z.le.
  destruct (Qnum (Qabs (hd s) / (1 - a))%Q * Qden e ?= Qnum e * Qden (Qabs (hd s) / (1 - a))%Q)%Z;
    split; auto with *.
 Qed.
@@ -174,7 +174,7 @@ Proof.
 Qed.
 
 Lemma InfiniteSum_raw_N_Psucc : forall p c,
- InfiniteSum_raw_N (Psucc p) c =
+ InfiniteSum_raw_N (Pos.succ p) c =
  InfiniteSum_raw_F (fun err s => InfiniteSum_raw_N p c err s).
 Proof.
  intros p.
@@ -202,13 +202,13 @@ Proof.
     destruct (err (tl s));[reflexivity|contradiction]).
  intros q s err H H0.
  destruct q using Pind.
-  elim (Psucc_discr p).
+  elim (Pos.succ_discr p).
   apply Zpos_eq_rev.
   apply Zle_antisym.
    rewrite Pplus_one_succ_r.
    rewrite Zpos_plus_distr.
    auto with *.
-  eapply Zle_trans.
+  eapply Z.le_trans.
    apply H0.
   auto with *.
  do 2 rewrite InfiniteSum_raw_N_Psucc.
@@ -222,7 +222,7 @@ Qed.
 
 Lemma InfiniteSum_raw_N_extend : forall (p:positive) s (err : Stream Q -> bool),
  (err (Str_nth_tl (nat_of_P p) s)) ->
- InfiniteSum_raw_N p (fun _ _ => 0) err s = InfiniteSum_raw_N (Psucc p) (fun _ _ => 0) err s.
+ InfiniteSum_raw_N p (fun _ _ => 0) err s = InfiniteSum_raw_N (Pos.succ p) (fun _ _ => 0) err s.
 Proof.
  intros.
  apply InfiniteSum_raw_N_extend'; auto with *.
@@ -312,7 +312,7 @@ Proof.
    stepl (/a); [| simpl; ring].
    apply Qle_refl.
   rewrite Zpos_succ_morphism.
-  unfold Zsucc.
+  unfold Z.succ.
   rewrite -> Qpower_plus;[|auto with *].
   rewrite -> Qinv_mult_distr.
   rewrite -> injz_plus.
@@ -331,7 +331,7 @@ Qed.
 Definition InfiniteGeometricSum_maxIter series (err:Qpos) : positive :=
 let x := (1-a) in
 let (n,d) := (Qabs (hd series))/(err*x*x) in
-match Zsucc (Zdiv n d) with
+match Z.succ (Z.div n d) with
 | Zpos p => p
 | _ => 1%positive
 end.
@@ -347,8 +347,8 @@ Proof.
   generalize (Qabs (hd (tl series)) / (err * (1 - a) * (1 - a)))
     (Qabs (hd series) / (err * (1 - a) * (1 - a))).
   intros [na da] [nb db] H.
-  cut (Zsucc (na/da) <= Zsucc (nb/db))%Z.
-   generalize (Zsucc (na / da)) (Zsucc (nb/db)).
+  cut (Z.succ (na/da) <= Z.succ (nb/db))%Z.
+   generalize (Z.succ (na / da)) (Z.succ (nb/db)).
    intros [|x|x] [|y|y] Hxy; try solve [apply Hxy | apply Qle_refl | elim Hxy; constructor
      | unfold Qle; simpl; repeat rewrite Pmult_1_r; auto with *].
   apply Zsucc_le_compat.
@@ -398,17 +398,17 @@ Proof.
    cut (0 < (Qabs (hd series) / (err * (1 - a) * (1 - a)))).
     generalize (Qabs (hd series) / (err * (1 - a) * (1 - a))).
     intros [n d] Hnd.
-    apply Qle_trans with (Zsucc (n/d)).
+    apply Qle_trans with (Z.succ (n/d)).
      unfold Qle.
      simpl.
-     unfold Zsucc.
+     unfold Z.succ.
      apply Zle_0_minus_le.
      replace RHS with (d*(n/d) + n mod d - n mod d - n + d)%Z by ring.
      rewrite <- Z_div_mod_eq; auto with *.
      replace RHS with (d - n mod d)%Z by ring.
      apply Zle_minus_le_0.
      destruct (Z_mod_lt n d); auto with *.
-    generalize (Zsucc (n/d)).
+    generalize (Z.succ (n/d)).
     intros [|z|z].
       discriminate.
      apply Qle_refl.
@@ -434,7 +434,7 @@ Proof.
   assumption.
  rewrite nat_of_P_succ_morphism.
  rewrite Zpos_succ_morphism.
- unfold Zsucc.
+ unfold Z.succ.
  rewrite -> Qpower_plus';[|discriminate].
  stepr ((Qabs (hd series) * a ^ p)*a); [| simpl; ring].
  apply Qle_trans with (Qabs (hd (Str_nth_tl (nat_of_P p) series))*a).

--- a/reals/fast/CRcorrect.v
+++ b/reals/fast/CRcorrect.v
@@ -211,7 +211,7 @@ Proof.
   rewrite <- Zplus_assoc.
   rewrite <- Zpos_plus_distr.
   rewrite <- Pplus_one_succ_l.
-  change (dd+0 <=  dd + Psucc (P_of_succ_nat n))%Z.
+  change (dd+0 <=  dd + Pos.succ (P_of_succ_nat n))%Z.
   auto with *.
  change (dd <= dn*dd)%Z.
  auto with *.
@@ -242,7 +242,7 @@ Proof.
  destruct (le_lt_dec n' m) as [H|H].
   eapply AbsSmall_trans;[|apply Hn';assumption].
   change (ed < en*(P_of_succ_nat m))%Z.
-  apply Zlt_le_trans with (P_of_succ_nat m).
+  apply Z.lt_le_trans with (P_of_succ_nat m).
    rewrite <- POS_anti_convert.
    rewrite Zpos_eq_Z_of_nat_o_nat_of_P.
    apply inj_lt.

--- a/reals/fast/CRexp.v
+++ b/reals/fast/CRexp.v
@@ -133,7 +133,7 @@ Proof.
     (P_of_succ_nat (pred (S n)) * P_of_succ_nat (pred (fact n)))%positive.
    rewrite <- pred_Sn.
    rewrite inj_S.
-   unfold Zsucc.
+   unfold Z.succ.
    rewrite -> Qpower_plus'; auto with *.
    change ((1 # P_of_succ_nat n * P_of_succ_nat (pred (fact n))%positive))%Q
      with ((1 # P_of_succ_nat n) * (1#P_of_succ_nat (pred (fact n))))%Q.
@@ -234,7 +234,7 @@ Proof.
   replace LHS with (-(2%positive^n*2^1)) by simpl; ring.
   rewrite <- Qpower_plus;[|discriminate].
   replace RHS with a by (simpl; field; discriminate).
-  change (- (2 ^ Zsucc n)%Z <= a) in H0.
+  change (- (2 ^ Z.succ n)%Z <= a) in H0.
   rewrite ->  Zpower_Qpower in H0.
    assumption.
   auto with *.
@@ -350,7 +350,7 @@ Proof.
  change (n * 1 <= 2 ^ Psize n * d)%Z.
  apply Zmult_le_compat; try auto with *.
  clear - n.
- apply Zle_trans with (n+1)%Z.
+ apply Z.le_trans with (n+1)%Z.
   auto with *.
  induction n.
    change (Psize (xI n)) with (1 + (Psize n))%nat.
@@ -363,7 +363,7 @@ Proof.
   rewrite inj_plus.
   rewrite Zpower_exp; try auto with *.
   rewrite Zpos_xO.
-  apply Zle_trans with (2*(n+1))%Z.
+  apply Z.le_trans with (2*(n+1))%Z.
    auto with *.
   apply Zmult_le_compat; auto with *.
  discriminate.

--- a/reals/fast/CRln.v
+++ b/reals/fast/CRln.v
@@ -122,12 +122,12 @@ Proof.
   apply (Zlt_not_le _ _ Ha).
   ring_simplify in H.
   ring_simplify.
-  apply Zle_trans with (-(d*1))%Z; auto with *.
+  apply Z.le_trans with (-(d*1))%Z; auto with *.
   apply Zle_left_rev.
   replace RHS with (-(n + (d*1)))%Z by ring.
   simpl.
   rewrite H.
-  apply Zle_refl.
+  apply Z.le_refl.
  clear - Y.
  assert (X:inj_Q IR (a + 1)[#][0]).
   stepl (inj_Q IR a [+]inj_Q IR (nring 1)); [| now apply eq_symmetric; apply inj_Q_plus].
@@ -230,7 +230,7 @@ Definition ln_scale_power_factor q (Hq:0 < q) : Z.
 Proof.
  revert q Hq.
  intros [[|n|n] d] Hq; try abstract discriminate Hq.
- exact (Zpred (log_inf d - (log_sup n)))%Z.
+ exact (Z.pred (log_inf d - (log_sup n)))%Z.
 Defined.
 
 Definition rational_ln (a:Q) (p: 0 < a) : CR :=

--- a/reals/fast/CRpi_fast.v
+++ b/reals/fast/CRpi_fast.v
@@ -81,7 +81,7 @@ Proof.
  intros [x y] [w z].
  unfold f.
  rewrite -> Qred_correct.
- destruct (Z_eq_dec (y*z) (x*w)) as [H|H].
+ destruct (Z.eq_dec (y*z) (x*w)) as [H|H].
   unfold Qmult.
   simpl ((Qnum (x # y) * Qnum (w # z) # Qden (x # y) * Qden (w # z))).
   repeat rewrite <- H.

--- a/reals/fast/CRpi_slow.v
+++ b/reals/fast/CRpi_slow.v
@@ -81,7 +81,7 @@ Proof.
  intros [x y] [w z].
  unfold f.
  rewrite -> Qred_correct.
- destruct (Z_eq_dec (y*z) (x*w)) as [H|H].
+ destruct (Z.eq_dec (y*z) (x*w)) as [H|H].
   unfold Qmult.
   simpl ((Qnum (x # y) * Qnum (w # z) # Qden (x # y) * Qden (w # z))).
   repeat rewrite <- H.

--- a/reals/fast/CRpower.v
+++ b/reals/fast/CRpower.v
@@ -46,7 +46,7 @@ Variable n : N.
 Definition Qpower_N_modulus (c:Qpos) (e:Qpos) : QposInf :=
   match n with 
   | N0 => QposInfinity
-  | Npos p => Qpos2QposInf (e/((p#1)*c^(Zpred p)))
+  | Npos p => Qpos2QposInf (e/((p#1)*c^(Z.pred p)))
   end.
 
 Lemma Qpower_positive_correct : forall p q, (inj_Q IR (Qpower_positive q p)[=]((FId{^}(nat_of_P p)) (inj_Q IR q) I)).
@@ -61,7 +61,7 @@ Proof.
   algebra.
  rewrite nat_of_P_o_P_of_succ_nat_eq_succ.
  rewrite nat_of_P_o_P_of_succ_nat_eq_succ in IHm.
- change (P_of_succ_nat (S m)) with (Psucc (P_of_succ_nat m)).
+ change (P_of_succ_nat (S m)) with (Pos.succ (P_of_succ_nat m)).
  simpl in *.
  rewrite Pplus_one_succ_r.
  stepl (inj_Q IR (Qpower_positive q (P_of_succ_nat m))[*](inj_Q IR q)).
@@ -90,10 +90,10 @@ Proof.
   ring_simplify.
   change (0 < ((2#1)*c)%Qpos).
   apply Qpos_prf.
- apply (fun x => @is_UniformlyContinuousFunction_wd _ _ (fun x : Q_as_MetricSpace => Qpower_positive (QboundAbs c x) p) x (Qscale_modulus ((p#1)*c^(Zpred p))%Qpos)).
+ apply (fun x => @is_UniformlyContinuousFunction_wd _ _ (fun x : Q_as_MetricSpace => Qpower_positive (QboundAbs c x) p) x (Qscale_modulus ((p#1)*c^(Z.pred p))%Qpos)).
    reflexivity.
   intros x.
-  generalize ((p # 1) * c ^ Zpred p)%Qpos.
+  generalize ((p # 1) * c ^ Z.pred p)%Qpos.
   apply Qpos_positive_numerator_rect.
   intros qn qd.
   simpl.
@@ -112,8 +112,8 @@ Proof.
  simpl.
  intros x _ Hx.
  change (AbsIR ((nring (R:=IR) (S m))[*]([1][*]nexp IR m (inj_Q IR x)))[<=]
-   inj_Q IR (((p # 1)[*]((c ^ Zpred p)%Qpos:Q)))).
- stepr ((inj_Q IR ((p # 1))[*](inj_Q IR ((c ^ Zpred p)%Qpos:Q)))); [| now
+   inj_Q IR (((p # 1)[*]((c ^ Z.pred p)%Qpos:Q)))).
+ stepr ((inj_Q IR ((p # 1))[*](inj_Q IR ((c ^ Z.pred p)%Qpos:Q)))); [| now
    (apply eq_symmetric; apply inj_Q_mult)].
  stepl ((nring (R:=IR) (S m)[*]AbsIR ([1][*]nexp IR m (inj_Q IR x)))); [| now apply AbsIR_mult;apply nring_nonneg; auto with *].
  apply mult_resp_leEq_both.
@@ -128,7 +128,7 @@ Proof.
  stepl ([1][*](AbsIR (nexp IR m (inj_Q IR x)))); [| now apply AbsIR_mult; apply less_leEq; apply pos_one].
  stepl (AbsIR (nexp IR m (inj_Q _ x))); [| now apply eq_symmetric; apply one_mult].
  stepl (nexp IR m (AbsIR (inj_Q _ x))); [| now apply eq_symmetric; apply AbsIR_nexp].
- stepr (inj_Q IR (c ^ Zpred p)); [| now apply inj_Q_wd; reflexivity].
+ stepr (inj_Q IR (c ^ Z.pred p)); [| now apply inj_Q_wd; reflexivity].
  rewrite Hm.
  rewrite <- POS_anti_convert.
  rewrite inj_S.

--- a/reals/fast/CRroot.v
+++ b/reals/fast/CRroot.v
@@ -330,12 +330,12 @@ Proof.
   induction d; split; try discriminate; destruct IHd as [A B];
     set (t:=iter_nat (S (Psize d)) positive (fun x : positive => (x * x)%positive) 2%positive) in *.
      rewrite Zpos_xI.
-     apply Zle_trans with (4*d)%Z; auto with *.
+     apply Z.le_trans with (4*d)%Z; auto with *.
      apply (Zmult_le_compat 4 d t t); auto with *.
     change (4%Z) with (2*2)%Z.
     apply (Zmult_le_compat 2 2 t t); auto with *.
    rewrite Zpos_xO.
-   apply Zle_trans with (4*d)%Z; auto with *.
+   apply Z.le_trans with (4*d)%Z; auto with *.
    apply (Zmult_le_compat 4 d t t); auto with *.
   change (4%Z) with (2*2)%Z.
   apply (Zmult_le_compat 2 2 t t); auto with *.
@@ -574,7 +574,7 @@ Fixpoint rational_sqrt_big_bounded (n:nat) a (Ha:1 <= a <= (4 ^ n)%Z) : CR.
  clear rational_sqrt_big_bounded.
  abstract ( destruct H; split;[apply Qle_shift_div_l;[constructor|assumption]|];
    apply Qle_shift_div_r;[constructor|]; rewrite -> Zpower_Qpower in *; try auto with *;
-     change (a <= ((4#1) ^ n) * (4#1)^1); rewrite <- Qpower_plus; try discriminate; change (n+1)%Z with (Zsucc n);
+     change (a <= ((4#1) ^ n) * (4#1)^1); rewrite <- Qpower_plus; try discriminate; change (n+1)%Z with (Z.succ n);
        rewrite <- inj_S; assumption).
 Defined.
 

--- a/reals/fast/CRseries.v
+++ b/reals/fast/CRseries.v
@@ -268,7 +268,7 @@ The stream of postive numbers (as positive).
 We do not use [positives] because [positive] does not form a semiring.
 *)
 CoFixpoint ppositives_help (n:positive) : Stream positive :=
-Cons n (ppositives_help (Psucc n)).
+Cons n (ppositives_help (Pos.succ n)).
 
 Definition ppositives := ppositives_help 1.
 
@@ -372,9 +372,9 @@ Instance Qrecip_positives_zl : Limit Qrecip_positives 0.
  abstract ( apply Qrecip_positives_help_nbz; induction d using Pind;[simpl;auto with *|];
    autorewrite with UnLazyNat in *; rewrite nat_of_P_succ_morphism; assert (H:=lt_O_nat_of_P d);
      destruct (nat_of_P d);[elimtype False;auto with *|]; simpl in *;
-       replace (Pplus_LazyNat 2 (LazifyNat n0)) with (Psucc (Pplus_LazyNat 1 (LazifyNat n0)));[
+       replace (Pplus_LazyNat 2 (LazifyNat n0)) with (Pos.succ (Pplus_LazyNat 1 (LazifyNat n0)));[
          repeat rewrite Zpos_succ_morphism; auto with * |]; clear -n0;
-           change 2%positive with (Psucc 1); generalize 1%positive;
+           change 2%positive with (Pos.succ 1); generalize 1%positive;
              induction n0;intros p;[reflexivity|]; simpl in *; rewrite IHn0; reflexivity ).
 Defined.
 
@@ -390,7 +390,7 @@ Proof.
   simpl.
   split.
    discriminate.
-  change (p <= Psucc p)%Z.
+  change (p <= Pos.succ p)%Z.
   repeat rewrite Zpos_succ_morphism.
   auto with *.
  simpl.
@@ -404,7 +404,7 @@ The stream of factorials as positives.
 Again, we do not use [factorials] because [positive] does not form a semiring.
 *)
 CoFixpoint pfactorials_help (n c:positive) : Stream positive :=
-Cons c (pfactorials_help (Psucc n) (n*c)).
+Cons c (pfactorials_help (Pos.succ n) (n*c)).
 
 Definition pfactorials := pfactorials_help 1 1.
 
@@ -429,7 +429,7 @@ Proof.
  intros a b.
  unfold Str_nth in *.
  simpl.
- assert (X:=IHn (b*a)%positive (Psucc b)).
+ assert (X:=IHn (b*a)%positive (Pos.succ b)).
  clear IHn.
  rewrite nat_of_P_succ_morphism in X.
  rewrite <- plus_n_Sm.

--- a/reals/fast/CRsin.v
+++ b/reals/fast/CRsin.v
@@ -228,7 +228,7 @@ Proof.
    induction (fact (S n')).
     simpl; reflexivity.
    rewrite inj_S.
-   unfold Zsucc.
+   unfold Z.succ.
    simpl in *.
    rewrite -> IHn0.
    rewrite -> injz_plus.

--- a/reals/fast/CRsum.v
+++ b/reals/fast/CRsum.v
@@ -124,18 +124,18 @@ Proof.
      (map (fun x : RegularFunction Q_as_MetricSpace => approximate x e1) l) z3) (approximate a e4 +
        fold_left Qplus (map (fun x : RegularFunction Q_as_MetricSpace => approximate x e2) l) z2)).
   intros H.
-  apply (H (approximate s ((1 # Psucc (P_of_succ_nat n)) * e)%Qpos)
-    ((1 # Psucc (P_of_succ_nat n)) * e)%Qpos ((1 # Psucc (P_of_succ_nat n)) * e +
+  apply (H (approximate s ((1 # Pos.succ (P_of_succ_nat n)) * e)%Qpos)
+    ((1 # Pos.succ (P_of_succ_nat n)) * e)%Qpos ((1 # Pos.succ (P_of_succ_nat n)) * e +
       (1 # P_of_succ_nat n) * ((1 # 2) * e))%Qpos).
     simpl.
     rewrite -> Qplus_0_l.
     apply: regFun_prf.
    ring.
   autorewrite with QposElim.
-  replace LHS with ((1 # Psucc (P_of_succ_nat n)) * (2+n) *e +
+  replace LHS with ((1 # Pos.succ (P_of_succ_nat n)) * (2+n) *e +
     ((1 # P_of_succ_nat n) * (1 + n) * ((1 # 2) * e)  + (1 # 2) * e)) by simpl; ring.
   repeat rewrite -> Qmake_Qdiv.
-  change (Zpos (Psucc (P_of_succ_nat n))) with (Z_of_nat (1+1+n)).
+  change (Zpos (Pos.succ (P_of_succ_nat n))) with (Z_of_nat (1+1+n)).
   change (Zpos (P_of_succ_nat n)) with (Z_of_nat (1+n)).
   repeat rewrite -> inj_plus.
   repeat rewrite -> injz_plus.

--- a/reals/fast/Compress.v
+++ b/reals/fast/Compress.v
@@ -42,13 +42,13 @@ But for speed we simply do division to quickly find a good rational
 approximation.
 *)
 Definition approximateQ (x:Q) (p:positive) :=
-let (n,d) := x in (Zdiv (n*p) d#p).
+let (n,d) := x in (Z.div (n*p) d#p).
 
 Lemma approximateQ_correct : forall x p, ball (1#p) x (approximateQ x p).
 Proof.
  intros [n d] p.
  split; simpl; unfold Qle; simpl.
-  apply Zle_trans with 0%Z.
+  apply Z.le_trans with 0%Z.
    discriminate.
   apply Zmult_le_0_compat; auto with *.
   replace RHS with (n * p - ((n * p / d) * d))%Z by ring.
@@ -75,12 +75,12 @@ Proof.
  unfold Qle in *.
  simpl in *.
  apply Zlt_succ_le.
- unfold Zsucc.
+ unfold Z.succ.
  apply Zmult_gt_0_lt_reg_r with d.
   auto with *.
  replace RHS with (d* (n*p/d) + (Zmod (n*p) d) - (Zmod (n*p) d) + d)%Z by ring.
  rewrite <- (Z_div_mod_eq (n*p) d); try auto with *.
- apply Zle_lt_trans with (n*1*p)%Z.
+ apply Z.le_lt_trans with (n*1*p)%Z.
   replace LHS with (z*d*p)%Z by ring.
   apply Zmult_lt_0_le_compat_r; auto with *.
  apply Zlt_0_minus_lt.
@@ -99,7 +99,7 @@ match e with
 | QposInfinity => approximate x e
 | Qpos2QposInf e =>
  let (n,d) := e: Q in
- match (Zsucc (Zdiv (2*d) n)) with
+ match (Z.succ (Z.div (2*d) n)) with
   Zpos p => approximateQ (approximate x (Qpos2QposInf (1#p))) p
  |_ => approximate x e
  end
@@ -111,14 +111,14 @@ Proof.
  apply Qpos_positive_numerator_rect.
  intros n d.
  simpl.
- case_eq (Zsucc (xO d / n));try (intros; apply: ball_approx_r).
+ case_eq (Z.succ (xO d / n));try (intros; apply: ball_approx_r).
  intros p Hp.
  apply ball_weak_le with (2#p)%Qpos.
   unfold Qle.
   simpl.
   rewrite Zpos_mult_morphism.
   rewrite <- Hp.
-  unfold Zsucc.
+  unfold Z.succ.
   rewrite Zmult_plus_distr_r.
   apply Zle_0_minus_le.
   replace RHS with (n - (xO d - n * (xO d / n)))%Z by ring.

--- a/reals/fast/Integration.v
+++ b/reals/fast/Integration.v
@@ -64,7 +64,7 @@ function to be as balanced as possible.
 First we create a step function with n steps that appoximates the
 identity function, [stepSample]. *)
 
-Lemma oddGluePoint (p:positive) : 0 < Psucc p # xI p /\ Psucc p # xI p < 1.
+Lemma oddGluePoint (p:positive) : 0 < Pos.succ p # xI p /\ Pos.succ p # xI p < 1.
 Proof.
  split; unfold Qlt.
   constructor.
@@ -73,7 +73,7 @@ Proof.
  simpl.
  apply Zlt_left_rev.
  rewrite Zpos_succ_morphism, Zpos_xI.
- unfold Zsucc.
+ unfold Z.succ.
  ring_simplify.
  auto with *.
 Qed.
@@ -84,7 +84,7 @@ Local Open Scope StepQ_scope.
 
 Definition stepSample : positive -> StepQ := positive_rect2
  (fun _ => StepQ)
- (fun p rec1 rec2 => glue (Build_OpenUnit (oddGluePoint p)) (constStepF (Psucc p#xI p:QS) * rec1) ((constStepF (1#(xI p):QS))*(constStepF (Psucc p:QS) + constStepF (p:QS)*rec2)))
+ (fun p rec1 rec2 => glue (Build_OpenUnit (oddGluePoint p)) (constStepF (Pos.succ p#xI p:QS) * rec1) ((constStepF (1#(xI p):QS))*(constStepF (Pos.succ p:QS) + constStepF (p:QS)*rec2)))
  (fun p rec => glue (ou (1#2)) (constStepF (1#2:QS) * rec) (constStepF (1#2:QS) * (constStepF (1:QS) + rec)))
  (constStepF (1#2:QS)).
 
@@ -379,7 +379,7 @@ Proof.
  unfold QposEq.
  induction p using positive_rect2.
    replace (stepSample (xI p))
-     with (glue (Build_OpenUnit (oddGluePoint p)) (constStepF (Psucc p#xI p:QS) * (stepSample (Psucc p))) ((constStepF (1#(xI p):QS))*(constStepF (Psucc p:QS) + constStepF (p:QS)*(stepSample p))))
+     with (glue (Build_OpenUnit (oddGluePoint p)) (constStepF (Pos.succ p#xI p:QS) * (stepSample (Pos.succ p))) ((constStepF (1#(xI p):QS))*(constStepF (Pos.succ p:QS) + constStepF (p:QS)*(stepSample p))))
        by (symmetry;apply: positive_rect2_red1).
    rewrite -> SupDistanceToLinear_glue.
    generalize (@affineCombo_gt (OpenUnitDual (Build_OpenUnit (oddGluePoint p))) 0 1 (pos_one Q_as_COrdField))
@@ -388,35 +388,35 @@ Proof.
    set (C:=(pos_one Q_as_COrdField)) in *.
    transitivity (Qmax (1#2*xI p) (1#2*xI p))%Q;[|apply Qmax_idem].
    apply Qmax_compat.
-    set (LHS := (SupDistanceToLinear (constStepF (X:=QS) (Psucc p # xI p) * stepSample (Psucc p)) A)).
-    transitivity ((Psucc p#xI p)*(SupDistanceToLinear (stepSample (Psucc p)) C))%Q; [|rewrite -> IHp;
-      change ((Psucc p * 1 * (2 * (2* p + 1)) = 2* (Psucc p + p * (2* (Psucc p))))%Z);
+    set (LHS := (SupDistanceToLinear (constStepF (X:=QS) (Pos.succ p # xI p) * stepSample (Pos.succ p)) A)).
+    transitivity ((Pos.succ p#xI p)*(SupDistanceToLinear (stepSample (Pos.succ p)) C))%Q; [|rewrite -> IHp;
+      change ((Pos.succ p * 1 * (2 * (2* p + 1)) = 2* (Pos.succ p + p * (2* (Pos.succ p))))%Z);
         repeat rewrite Zpos_succ_morphism; ring].
-    assert (X:(Psucc p # xI p) *0 < (Psucc p # xI p) *1).
+    assert (X:(Pos.succ p # xI p) *0 < (Pos.succ p # xI p) *1).
      constructor.
     rewrite -> (fun a => SupDistanceToLinear_scale a C X).
     apply SupDistanceToLinear_wd1.
      simpl; ring.
     unfold affineCombo; simpl; ring.
    set (LHS := (SupDistanceToLinear (constStepF (X:=QS) (1 # xI p) *
-     (constStepF (X:=QS) (Psucc p) + constStepF (X:=QS) p * stepSample p)) B)%Q).
+     (constStepF (X:=QS) (Pos.succ p) + constStepF (X:=QS) p * stepSample p)) B)%Q).
    transitivity ((1#xI p)*(p*(SupDistanceToLinear (stepSample (p)) C)))%Q; [|rewrite -> IHp0;
      change ((p * 1 * (2 * (2* p + 1)) = 2* (p + p * (2* p)))%Z); ring].
    assert (X0:(p *0 < p *1)).
     constructor.
    rewrite -> (fun a => SupDistanceToLinear_scale a C X0).
-   assert (X1:(p*0 + Psucc p < p*1 + Psucc p)).
+   assert (X1:(p*0 + Pos.succ p < p*1 + Pos.succ p)).
     apply: plus_resp_less_rht.
     assumption.
    rewrite -> (fun a => SupDistanceToLinear_translate a X0 X1).
-   assert (X2:((1# xI p)*(p*0 + Psucc p) < (1#xI p)*(p*1 + Psucc p))).
+   assert (X2:((1# xI p)*(p*0 + Pos.succ p) < (1#xI p)*(p*1 + Pos.succ p))).
     apply: mult_resp_less_lft;simpl; auto with *.
    rewrite -> (fun a => SupDistanceToLinear_scale a X1 X2).
    apply SupDistanceToLinear_wd1.
     unfold affineCombo; simpl.
     repeat rewrite -> Zpos_succ_morphism; repeat rewrite -> Qmake_Qdiv; repeat rewrite -> Zpos_xI;
       field; auto with *.
-   change (2*(p*1) + 1 = ((p*1*1 + Psucc p*1)*1))%Z.
+   change (2*(p*1) + 1 = ((p*1*1 + Pos.succ p*1)*1))%Z.
    rewrite Zpos_succ_morphism; ring.
   change (1#2*xO p)%Q with ((1#2)*(1#(2*p)))%Q.
   replace (stepSample (xO p)) with (glue (ou (1#2)) (constStepF (1#2:QS) * (stepSample p))

--- a/reals/fast/Interval.v
+++ b/reals/fast/Interval.v
@@ -51,9 +51,9 @@ Let f n (i:Z) := l + ((r-l)*(2*i+1#1))/(2*Z_of_nat n#1).
 (** [UniformPartition] produces a set of n points uniformly distributed
 inside the interval [[l, r]]. *)
 Definition UniformPartition (n:nat) :=
-map (f n) (iterateN Zsucc 0%Z n).
+map (f n) (iterateN Z.succ 0%Z n).
 
-Lemma UniformPartitionZ : forall n z, In z (iterateN Zsucc 0%Z n) <-> (0 <= z < n)%Z.
+Lemma UniformPartitionZ : forall n z, In z (iterateN Z.succ 0%Z n) <-> (0 <= z < n)%Z.
 Proof.
  intros n z.
  change (0 <= z < n)%Z with (0 <= z < 0 + n)%Z.
@@ -64,13 +64,13 @@ Proof.
   apply (Zle_not_lt a a); auto with *.
   rewrite Zplus_comm in H.
   simpl in H.
-  apply Zle_lt_trans with z; auto with *.
+  apply Z.le_lt_trans with z; auto with *.
  split.
   intros [H | H].
    rewrite H.
    rewrite inj_S.
    auto with *.
-  change (In z (iterateN Zsucc (Zsucc a) n)) in H.
+  change (In z (iterateN Z.succ (Z.succ a) n)) in H.
   rewrite -> IHn in H.
   rewrite inj_S.
   auto with *.
@@ -90,10 +90,10 @@ Lemma UniformPartition_inside : forall n x, In x (UniformPartition n) -> l <= x 
 Proof.
  intros n x.
  unfold UniformPartition.
- cut (forall z, In z (iterateN Zsucc 0%Z n) -> (0 <= z < n)%Z).
+ cut (forall z, In z (iterateN Z.succ 0%Z n) -> (0 <= z < n)%Z).
   destruct n.
    contradiction.
-  generalize (iterateN Zsucc 0%Z (S n)).
+  generalize (iterateN Z.succ 0%Z (S n)).
   intros s Hs H.
   induction s.
    contradiction.
@@ -130,7 +130,7 @@ Proof.
  intros z x Hx.
  destruct Hx as [Hx | Hx].
   rewrite <- Hx; split; simpl; auto with *.
- destruct (IHn (Zsucc z) x Hx).
+ destruct (IHn (Z.succ z) x Hx).
  rewrite inj_S.
  auto with *.
 Qed.
@@ -234,7 +234,7 @@ Proof.
  abstract ( split; [apply: in_map; rewrite -> UniformPartitionZ; rewrite inj_S; auto with *|];
    destruct Hx as [_ Hx]; (setoid_replace x with r; [| now apply Qle_antisym; auto with *]); unfold f;
      change (2*S n #1) with (2*S n); change (2*n + 1#1) with ((2*n + 1)%Z:Q); rewrite (inj_S n);
-       unfold Zsucc; do 2 rewrite -> injz_plus; (setoid_replace ((2%positive * n)%Z:Q) with (2*n)
+       unfold Z.succ; do 2 rewrite -> injz_plus; (setoid_replace ((2%positive * n)%Z:Q) with (2*n)
          ; [| now unfold Qeq; simpl; auto with *]);
            (setoid_replace (r - (l + (r - l) * (2 * n + 1%positive) / (2 * (n + 1%positive))))
              with (((r-l) / (2 * (n + 1%positive)))); [| now simpl; field; unfold Qeq; simpl; auto with *]);
@@ -320,7 +320,7 @@ Proof.
   unfold Qle.
   simpl.
   ring_simplify.
-  eapply Zle_trans;[|apply Zle_max_r].
+  eapply Z.le_trans;[|apply Z.le_max_r].
   rewrite <- Z_to_nat_correct.
   auto with *.
  autorewrite with QposElim.
@@ -477,7 +477,7 @@ Proof.
    unfold Qle.
    simpl.
    ring_simplify.
-   eapply Zle_trans;[|apply Zle_max_r].
+   eapply Z.le_trans;[|apply Z.le_max_r].
    rewrite <- Z_to_nat_correct.
    auto with *.
   right.

--- a/reals/fast/LazyNat.v
+++ b/reals/fast/LazyNat.v
@@ -108,5 +108,5 @@ Hint Rewrite <- LazifyNat_of_P LazifyPmult_LazyNat LazifyPlus LazifyPred : UnLaz
 Fixpoint Pplus_LazyNat (p:positive)(n:LazyNat) {struct n} : positive :=
 match n with
 | LazyO => p
-| (LazyS n') => (Pplus_LazyNat (Psucc p) (n' tt))
+| (LazyS n') => (Pplus_LazyNat (Pos.succ p) (n' tt))
 end.

--- a/reals/fast/PowerBound.v
+++ b/reals/fast/PowerBound.v
@@ -41,20 +41,20 @@ Proof.
  rewrite Zpos_mult_morphism.
  apply Zmult_le_compat; auto with *.
  clear - n.
- apply Zle_trans with (two_p (Zsucc (log_inf n))-1)%Z.
+ apply Z.le_trans with (two_p (Z.succ (log_inf n))-1)%Z.
   rewrite <- Zle_plus_swap.
   apply Zlt_succ_le.
-  change (Zpos n+1) with (Zsucc (Zpos n)).
+  change (Zpos n+1) with (Z.succ (Zpos n)).
   apply Zsucc_lt_compat.
   destruct (log_inf_correct2 n).
   assumption.
- replace (Zsucc (log_inf n)) with (Z_of_nat (Psize n)).
-  apply Zle_trans with (two_p (Z_of_nat (Psize n))).
+ replace (Z.succ (log_inf n)) with (Z_of_nat (Psize n)).
+  apply Z.le_trans with (two_p (Z_of_nat (Psize n))).
    auto with *.
   induction (Psize n); auto with *.
   rewrite inj_S.
   simpl.
-  unfold Zsucc.
+  unfold Z.succ.
   rewrite two_p_is_exp; auto with *.
   change (two_p 1) with 2.
   rewrite Zpower_exp; auto with *.
@@ -77,9 +77,9 @@ Proof.
  simpl.
  ring_simplify.
  induction n.
-  apply Zle_refl.
+  apply Z.le_refl.
  rewrite inj_S.
- unfold Zsucc.
+ unfold Z.succ.
  do 2 (rewrite Zpower_exp;try auto with * ).
  ring_simplify.
  apply Zmult_le_compat; try discriminate.
@@ -88,7 +88,7 @@ Proof.
  induction n.
   discriminate.
  rewrite inj_S.
- unfold Zsucc.
+ unfold Z.succ.
  rewrite Zpower_exp;try auto with *.
 Qed.
 
@@ -105,7 +105,7 @@ Proof.
    induction (Psize d).
     constructor.
    rewrite inj_S.
-   unfold Zsucc.
+   unfold Z.succ.
    rewrite -> Qpower_plus;[|discriminate].
    apply: mult_resp_pos;[assumption|constructor].
   rewrite <- Zpower_Qpower; try auto with *.

--- a/reals/fast/RasterQ.v
+++ b/reals/fast/RasterQ.v
@@ -132,22 +132,22 @@ Proof.
    simpl.
    left; reflexivity.
   rewrite inj_S.
-  cut (In ((f0 (Zsucc j)), (f1 0%Z)) (map (fun x : Q => (x, (f1 0%Z)))
-    (map (@fst _ _) (filter (@snd _ _) (combine (map f0 (iterateN Zsucc 1%Z n)) a0))))).
+  cut (In ((f0 (Z.succ j)), (f1 0%Z)) (map (fun x : Q => (x, (f1 0%Z)))
+    (map (@fst _ _) (filter (@snd _ _) (combine (map f0 (iterateN Z.succ 1%Z n)) a0))))).
    intros L.
    destruct a; try right; auto.
-  change (1%Z) with (Zsucc 0).
+  change (1%Z) with (Z.succ 0).
   rewrite iterateN_f.
-  rewrite (map_map Zsucc f0).
-  apply (IHa (fun x:Z => f0 (Zsucc x))).
+  rewrite (map_map Z.succ f0).
+  apply (IHa (fun x:Z => f0 (Z.succ x))).
   apply H.
  rewrite inj_S.
- set (f1':= fun (x:Z) =>(f1 (Zsucc x))).
+ set (f1':= fun (x:Z) =>(f1 (Z.succ x))).
  fold (f1' i).
  simpl.
  apply in_or_app.
  right.
- change (1%Z) with (Zsucc 0).
+ change (1%Z) with (Z.succ 0).
  rewrite iterateN_f.
  rewrite map_map.
  fold f1'.
@@ -187,21 +187,21 @@ Proof.
     inversion_clear H0.
     auto.
    edestruct IHa as [z Hz].
-    change 1%Z with (Zsucc 0) in H0.
+    change 1%Z with (Z.succ 0) in H0.
     rewrite iterateN_f in H0.
-    rewrite (map_map Zsucc f0) in H0.
+    rewrite (map_map Z.succ f0) in H0.
     apply H0.
    exists (S z).
    rewrite inj_S; auto.
   edestruct IHa as [z Hz].
    simpl in H0.
-   change 1%Z with (Zsucc 0) in H0.
+   change 1%Z with (Z.succ 0) in H0.
    rewrite iterateN_f in H0.
-   rewrite (map_map Zsucc f0) in H0.
+   rewrite (map_map Z.succ f0) in H0.
    apply H0.
   exists (S z).
   rewrite inj_S; auto.
- change 1%Z with (Zsucc 0) in H0.
+ change 1%Z with (Z.succ 0) in H0.
  rewrite iterateN_f in H0.
  rewrite (map_map) in H0.
  edestruct IHbitmap as [z Hz].

--- a/reals/fast/RasterizeQ.v
+++ b/reals/fast/RasterizeQ.v
@@ -46,8 +46,8 @@ is chosen that contains all the points, so that this doesn't matter.
 
 [Rasterize Point] adds a single point [p] into a raster. *)
 Definition RasterizePoint n m (bm:raster n m) (t l b r:Q) (p:Q*Q) : raster n m :=
-let i := min (pred n) (Z_to_nat (Zle_max_l 0 (rasterize1 l r n (fst p)))) in
-let j := min (pred m) (Z_to_nat (Zle_max_l 0 (rasterize1 b t m (snd p)))) in
+let i := min (pred n) (Z_to_nat (Z.le_max_l 0 (rasterize1 l r n (fst p)))) in
+let j := min (pred m) (Z_to_nat (Z.le_max_l 0 (rasterize1 b t m (snd p)))) in
 setRaster bm true (pred m - j) i.
 (* begin hide *)
 Add Parametric Morphism n m bm : (@RasterizePoint n m bm) with signature Qeq ==> Qeq ==> Qeq ==> Qeq ==> (@eq _) ==> (@eq _) as RasterizePoint_wd.
@@ -72,10 +72,10 @@ Lemma RasterizePoint_carry : forall t l b r n m (bm:raster n m) p i j,
 Proof.
  intros t l b r m n bm p i j H.
  unfold RasterizePoint.
- set (j0:=(min (pred m) (Z_to_nat (z:=Zmax 0 (rasterize1 l r m (fst p)))
-   (Zle_max_l 0 (rasterize1 l r m (fst p)))))).
+ set (j0:=(min (pred m) (Z_to_nat (z:=Z.max 0 (rasterize1 l r m (fst p)))
+   (Z.le_max_l 0 (rasterize1 l r m (fst p)))))).
  set (i0:=(pred n - min (pred n)
-   (Z_to_nat (z:=Zmax 0 (rasterize1 b t n (snd p))) (Zle_max_l 0 (rasterize1 b t n (snd p)))))%nat).
+   (Z_to_nat (z:=Z.max 0 (rasterize1 b t n (snd p))) (Z.le_max_l 0 (rasterize1 b t n (snd p)))))%nat).
  destruct (le_lt_dec n i0).
   rewrite setRaster_overflow; auto.
  destruct (le_lt_dec m j0).
@@ -115,13 +115,13 @@ Lemma rasterization_error : forall l (w:Qpos) n x,
 (l <= x <= l + w) ->
 ball (m:=Q_as_MetricSpace) ((1 #2*P_of_succ_nat n) * w) (C l (l + w) (S n) (min n
              (Z_to_nat
-                (Zle_max_l 0 (rasterize1 l (l+w) (S n) x))))) x.
+                (Z.le_max_l 0 (rasterize1 l (l+w) (S n) x))))) x.
 Proof.
  clear - C.
  intros l w n x H0.
  destruct (Qlt_le_dec x (l+w)).
-  replace (Z_of_nat (min n (Z_to_nat (z:=Zmax 0 (rasterize1 l (l + w) (S n) x))
-    (Zle_max_l 0 (rasterize1 l (l + w) (S n) x))))) with (rasterize1 l (l + w) (S n) x).
+  replace (Z_of_nat (min n (Z_to_nat (z:=Z.max 0 (rasterize1 l (l + w) (S n) x))
+    (Z.le_max_l 0 (rasterize1 l (l + w) (S n) x))))) with (rasterize1 l (l + w) (S n) x).
    apply ball_sym.
    simpl.
    rewrite -> Qball_Qabs.
@@ -140,7 +140,7 @@ Proof.
   rewrite inj_min.
   rewrite <- Z_to_nat_correct.
   rewrite Zmax_right.
-   apply Zmin_case_strong.
+   apply Z.min_case_strong.
     intros H.
     apply Zle_antisym; auto.
     apply Zlt_succ_le.
@@ -154,8 +154,8 @@ Proof.
   apply rasterize1_boundL; auto.
   apply Qle_trans with x; auto.
  simpl.
- replace (min n (Z_to_nat (z:=Zmax 0 (rasterize1 l (l + w) (S n) x))
-   (Zle_max_l 0 (rasterize1 l (l + w) (S n) x)))) with n.
+ replace (min n (Z_to_nat (z:=Z.max 0 (rasterize1 l (l + w) (S n) x))
+   (Z.le_max_l 0 (rasterize1 l (l + w) (S n) x)))) with n.
   setoid_replace x with (l + w).
    apply: ball_sym.
    rewrite ->  Qball_Qabs.
@@ -166,7 +166,7 @@ Proof.
    change (2*S n #1) with (2*S n).
    change (2*n + 1#1) with ((2*n + 1)%Z:Q).
    rewrite (inj_S n).
-   unfold Zsucc.
+   unfold Z.succ.
    do 2 rewrite -> injz_plus.
    setoid_replace ((2%positive * n)%Z:Q) with (2*n); [| now (unfold Qeq; simpl; auto with * )].
    setoid_replace (l + w - (l + (l + w - l) * (2 * n + 1%positive) / (2 * (n + 1%positive))))
@@ -181,7 +181,7 @@ Proof.
  apply min_l.
  apply surj_le.
  rewrite <- Z_to_nat_correct.
- eapply Zle_trans;[|apply Zle_max_r].
+ eapply Z.le_trans;[|apply Z.le_max_r].
  unfold rasterize1.
  rewrite <- (Qfloor_Z n).
  apply Qfloor_resp_le.
@@ -212,7 +212,7 @@ Proof.
  unfold Zminus.
  rewrite -> injz_plus.
  rewrite (inj_S m).
- unfold Zsucc.
+ unfold Z.succ.
  rewrite -> injz_plus.
  change ((-j)%Z:Q) with (-j).
  field.
@@ -267,8 +267,8 @@ Proof.
   unfold RasterizePoint at 1.
   simpl (pred (S n)).
   simpl (pred (S m)).
-  set (i:=min n (Z_to_nat (Zle_max_l 0 (rasterize1 l r (S n) (fst a))))).
-  set (j:=min m (Z_to_nat (Zle_max_l 0 (rasterize1 b t (S m) (snd a))))).
+  set (i:=min n (Z_to_nat (Z.le_max_l 0 (rasterize1 l r (S n) (fst a))))).
+  set (j:=min m (Z_to_nat (Z.le_max_l 0 (rasterize1 b t (S m) (snd a))))).
   cbv zeta.
   apply existsWeaken.
   exists (C l r (S n) i,C t b (S m) (m -j)%nat).
@@ -363,10 +363,10 @@ Proof.
  simpl (fold_right (fun (y : Q * Q) (x : raster (S n) (S m)) =>
    RasterizePoint x t l b r y) (emptyRaster (S n) (S m)) (a :: l0)) in Hij.
  unfold RasterizePoint at 1 in Hij.
- set (i0:=min (pred (S n)) (Z_to_nat (z:=Zmax 0 (rasterize1 l r (S n) (fst a)))
-   (Zle_max_l 0 (rasterize1 l r (S n) (fst a))))) in *.
- set (j0:=min (pred (S m)) (Z_to_nat (z:=Zmax 0 (rasterize1 b t (S m) (snd a)))
-   (Zle_max_l 0 (rasterize1 b t (S m) (snd a))))) in *.
+ set (i0:=min (pred (S n)) (Z_to_nat (z:=Z.max 0 (rasterize1 l r (S n) (fst a)))
+   (Z.le_max_l 0 (rasterize1 l r (S n) (fst a))))) in *.
+ set (j0:=min (pred (S m)) (Z_to_nat (z:=Z.max 0 (rasterize1 b t (S m) (snd a)))
+   (Z.le_max_l 0 (rasterize1 b t (S m) (snd a))))) in *.
  cbv zeta in Hij.
  assert (L:((i=i0)/\(j=m-j0) \/ ((j<>(m-j0)) \/ (i<>i0)))%nat) by omega.
  destruct L as [[Hi Hj] | L].

--- a/reals/faster/ARAlternatingSum.v
+++ b/reals/faster/ARAlternatingSum.v
@@ -269,7 +269,7 @@ Proof.
   simpl.
   rewrite rings.preserves_plus, rings.preserves_negate.
   rewrite Qminus'_correct. unfold Qminus.
-  setoid_replace (Psucc l * 2 ^ k)%Qpos with (2 ^ k + l * 2 ^ k)%Qpos.
+  setoid_replace (Pos.succ l * 2 ^ k)%Qpos with (2 ^ k + l * 2 ^ k)%Qpos.
    apply Qball_plus.
     generalize d. intros d'. destruct d' as [? ? ? E]. (* ugly *)
     rewrite E.

--- a/reals/faster/ARbigD.v
+++ b/reals/faster/ARbigD.v
@@ -43,7 +43,7 @@ Program Instance bigD_div: AppDiv bigD := λ x y k,
   BigZ.div (BigZ.shiftl (mant x) (-('k - 1) + expo x - expo y)) (mant y) ▼ ('k - 1).
 
 Lemma Qdiv_bounded_Zdiv (x y : Z) :
-  'Zdiv x y ≤ ('x / 'y : Q) < 'Zdiv x y + 1.
+  'Z.div x y ≤ ('x / 'y : Q) < 'Z.div x y + 1.
 Proof.
   rewrite Qround.Zdiv_Qdiv.
   split.
@@ -66,7 +66,7 @@ Proof.
   rewrite Z.shiftl_div_pow2 by trivial.
   assert (('x * 2 ^ n : Q) = 'x / 'Zpower 2 (-n)).
    rewrite Qpower.Zpower_Qpower.
-    rewrite <-Qpower.Qpower_opp, Zopp_involutive.
+    rewrite <-Qpower.Qpower_opp, Z.opp_involutive.
     reflexivity.
    now apply rings.flip_nonpos_negate in En.
   split.
@@ -89,7 +89,7 @@ Proof.
    transitivity ('xm / 'ym * 2 ^ xe / 2 ^ ye * (2 ^ (k - 1) / 2 ^ (k - 1)) : Q); [| ring].
    rewrite dec_recip_inverse by solve_propholds. ring.
   assert (∀ xm xe ym ye : Z, 
-      'Zdiv (Z.shiftl xm (-(k - 1) + xe - ye)) ym * 2 ^ (k - 1) - 2 ^ k  ≤ ('xm * 2 ^ xe) / ('ym * 2 ^ ye : Q)) as Pleft.
+      'Z.div (Z.shiftl xm (-(k - 1) + xe - ye)) ym * 2 ^ (k - 1) - 2 ^ k  ≤ ('xm * 2 ^ xe) / ('ym * 2 ^ ye : Q)) as Pleft.
    clear x y.
    assert (∀ z : Q, z * 2 ^ (k - 1) - 2 ^ k = ((z - 1) - 1) * 2 ^ (k - 1)) as E2.
     intros.
@@ -127,7 +127,7 @@ Proof.
     now apply orders.lt_le.
    now apply orders.lt_le, Qpow_bounded_Zshiftl.
   assert (∀ xm xe ym ye : Z, 
-      ('xm * 2 ^ xe) / ('ym * 2 ^ ye : Q) ≤ '(Zdiv (Z.shiftl xm (-(k - 1) + xe - ye)) ym) * 2 ^ (k - 1) + 2 ^ k) as Pright.
+      ('xm * 2 ^ xe) / ('ym * 2 ^ ye : Q) ≤ '(Z.div (Z.shiftl xm (-(k - 1) + xe - ye)) ym) * 2 ^ (k - 1) + 2 ^ k) as Pright.
    clear x y.
    assert (∀ z : Q, z * 2 ^ (k - 1) + 2 ^ k = ((z + 1) + 1) * 2 ^ (k - 1)) as E2.
     intros.

--- a/reals/faster/ARexp.v
+++ b/reals/faster/ARexp.v
@@ -103,7 +103,7 @@ Context {a : AQ} (Pa : a ≤ 0).
 Definition AQexp_neg_bound : nat := 
   match decide_rel (≤) (-1) a with
   | left _ => 0
-  | right _ => Zabs_nat (1 + Qdlog2 (-'a))
+  | right _ => Z.abs_nat (1 + Qdlog2 (-'a))
   end.
 
 Lemma AQexp_neg_bound_correct : -2 ^ AQexp_neg_bound ≤ a ≤ 0.
@@ -157,13 +157,13 @@ Proof. apply AQexp_neg_bounded_correct. Qed.
 
 (* We could use a number closer to 1/exp 1, for example 11 $ -5, but in practice this seems
     to make it slower. *)
-Program Definition AQexp_inv_pos_bound : AQ₊ := ((1 ≪ (-2)) ^ Zabs_N (Qfloor ('a)))↾_.
+Program Definition AQexp_inv_pos_bound : AQ₊ := ((1 ≪ (-2)) ^ Z.abs_N (Qfloor ('a)))↾_.
 Next Obligation. solve_propholds. Qed.
 
 Lemma AQexp_inv_pos_bound_correct :
   '(cast (AQ₊) Q AQexp_inv_pos_bound) ≤ rational_exp ('a). 
 Proof.
-  change (cast Q CR (cast AQ Q ((1 ≪ (-2)) ^ Zabs_N (Qfloor ('a)))) ≤ rational_exp ('a)).
+  change (cast Q CR (cast AQ Q ((1 ≪ (-2)) ^ Z.abs_N (Qfloor ('a)))) ≤ rational_exp ('a)).
   rewrite preserves_nat_pow.
   rewrite aq_shift_opp_2.
   rewrite rings.preserves_1, rings.mult_1_l.

--- a/reals/faster/ARsin.v
+++ b/reals/faster/ARsin.v
@@ -141,7 +141,7 @@ Qed.
 Section sin_pos.
 Context {a : AQ} (Pa : 0 ≤ a).
 
-Definition AQsin_pos_bound : nat := Zabs_nat (1 + Qdlog 3 ('a)).
+Definition AQsin_pos_bound : nat := Z.abs_nat (1 + Qdlog 3 ('a)).
 
 Lemma AQsin_pos_bound_correct : 0 ≤ a ≤ 3 ^ AQsin_pos_bound.
 Proof.

--- a/stdlib_omissions/P.v
+++ b/stdlib_omissions/P.v
@@ -37,17 +37,17 @@ Qed.
 
 Hint Immediate nat_of_P_nonzero.
 
-Lemma Plt_lt (p q: positive): Plt p q <-> (nat_of_P p < nat_of_P q).
+Lemma Plt_lt (p q: positive): Pos.lt p q <-> (nat_of_P p < nat_of_P q).
 Proof.
  split. apply nat_of_P_lt_Lt_compare_morphism.
  apply nat_of_P_lt_Lt_compare_complement_morphism.
 Qed.
 
-Lemma Ple_le (p q: positive): Ple p q <-> le (nat_of_P p) (nat_of_P q).
+Lemma Ple_le (p q: positive): Pos.le p q <-> le (nat_of_P p) (nat_of_P q).
 Proof.
- rewrite Ple_lteq, Plt_lt, Lt.le_lt_or_eq_iff, nat_of_P_inj_iff.
+ rewrite Pos.le_lteq, Plt_lt, Lt.le_lt_or_eq_iff, nat_of_P_inj_iff.
  reflexivity.
 Qed.
 
-Lemma Ple_refl p: Ple p p.
-Proof. intros. apply Ple_lteq. firstorder. Qed.
+Lemma Ple_refl p: Pos.le p p.
+Proof. intros. apply Pos.le_lteq. firstorder. Qed.

--- a/stdlib_omissions/Q.v
+++ b/stdlib_omissions/Q.v
@@ -39,7 +39,7 @@ Proof.
  do 2 rewrite Zmult_1_r. reflexivity.
 Qed.
 
-Lemma Zsucc_Qplus (z: Z): inject_Z (Zsucc z) = inject_Z z + 1.
+Lemma Zsucc_Qplus (z: Z): inject_Z (Z.succ z) = inject_Z z + 1.
 Proof. apply Zplus_Qplus. Qed.
 
 Lemma Zmult_Qmult (x y: Z): inject_Z (x * y) = inject_Z x * inject_Z y.
@@ -71,7 +71,7 @@ Proof with simpl; try reflexivity.
    rewrite Zmult_0_r...
   rewrite Zmult_1_r...
  rewrite <- Zopp_eq_mult_neg_1.
- rewrite <- (Zopp_involutive (Zpos p)).
+ rewrite <- (Z.opp_involutive (Zpos p)).
  rewrite Zdiv_opp_opp...
 Qed.
 

--- a/stdlib_omissions/Z.v
+++ b/stdlib_omissions/Z.v
@@ -98,7 +98,7 @@ intro A; destruct z as [| p | p]; trivial.
 unfold Z.le in A; now contradict A.
 Qed.
 
-Lemma Ple_Zle (p q: positive): Ple p q <-> (Zpos p <= Zpos q).
+Lemma Ple_Zle (p q: positive): Pos.le p q <-> (Zpos p <= Zpos q).
 Proof.
  rewrite Ple_le, inj_le_iff.
  do 2 rewrite <- Zpos_eq_Z_of_nat_o_nat_of_P.

--- a/transc/Pi.v
+++ b/transc/Pi.v
@@ -1016,12 +1016,12 @@ Lemma Sin_periodic_Z : forall (x : IR) z, Sin (x[+]zring z[*](Two[*]Pi)) [=] Sin
 Proof.
  intros x z; revert x; induction z using Zind; intros x.
    rational.
-  unfold Zsucc.
+  unfold Z.succ.
   rewrite -> zring_plus.
   rstepl (Sin (x[+]zring z[*](Two[*]Pi)[+]Two[*]Pi)).
   rewrite -> Sin_periodic.
   auto.
- unfold Zpred.
+ unfold Z.pred.
  rewrite -> zring_plus.
  rstepl (Sin (x[-]Two[*]Pi[+]zring z[*](Two[*]Pi))).
  rstepr (Sin (x[-]Two[*]Pi[+]Two[*]Pi)).
@@ -1033,12 +1033,12 @@ Lemma Cos_periodic_Z : forall (x : IR) z, Cos (x[+]zring z[*](Two[*]Pi)) [=] Cos
 Proof.
  intros x z; revert x; induction z using Zind; intros x.
    rational.
-  unfold Zsucc.
+  unfold Z.succ.
   rewrite -> zring_plus.
   rstepl (Cos (x[+]zring z[*](Two[*]Pi)[+]Two[*]Pi)).
   rewrite -> Cos_periodic.
   auto.
- unfold Zpred.
+ unfold Z.pred.
  rewrite -> zring_plus.
  rstepl (Cos (x[-]Two[*]Pi[+]zring z[*](Two[*]Pi))).
  rstepr (Cos (x[-]Two[*]Pi[+]Two[*]Pi)).

--- a/util/Extract.v
+++ b/util/Extract.v
@@ -55,28 +55,28 @@ Extract Inductive Z => Integer [ "0" "" "negate" ]
 "(\f0 fp fn z -> if z == 0 then f0 () else if z > 0 then fp z else fn (negate z))".
 
 Extract Inlined Constant Pplus => "(+)".
-Extract Inlined Constant Psucc => "succ".
-Extract Inlined Constant Ppred => "pred".
+Extract Inlined Constant Pos.succ => "succ".
+Extract Inlined Constant Pos.pred => "pred".
 Extract Inlined Constant Pminus => "\n m -> max 1 (n - m)".
 Extract Inlined Constant Pmult => "(*)".
-Extract Inlined Constant Pmin => "min".
-Extract Inlined Constant Pmax => "max".
+Extract Inlined Constant Pos.min => "min".
+Extract Inlined Constant Pos.max => "max".
 (* Probably a change in the way Coq handles numbers, ask PL.
 Extract Inlined Constant Pcompare => "compare".*)
 Extract Inlined Constant positive_eq_dec => "(==)".
 Extraction Inline positive_rec.
 
 Extract Inlined Constant Zplus => "(+)".
-Extract Inlined Constant Zsucc => "succ".
-Extract Inlined Constant Zpred => "pred".
+Extract Inlined Constant Z.succ => "succ".
+Extract Inlined Constant Z.pred => "pred".
 Extract Inlined Constant Zminus => "(-)".
 Extract Inlined Constant Zmult => "(*)".
-Extract Inlined Constant Zopp => "negate".
-Extract Inlined Constant Zabs => "abs".
-Extract Inlined Constant Zmin => "min".
-Extract Inlined Constant Zmax => "max".
-Extract Inlined Constant Zcompare => "compare".
-Extract Inlined Constant Z_eq_dec => "(==)".
+Extract Inlined Constant Z.opp => "negate".
+Extract Inlined Constant Z.abs => "abs".
+Extract Inlined Constant Z.min => "min".
+Extract Inlined Constant Z.max => "max".
+Extract Inlined Constant Z.compare => "compare".
+Extract Inlined Constant Z.eq_dec => "(==)".
 Extraction Inline Z_rec.
 Extract Inlined Constant Z_of_nat => "id".
 

--- a/util/Qdlog.v
+++ b/util/Qdlog.v
@@ -37,11 +37,11 @@ Proof.
      apply (order_preserving _).
      now apply Z.log2_up_spec.
     now apply Z.log2_up_nonneg.
-   mc_setoid_replace (1 - Z.log2_up (Qceiling (/x))) with (-Zpred (Z.log2_up (Qceiling (/x)))).
+   mc_setoid_replace (1 - Z.log2_up (Qceiling (/x))) with (-Z.pred (Z.log2_up (Qceiling (/x)))).
     rewrite int_pow_negate.
     apply dec_fields.flip_lt_dec_recip_r.
      solve_propholds.
-    apply orders.le_lt_trans with ('Zpred (Qceiling (/x))).
+    apply orders.le_lt_trans with ('Z.pred (Qceiling (/x))).
      change 2 with ('(2 : Z)). rewrite <-Qpower.Zpower_Qpower.
       apply (order_preserving _).
       now apply Z.lt_le_pred, Z.log2_up_spec.
@@ -60,14 +60,14 @@ Proof.
      now apply Z.log2_spec, Qfloor_pos. 
     now apply Z.log2_nonneg.
    now apply Qfloor_le.
-  apply orders.lt_le_trans with ('Zsucc (Qfloor x)).
+  apply orders.lt_le_trans with ('Z.succ (Qfloor x)).
    rewrite <-Z.add_1_r.
    now apply Qlt_floor.
   rewrite Z.add_1_l.
   change 2 with ('(2 : Z)).
   rewrite <-Qpower.Zpower_Qpower.
    apply (order_preserving _).
-   now apply Zle_succ_l, Z.log2_spec, Qfloor_pos.
+   now apply Z.le_succ_l, Z.log2_spec, Qfloor_pos.
   now apply Zle_le_succ, Z.log2_nonneg.
 Qed.
 
@@ -163,7 +163,7 @@ Fixpoint Qdlog_bounded (b : nat) (n : Z) (x : Q) : Z :=
     else 1 + Qdlog_bounded c n (x / ('n:Q))
   end.
 
-Definition Qdlog (n : Z) (x : Q) : Z := Qdlog_bounded (Zabs_nat (Qdlog2 x)) n x.
+Definition Qdlog (n : Z) (x : Q) : Z := Qdlog_bounded (Z.abs_nat (Qdlog2 x)) n x.
 
 Lemma Qdlog_bounded_nonneg (b : nat) (n : Z) (x : Q) :
   0 ≤ Qdlog_bounded b n x.
@@ -177,7 +177,7 @@ Lemma Qdlog2_le1 (n : Z) (x : Q) :
   2 ≤ n → x ≤ 1 → Qdlog n x = 0.
 Proof.
   intros En Ex. unfold Qdlog.
-  generalize (Zabs_nat (Qdlog2 x)). 
+  generalize (Z.abs_nat (Qdlog2 x)). 
   intros b. induction b; simpl; [reflexivity |].
   case (decide_rel _); intros E; [reflexivity |].
   destruct E.
@@ -252,11 +252,11 @@ Lemma Qdlog_spec (n : Z) (x : Q) :
   2 ≤ n → 1 ≤ x → 'n ^ Qdlog n x ≤ x ∧ x < 'n ^ (1 + Qdlog n x).
 Proof. 
   intros. apply Qdlog_spec_bounded; trivial.
-  rewrite inj_Zabs_nat, Zabs_eq; [reflexivity |].
+  rewrite inj_Zabs_nat, Z.abs_eq; [reflexivity |].
   now apply Qdlog2_nonneg.
 Qed.
 
-Definition Qdlog4 (x : Q) : Z := Zdiv (Qdlog2 x) 2.
+Definition Qdlog4 (x : Q) : Z := Z.div (Qdlog2 x) 2.
 
 Instance: Proper (=) Qdlog4.
 Proof. unfold Qdlog4. intros ? ? E. now rewrite E. Qed.
@@ -278,7 +278,7 @@ Proof.
   apply nat_int.le_iff_lt_plus_1.
   rewrite commutativity.
   apply (strictly_order_preserving (+1)).
-  change (1 + (Qdlog2 x / 2)%Z) with (1 + Zdiv (Qdlog2 x) 2)%Z.
-  rewrite (Z.add_1_l (Zdiv (Qdlog2 x) 2)).
+  change (1 + (Qdlog2 x / 2)%Z) with (1 + Z.div (Qdlog2 x) 2)%Z.
+  rewrite (Z.add_1_l (Z.div (Qdlog2 x) 2)).
   now apply Z.mul_succ_div_gt.
 Qed.


### PR DESCRIPTION
The compatibility notations that will be soon deprecated are replaced by their standard names. The changes are rather simple, but particularly tedious. The changes were mostly performed by a script analyzing the warnings produced by Coq.

See https://github.com/coq/coq/issues/8383 for more information.