### PR TITLE
Make trivial instances explicit

### DIFF
--- a/logic/CornBasics.v
+++ b/logic/CornBasics.v
@@ -74,7 +74,7 @@ Global Set Automatic Coercions Import.
 
 Global Set Automatic Introduction.
 
-Instance: @DefaultRelation nat eq | 2.
+Instance: @DefaultRelation nat eq | 2 := {}.
 
 (**
 * Basics

--- a/metric2/Classified.v
+++ b/metric2/Classified.v
@@ -104,7 +104,7 @@ Local Existing Instance mspc_setoid.
 
 End MetricSpaceClass.
 
-Instance: Params (@mspc_ball) 2.
+Instance: Params (@mspc_ball) 2 := {}.
 
 Hint Resolve Qlt_le_weak Qplus_lt_le_0_compat.
   (* Todo: Move. *)
@@ -1164,9 +1164,9 @@ End curried_uc.
 
 Class HasLambda `{X: Type} (x: X): Prop.
 
-Instance lambda_has_lambda `(f: A → B): HasLambda (λ x, f x).
-Instance application_has_lambda_left: ∀ `(f: A → B) (x: A), HasLambda f → HasLambda (f x).
-Instance application_has_lambda_right: ∀ `(f: A → B) (x: A), HasLambda x → HasLambda (f x).
+Instance lambda_has_lambda `(f: A → B): HasLambda (λ x, f x) := {}.
+Instance application_has_lambda_left: ∀ `(f: A → B) (x: A), HasLambda f → HasLambda (f x) := {}.
+Instance application_has_lambda_right: ∀ `(f: A → B) (x: A), HasLambda x → HasLambda (f x) := {}.
 
 
 Section lambda_uc.

--- a/model/setoids/CRsetoid.v
+++ b/model/setoids/CRsetoid.v
@@ -24,7 +24,7 @@ Require Export CoRN.model.metric2.CRmetric.
 Require Export CoRN.algebra.CSetoids.
 Require Import CoRN.tactics.CornTac.
 
-Instance CR_default : @DefaultRelation CR (@st_eq CR) | 2.
+Instance CR_default : @DefaultRelation CR (@st_eq CR) | 2 := {}.
 
 (**
 ** Example of a setoid: [CR]

--- a/model/structures/Qpossec.v
+++ b/model/structures/Qpossec.v
@@ -182,7 +182,7 @@ Hint Rewrite QposAsmkQpos QposAsQposMake : QposElim.
 *** Equality
 *)
 Definition QposEq (a b:Qpos) := Qeq a b.
-Instance Qpos_default : @DefaultRelation Qpos QposEq | 2.
+Instance Qpos_default : @DefaultRelation Qpos QposEq | 2 := {}.
 
 Add Relation Qpos QposEq
  reflexivity proved by (fun (x:Qpos) => Qeq_refl x)

--- a/model/structures/Qsec.v
+++ b/model/structures/Qsec.v
@@ -63,7 +63,7 @@ b,n\rangle$#&lang;a,m&rang;=&lang;b,n&rang;# iff [an [=] bm]. We
 also define apartness, order, addition, multiplication, opposite,
 inverse an de constants 0 and 1.  *)
 
-Instance Q_default : @DefaultRelation Q Qeq | 2.
+Instance Q_default : @DefaultRelation Q Qeq | 2 := {}.
 
 Definition Qap (x y : Q) := ~(Qeq x y).
 Infix "/=" := Qap (no associativity, at level 70) : Q_scope.

--- a/model/structures/StepQsec.v
+++ b/model/structures/StepQsec.v
@@ -81,7 +81,7 @@ Defined.
 End QS.
 
 Notation "'StepQ'" := (StepF QS) : StepQ_scope.
-Instance StepQ_default : @DefaultRelation (StepF QS) (@StepF_eq QS) | 2.
+Instance StepQ_default : @DefaultRelation (StepF QS) (@StepF_eq QS) | 2 := {}.
 
 Delimit Scope StepQ_scope with SQ.
 Bind Scope StepQ_scope with StepF.

--- a/model/structures/Zsec.v
+++ b/model/structures/Zsec.v
@@ -40,7 +40,7 @@ Require Export Coq.ZArith.ZArith.
 Require Import CoRN.logic.CLogic.
 Require Import Coq.Setoids.Setoid.
 
-Instance Z_default : @DefaultRelation Z (@eq Z) | 2.
+Instance Z_default : @DefaultRelation Z (@eq Z) | 2 := {}.
 
 (**
 * [Z]

--- a/reals/CauchySeq.v
+++ b/reals/CauchySeq.v
@@ -54,7 +54,7 @@ Proof. exact Cauchy_IR.Cauchy_IR. Qed.
   (* Defining IR directly with := and then setting [Global Opaque] keeps it semi-transparent, so
    we really need [Qed] to get full opacity. *)
 
-Instance IR_default : @DefaultRelation IR (@st_eq IR) | 2.
+Instance IR_default : @DefaultRelation IR (@st_eq IR) | 2 := {}.
 
 Notation PartIR := (PartFunct IR).
 Notation ProjIR1 := (prj1 IR _ _ _).


### PR DESCRIPTION
This is in preparation for coq/coq#9274.

Should be backward compatible, but that remains to be tested.