### PR TITLE
Add explicit {struct} annotation to avoid Coq expensive guessing

### DIFF
--- a/algebra/CPoly_Newton.v
+++ b/algebra/CPoly_Newton.v
@@ -79,7 +79,7 @@ Section contents.
 
   (** Definition of the Newton polynomial: *)
 
-  Fixpoint divdiff_l (a: QPoint) (xs: list QPoint): CR :=
+  Fixpoint divdiff_l (a: QPoint) (xs: list QPoint) {struct xs} : CR :=
     match xs with
     | nil => snd a
     | cons b l => (divdiff_l a l - divdiff_l b l) * ' / (fst a - fst b)


### PR DESCRIPTION
This https://github.com/coq/coq/pull/9602 makes the termination checker smart, but also more expensive.
This patch adds a `{struct}` annotation that makes Coq do not blindly try the wrong argument.