### PR TITLE
Use Z.log2 instead of the deprecated Zlogarithm

### DIFF
--- a/metric2/Compact.v
+++ b/metric2/Compact.v
@@ -659,7 +659,7 @@ Qed.
 Definition CompactTotallyBoundedIndex (e d1 d2:Qpos) : nat :=
 let (n,d):=((1+(1#4))*d1 + d2)/e/(1-(1#4)) in
  match Z.succ (Z.div n d) with
-| Zpos p => div2 (S (Z_to_nat (log_sup_correct1 p)))
+| Zpos p => div2 (S (Z_to_nat (Z.log2_up_nonneg (Zpos p))))
 | _ => O
 end.
 
@@ -683,7 +683,7 @@ Proof.
  rewrite -> Qmult_comm.
  apply Qle_shift_div_r.
   induction (let (n, d) := a * / e * / b in match Z.succ (n / d) with | Z0 => 0%nat
-    | Zpos p => div2 (S (Z_to_nat (z:=log_sup p) (log_sup_correct1 p))) | Zneg _ => 0%nat end).
+    | Zpos p => div2 (S (Z_to_nat (Z.log2_up_nonneg (Zpos p)))) | Zneg _ => 0%nat end).
    constructor.
   change (S n) with (1+n)%nat.
   rewrite inj_plus.
@@ -728,13 +728,13 @@ Proof.
    change (4%positive:Z) with (2^2)%Z.
    rewrite -> Zpower_Qpower;[|discriminate].
    rewrite <- Qpower_mult.
-   apply Qle_trans with (two_p (log_sup p)).
+   apply Qle_trans with (2 ^ Z.log2_up (Zpos p))%Z.
     unfold Qle; simpl.
     rewrite Pmult_comm;simpl.
     ring_simplify.
-    destruct (log_sup_correct2 p).
-    auto.
-   generalize  (log_sup p) (log_sup_correct1 p).
+    destruct (Z.log2_log2_up_spec p); [ reflexivity | ].
+    assumption.
+   generalize  (Z.log2_up (Zpos p)) (Z.log2_up_nonneg (Zpos p)).
    intros z Hz.
    clear p.
    cut (z <=  (2 * div2 (S (Z_to_nat (z:=z) Hz))))%Z.

--- a/reals/fast/CRln.v
+++ b/reals/fast/CRln.v
@@ -230,7 +230,7 @@ Definition ln_scale_power_factor q (Hq:0 < q) : Z.
 Proof.
  revert q Hq.
  intros [[|n|n] d] Hq; try abstract discriminate Hq.
- exact (Z.pred (log_inf d - (log_sup n)))%Z.
+ exact (Z.pred (Z.log2 d - Z.log2_up n))%Z.
 Defined.
 
 Definition rational_ln (a:Q) (p: 0 < a) : CR :=

--- a/reals/fast/PowerBound.v
+++ b/reals/fast/PowerBound.v
@@ -27,6 +27,12 @@ Require Import CoRN.algebra.COrdFields2.
 Require Import Coq.QArith.Qpower.
 Require Import CoRN.tactics.CornTac.
 
+Lemma Psize_Zlog2 (p: positive) :
+  Zpos (Pos.size p) = Z.succ (Z.log2 (Zpos p)).
+Proof.
+  destruct p; simpl; rewrite ?Pos.add_1_r; reflexivity.
+Qed.
+
 Local Open Scope Q_scope.
 
 (** These functions effiecently find bounds on rational numbers of the
@@ -41,14 +47,15 @@ Proof.
  rewrite Zpos_mult_morphism.
  apply Zmult_le_compat; auto with *.
  clear - n.
- apply Z.le_trans with (two_p (Z.succ (log_inf n))-1)%Z.
+ apply Z.le_trans with (two_p (Z.succ (Z.log2 (Zpos n)))-1)%Z.
   rewrite <- Zle_plus_swap.
   apply Zlt_succ_le.
   change (Zpos n+1) with (Z.succ (Zpos n)).
   apply Zsucc_lt_compat.
-  destruct (log_inf_correct2 n).
+  destruct (Z.log2_spec (Zpos n)); auto with zarith.
+  rewrite two_p_correct.
   assumption.
- replace (Z.succ (log_inf n)) with (Z_of_nat (Psize n)).
+ replace (Z.succ (Z.log2 (Zpos n))) with (Z_of_nat (Psize n)).
   apply Z.le_trans with (two_p (Z_of_nat (Psize n))).
    auto with *.
   induction (Psize n); auto with *.
@@ -61,8 +68,10 @@ Proof.
   change (3^1) with 3.
   apply Zmult_le_compat; auto with *.
   induction (Z_of_nat n0); auto with *.
- induction n; auto with *; simpl; rewrite <- IHn;
-   rewrite <- POS_anti_convert; rewrite inj_S; reflexivity.
+  rewrite <- Psize_Zlog2.
+  induction n as [ p ih | p ih | ]; auto; simpl;
+  rewrite Pos2Z.inj_succ, <- ih;
+  apply Z.P_of_succ_nat_Zplus.
 Close Scope Z_scope.
 Qed.
 


### PR DESCRIPTION
The Zlogarithm module has been deprecated for about 2³ years: see https://github.com/coq/coq/commit/59726c5343613379d38a9409af044d85cca130ed#diff-3f3b98a8b363f206c66dbc58be1f1f07