### PR TITLE
Avoid relying on `Export` bugs

### DIFF
--- a/algebra/COrdFields.v
+++ b/algebra/COrdFields.v
@@ -52,8 +52,8 @@
 (** printing FortyEightNZ %\ensuremath{\mathbf{48}}% #48# *)
 
 Require Export CoRN.tactics.FieldReflection.
-Require Export CoRN.algebra.CSetoids.
 Require Export CoRN.tactics.Rational.
+Require Export CoRN.algebra.CSetoids.
 
 (* ORDERED FIELDS *)
 

--- a/algebra/CPoly_Newton.v
+++ b/algebra/CPoly_Newton.v
@@ -1,10 +1,10 @@
 Require Import
  Unicode.Utf8
  Setoid Arith List Program Permutation metric2.Classified
- CSetoids CPoly_ApZero CRings CPoly_Degree
+ CSetoids CPoly_ApZero CPoly_Degree
  CRArith Qmetric Qring CReals Ranges
  stdlib_omissions.Pair stdlib_omissions.Q
- list_separates SetoidPermutation.
+ list_separates SetoidPermutation CRings.
 Require MathClasses.implementations.ne_list.
 Import CRing_Homomorphisms.coercions.
 Import ne_list.notations ne_list.coercions.

--- a/liouville/Liouville.v
+++ b/liouville/Liouville.v
@@ -326,7 +326,7 @@ Lemma Liouville_lemma7 : forall (p : Z_as_CRing) (q : positive), P ! (p#q)%Q [#]
 Proof.
  intros p q Hap.
  apply (leEq_wdr _ _ _ _ (Liouville_lemma6 _ _ Hap)).
- rewrite <- mult_assoc.
+ rewrite <- CRings.mult_assoc.
  apply mult_wdr.
  rewrite -> rh_pres_mult.
  apply AbsIR_resp_mult.
@@ -356,10 +356,10 @@ Lemma Liouville_lemma9 : forall (p : Z_as_CRing) (q : positive),
 Proof.
  intros p q Hap Hle.
  apply (leEq_transitive _ _ _ _ (Liouville_lemma7 _ _ Hap)).
- rewrite <- mult_assoc, <- mult_assoc.
+ rewrite <- CRings.mult_assoc, <- CRings.mult_assoc.
  apply mult_resp_leEq_lft.
   unfold C.
-  rewrite <- mult_assoc.
+  rewrite <- CRings.mult_assoc.
   apply mult_resp_leEq_lft; [|apply AbsIR_nonneg].
   apply (leEq_wdl _ _ _ _ (Liouville_lemma2 _ _ _ Hle)).
   apply AbsIR_wd.
@@ -433,7 +433,7 @@ Proof.
   reflexivity.
  rewrite H; clear H.
  rewrite <- nexp_ring_hom.
- rewrite <- mult_assoc.
+ rewrite <- CRings.mult_assoc.
  rewrite <- nexp_ring_hom.
  rewrite <- rh_pres_mult.
  assert (H : (1 # q)%Q[^]Liouville_degree[*](inject_Z q)[^]Liouville_degree [=] [1]).
@@ -453,7 +453,7 @@ Proof.
  apply (leEq_wdr _ _ _ _ (Liouville_lemma10 _ _ H _ _ H1)).
  fold C.
  rewrite -> (mult_commutes _ _ C).
- rewrite <- mult_assoc.
+ rewrite <- CRings.mult_assoc.
  apply mult_wdr.
  rewrite -> mult_commutes.
  apply mult_wdr.

--- a/metric2/Graph.v
+++ b/metric2/Graph.v
@@ -337,6 +337,9 @@ Definition CompactGraph_b (plFEX:PrelengthSpace (FinEnum stableX)) : Compact sta
 CompactImage_b (1#1) _ plFEX graphPoint_b.
 
 Require Import CoRN.model.ordfields.Qordfield.
+
+Local Open Scope Q_scope.
+
 Lemma CompactGraph_b_correct1 : forall plX plFEX x s, (inCompact x s) ->
 inCompact (Couple (x,(Cbind plX f x))) (CompactGraph_b plFEX s).
 Proof.

--- a/model/Zmod/Cmod.v
+++ b/model/Zmod/Cmod.v
@@ -134,7 +134,5 @@ Proof.
   2:intuition.
  set (H8:= (Zmod_cancel_multiple c0 r' b' H5)).
  rewrite H8.
- apply Zmod_small.
-  intuition.
- intuition.
+ apply Zmod_small; intuition.
 Qed.

--- a/ode/AbstractIntegration.v
+++ b/ode/AbstractIntegration.v
@@ -16,7 +16,8 @@ Import Qinf.notations QnonNeg.notations QnnInf.notations CRball.notations Qabs (
 
 Require CoRN.reals.fast.CRtrans CoRN.reals.faster.ARtrans. (* This is almost all CoRN *)
 
-Import Qinf.coercions QnonNeg.coercions QnnInf.coercions.
+Import Qinf.coercions QnonNeg.coercions QnnInf.coercions CoRN.stdlib_omissions.Q.
+
 
 Ltac done :=
   trivial; hnf; intros; solve
@@ -449,7 +450,7 @@ Section integral_approximation.
     Lemma step_0 (n : positive) : step 0 n == 0.
     Proof. unfold step; now rewrite Qmult_0_l. Qed.
 
-    Lemma step_mult (w : Q) (n : positive) : (n : Q) * step w n == w.
+    Lemma step_mult (w : Q) (n : positive) : (inject_Z n : Q) * step w n == w.
     Proof.
       unfold step.
       rewrite Qmake_Qdiv. unfold Qdiv. rewrite Qmult_1_l, (Qmult_comm w), Qmult_assoc.
@@ -632,7 +633,7 @@ Lemma riemann_sum_const (a : Q) (w : Q) (m : CR) (n : positive) :
 Proof.
 unfold riemann_sum. rewrite cmΣ_const, positive_nat_Z.
 change ('step w n * m * '(n : Q) = 'w * m).
-rewrite (mult_comm _ ('(n : Q))), mult_assoc, CRmult_Qmult, step_mult; reflexivity.
+rewrite (mult_comm _ ('(inject_Z n : Q))), mult_assoc, CRmult_Qmult, step_mult; reflexivity.
 Qed.
 
 Lemma riemann_sum_plus (f g : Q -> CR) (a w : Q) (n : positive) :
@@ -671,7 +672,7 @@ Lemma index_inside_r (a w : Q) (k : nat) (n : positive) :
   0 ≤ w -> k < Pos.to_nat n -> a + (k : Q) * step w n ≤ a + w.
 Proof.
 intros A1 A2. apply (orders.order_preserving (a +)).
-mc_setoid_replace w with ((n : Q) * (step w n)) at 2 by (symmetry; apply step_mult).
+mc_setoid_replace w with ((inject_Z n : Q) * (step w n)) at 2 by (symmetry; apply step_mult).
 apply (orders.order_preserving (.* step w n)).
 rewrite <- Zle_Qle, <- positive_nat_Z. apply inj_le. change (k ≤ Pos.to_nat n). solve_propholds.
 Qed.
@@ -681,7 +682,7 @@ Lemma riemann_sum_bounds (a w : Q) (m : CR) (e : Q) (n : positive) :
   gball (w * e) (riemann_sum f a w n) ('w * m).
 Proof.
 intros w_nn A. rewrite <- (riemann_sum_const a w m n). unfold riemann_sum.
-rewrite <- (step_mult w n), <- (Qmult_assoc n _ e), <- (positive_nat_Z n).
+rewrite <- (step_mult w n), <- (Qmult_assoc (inject_Z n) _ e), <- (positive_nat_Z n).
 apply CRΣ_gball. intros k A1. apply CRball.gball_CRmult_Q_nonneg; [now apply step_nonneg |].
 apply A. split; [apply index_inside_l | apply index_inside_r]; trivial.
 Qed.

--- a/ode/FromMetric2.v
+++ b/ode/FromMetric2.v
@@ -89,6 +89,8 @@ End FromCompleteMetricSpace.
 
 Require Import CoRN.model.metric2.CRmetric.
 
+Import metric.
+
 Section CompleteSegment.
 
 Context {X : MetricSpace} (r : Q) (a : Complete X).
@@ -123,6 +125,8 @@ Qed.
 End CompleteSegment.
 
 Require Import CoRN.model.setoids.Qsetoid CoRN.model.metric2.Qmetric CoRN.reals.fast.CRArith CoRN.reals.fast.CRball CoRN.reals.fast.CRabs MathClasses.theory.abs MathClasses.orders.minmax.
+
+Import canonical_names.
 
 Add Ring CR : (stdlib_ring_theory CR).
 
@@ -224,6 +228,8 @@ constructor.
   apply CRgball_plus; [now apply: (lip_prf f Lf) | now apply: (lip_prf g Lg)].
 Qed.
 *)
+
+Import metric.
 
 (* Needed to be able to state the property that the integral of the sum is
 the sum of integrals *)

--- a/ode/FromMetric2.v
+++ b/ode/FromMetric2.v
@@ -111,7 +111,7 @@ apply gball_weak_le with (q := QposAsQ e1 + r + (QposAsQ ((1 # 2) * e2)%Qpos)).
 + apply gball_complete, H.
 Qed.
 
-Global Instance : CompleteMetricSpaceClass (sig (mspc_ball r a)).
+Global Instance CompleteMetricSpaceClass_instance_1: CompleteMetricSpaceClass (sig (mspc_ball r a)).
 Proof.
 constructor; [| apply _].
 apply ext_equiv_r; [intros x y E; apply E |].

--- a/ode/metric.v
+++ b/ode/metric.v
@@ -514,7 +514,7 @@ Proof.
 constructor.
 + intros. apply lip_modulus_pos; [| assumption]. now apply (lip_nonneg f L).
 + unfold lip_modulus. intros e x1 x2 A1 A2. destruct (decide (L = 0)) as [A | A].
-  - apply mspc_eq; [| easy]. unfold equiv, mspc_equiv. rewrite <- (Qmult_0_l (msd x1 x2)), <- A.
+  - apply mspc_eq; [| easy]. unfold canonical_names.equiv, mspc_equiv. rewrite <- (Qmult_0_l (msd x1 x2)), <- A.
     now apply lip_prf; [| apply mspc_distance].
   - mc_setoid_replace e with (L * (e / L)) by now field.
     now apply lip_prf.

--- a/reals/Max_AbsIR.v
+++ b/reals/Max_AbsIR.v
@@ -1301,7 +1301,7 @@ Fixpoint SeqBound0 (n : nat) : IR :=
     end.
 
 Lemma SeqBound0_greater : forall (m n : nat),
-m < n -> AbsIR (seq m) [<=] SeqBound0 n.
+  (m < n)%nat -> AbsIR (seq m) [<=] SeqBound0 n.
 Proof.
  intros.
  elim H.

--- a/reals/fast/CRGeometricSum.v
+++ b/reals/fast/CRGeometricSum.v
@@ -18,7 +18,6 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE PROOF OR THE USE OR OTHER DEALINGS IN THE PROOF.
 *)
-
 Require Import CoRN.reals.fast.CRAlternatingSum.
 Require Import CoRN.model.ordfields.Qordfield.
 Require Import CoRN.model.totalorder.QMinMax.
@@ -39,6 +38,8 @@ Set Implicit Arguments.
 Opaque CR Qabs.
 
 Local Open Scope Q_scope.
+
+Import CoqStreams.
 
 (**
 ** Geometric Series
@@ -160,6 +161,7 @@ match n with
 | xI n' => InfiniteSum_raw_F (fun err s =>
  (InfiniteSum_raw_N n' (fun err s => InfiniteSum_raw_N n' cont err s)) err s)
 end.
+
 (*
 Remark : the eta expension here is important, else the virtual machine will
 compute the value of (InfiniteGeometricSum_raw_N n') before
@@ -167,7 +169,7 @@ reducing the call of InfiniteGeometricSum_raw_F.*)
 
 (** Lemmas for reasoning about InfiniteSum_raw_N. *)
 Lemma InfiniteSum_raw_N_F : forall p c,
- InfiniteSum_raw_N p (fun err s => InfiniteSum_raw_F c err s)=
+ InfiniteSum_raw_N p (fun err s => InfiniteSum_raw_F c err s) =
  InfiniteSum_raw_F (fun err s => InfiniteSum_raw_N p c err s).
 Proof.
  induction p; intro c; try reflexivity; simpl; repeat rewrite IHp; reflexivity.

--- a/reals/fast/CRcorrect.v
+++ b/reals/fast/CRcorrect.v
@@ -29,6 +29,8 @@ Require Export CoRN.reals.fast.CRFieldOps.
 
 Set Automatic Introduction.
 
+Local Open Scope nat_scope.
+
 Opaque Qmin Qmax.
 
 (**

--- a/reals/fast/CRseries.v
+++ b/reals/fast/CRseries.v
@@ -31,6 +31,7 @@ Require Import Coq.QArith.Qpower.
 Require Import CoRN.reals.fast.LazyNat. 
 Require Import Coq.setoid_ring.Ring MathClasses.interfaces.abstract_algebra MathClasses.theory.streams.
 Require Export MathClasses.theory.series.
+Require Import MathClasses.interfaces.abstract_algebra MathClasses.theory.streams.
 
 Opaque Qabs.
 Local Open Scope Q_scope.

--- a/reals/fast/CRsin.v
+++ b/reals/fast/CRsin.v
@@ -40,6 +40,8 @@ Require Import CoRN.reals.fast.PowerBound.
 Require Import CoRN.tactics.CornTac.
 Require Import MathClasses.interfaces.abstract_algebra.
 
+Import MathClasses.theory.CoqStreams.
+
 Set Implicit Arguments.
 
 Local Open Scope Q_scope.

--- a/reals/fast/Integration.v
+++ b/reals/fast/Integration.v
@@ -23,7 +23,6 @@ Require Export CoRN.model.metric2.IntegrableFunction.
 Require Export CoRN.model.metric2.BoundedFunction.
 Require Export CoRN.model.metric2.CRmetric.
 Require Export CoRN.reals.fast.CRArith.
-Require Import CoRN.model.metric2.LinfDistMonad.
 Require Import CoRN.reals.fast.CRIR.
 Require Import CoRN.ftc.Integral.
 Require Import CoRN.model.structures.StepQsec.
@@ -42,6 +41,7 @@ Require Import CoRN.reals.fast.ContinuousCorrect.
 Require Import CoRN.ftc.IntegrationRules.
 Require Import CoRN.ftc.MoreIntegrals.
 Require Import CoRN.tactics.CornTac.
+Require Import CoRN.model.metric2.LinfDistMonad.
 
 Set Implicit Arguments.
 

--- a/reals/fast/Plot.v
+++ b/reals/fast/Plot.v
@@ -23,7 +23,7 @@ Require Import CoRN.reals.fast.Interval.
 Require Export CoRN.metric2.Graph.
 Require Import CoRN.model.totalorder.QMinMax.
 Require Export CoRN.model.totalorder.QposMinMax.
-Require Import CoRN.tactics.CornTac.
+Require Import CoRN.tactics.CornTac CoRN.tactics.AlgReflection.
 
 Section Plot.
 (**

--- a/transc/InvTrigonom.v
+++ b/transc/InvTrigonom.v
@@ -360,7 +360,7 @@ Proof.
       apply cg_minus_wd.
        algebra.
       simpl in |- *; algebra.
-     unfold power in |- *.
+     unfold RealPowers.power in |- *.
      astepl (Exp [--] ([1] [/]TwoNZ[*]Log _ H4) [*]Cos x).
      astepl (([1][/] _[//]Exp_ap_zero ([1] [/]TwoNZ[*]Log _ H4)) [*]Cos x).
      astepr (Exp ([1] [/]TwoNZ[*]Log _ H4) [/] _[//]Exp_ap_zero ([1] [/]TwoNZ[*]Log _ H4)).
@@ -380,7 +380,7 @@ Proof.
      apply Log_wd.
      astepr (Cos x[^]2[+]Sin x[^]2[-]Sin x[^]2); rational.
     astepl (OneR[-][1]).
-    unfold cg_minus in |- *; apply plus_resp_less_lft.
+    unfold cg_minus in |- *.  apply plus_resp_less_lft.
     apply inv_resp_less.
     astepr (OneR[^]2); apply AbsIR_less_square.
     inversion_clear H3; apply Abs_Sin_less_One; auto.

--- a/transc/Pi.v
+++ b/transc/Pi.v
@@ -869,14 +869,14 @@ Proof.
   apply Sin_double.
  astepr ((Two:IR) [*][1] [/]TwoNZ).
  eapply eq_transitive.
-  apply eq_symmetric; apply mult_assoc.
+  apply eq_symmetric; apply CRings.mult_assoc.
  apply mult_wdr.
  cut (sqrt _ (less_leEq _ _ _ (pos_two IR)) [#] [0]). intro H.
   eapply eq_transitive.
    2: symmetry; apply (sqrt_lemma _ H).
   simpl in |- *.
   eapply eq_transitive.
-   2: apply mult_assoc.
+   2: apply CRings.mult_assoc.
   eapply eq_transitive.
    apply eq_symmetric; apply one_mult.
   apply mult_wdr.


### PR DESCRIPTION
Corn seems to relying in several places on `Export` bugs. I fixed all occurrences while maintaining backward-compatibility. This patch makes Corn compatible with https://github.com/coq/coq/pull/10476.

See https://github.com/coq/coq/issues/10474 and
https://github.com/coq/coq/issues/10480