### PR TITLE
typo. it's github.com not github/com.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ greater, which is a library of abstract interfaces for mathematical
 structures that is heavily based on Coq&#39;s type classes.
 
 
-  - [Bignums](https://github/com/coq/bignums)
+  - [Bignums](https://github.com/coq/bignums)
 
 
 ## Building and installation instructions


### PR DESCRIPTION
the bignums link was wrong