### PR TITLE
Avoid relying on `Export` bugs (again)

### DIFF
--- a/metric2/Classified.v
+++ b/metric2/Classified.v
@@ -133,7 +133,7 @@ Section genball.
 
   Definition ball_genball (q: Qpos) (a b: X): genball q a b ↔ R q a b.
   Proof.
-   unfold genball.
+   unfold genball; simpl.
    destruct Qdec_sign as [[|]|U].
      exfalso.
      destruct q.


### PR DESCRIPTION
It seems that two coercion paths do not trigger the same simpl behavior
(one of the coercions is a constructor, not the other one).