### PR TITLE
Remove or replace leftover SearchAbout.

### DIFF
--- a/examples/bigD.v
+++ b/examples/bigD.v
@@ -22,7 +22,7 @@ Check dy_pow.
 
 Check (Z⁺).
 Check NonNeg.
-SearchAbout NonNeg.
+Search NonNeg.
 Check ((1 _):(Z⁺)).
 
 (* Time Eval vm_compute in (test (dy_pow x (((40%Z) _)))).*)

--- a/stdlib_omissions/Q.v
+++ b/stdlib_omissions/Q.v
@@ -477,8 +477,6 @@ Qed.
 
 Hint Immediate positive_in_Q.
 
-SearchAbout (_ - ?x < _ - ?x)%Q.
-
 Lemma Qlt_Qceiling (q : Q) : inject_Z (Qceiling q) < q + 1.
 Proof.
 apply Qplus_lt_l with (z := (-1 # 1)). setoid_replace (q + 1 + (-1 # 1))%Q with q.


### PR DESCRIPTION
Compatibility with coq/coq#11944.

Depending on the location of the query command (sources or examples), I removed it entirely or replaced it with `Search`.