### PR TITLE
overlay for coq/coq#12162

### DIFF
--- a/algebra/Bernstein.v
+++ b/algebra/Bernstein.v
@@ -504,7 +504,7 @@ Opaque cpoly_cring.
 are all non-negative on the unit interval. *)
 
 Lemma BernsteinNonNeg : forall x:F, [0] [<=] x -> x [<=] [1] ->
-forall n i (p:le i n), [0][<=](Bernstein F p)!x.
+forall n i (p:Nat.le i n), [0][<=](Bernstein F p)!x.
 Proof.
  intros x Hx0 Hx1.
  induction n.

--- a/coq_reals/Rreals_iso.v
+++ b/coq_reals/Rreals_iso.v
@@ -119,6 +119,8 @@ Qed.
 
 (** less-than *)
 
+Open Scope R_scope.
+
 Lemma R_lt_as_IR : forall x y, (RasIR x [<] RasIR y -> x < y).
 Proof.
  intros x y H.
@@ -170,7 +172,7 @@ Proof.
  rewrite -> leEq_def.
  intro xy.
  assert (~ (y < x)).
-  apply RIneq.Rle_not_lt; assumption .
+  apply RIneq.Rle_not_lt; assumption.
  apply H0.
  apply R_lt_as_IR.
  assumption.
@@ -270,7 +272,7 @@ Lemma R_recip_as_IR : forall y Hy, (RasIR (1 / y) [=] ([1] [/] RasIR y [//] Hy))
 Proof.
  intros y Hy.
  simpl in Hy.
- assert (y [#] 0)%R.
+ assert (y [#] 0).
   apply: R_ap_as_IR.
   stepr ([0]:IR). assumption.
    symmetry.
@@ -904,7 +906,7 @@ Proof.
  unfold PI_tg in prf.
  rewrite -> R_mult_as_IR.
  apply mult_wd.
-  change 4%R with ((1 + 1) * (1 + 1))%R.
+  change 4 with ((1 + 1) * (1 + 1)).
   rewrite -> R_mult_as_IR.
   rewrite -> R_plus_as_IR.
   rewrite -> R_One_as_IR.
@@ -972,7 +974,7 @@ Proof.
  apply IR_ap_as_R.
  apply Rgt_not_eq.
  unfold Rgt.
- replace 0%R with (nring (R:=RRing) 0).
+ replace 0 with (nring (R:=RRing) 0).
   change ((nring (R:=RRing) 0 [<] nring (R:=RRing) (nat_of_P Qden))).
   apply nring_less.
   auto with *.
@@ -980,3 +982,5 @@ Proof.
 Qed.
 
 Hint Rewrite R_Q2R_as_IR : RtoIR.
+
+Close Scope R_scope.

--- a/ode/metric.v
+++ b/ode/metric.v
@@ -682,7 +682,7 @@ Section TotalOrderLattice.
 Context `{TotalOrder A} `{Lt A} `{∀ x y: A, Decision (x ≤ y)}.
 
 Lemma min_ind (P : A -> Prop) (x y : A) : P x → P y → P (min x y).
-Proof. unfold min, sort. destruct (decide_rel le x y); auto. Qed.
+Proof. unfold min, sort. destruct (decide_rel _ x y); auto. Qed.
 
 Lemma lt_min (x y z : A) : z < x -> z < y -> z < min x y.
 Proof. apply min_ind. Qed.

--- a/reals/fast/MultivariatePolynomials.v
+++ b/reals/fast/MultivariatePolynomials.v
@@ -302,7 +302,7 @@ Proof.
       rewrite <- (MVP_mult_apply Q_as_CRing).
       apply: MVP_apply_wd; try reflexivity.
       replace (lt_n_Sm_le n1 m (lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))
-        with (le_S_n n1 m l) by apply le_irrelevent.
+        with (Le.le_S_n n1 m l) by apply le_irrelevent.
       apply c_mult_apply.
      apply MVP_BernsteinNonNeg; auto.
     eapply Qle_trans;[|apply Qmax_ub_r].
@@ -430,7 +430,7 @@ Proof.
      rewrite <- (MVP_mult_apply Q_as_CRing).
      apply: MVP_apply_wd; try reflexivity.
      replace (lt_n_Sm_le n1 m (lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))
-       with (le_S_n n1 m l) by apply le_irrelevent.
+       with (Le.le_S_n n1 m l) by apply le_irrelevent.
      apply c_mult_apply.
     apply MVP_BernsteinNonNeg; auto.
    eapply Qle_trans;[apply Qmin_lb_r|].


### PR DESCRIPTION
The PR coq/coq#12162 renames `Bool.leb` into `Bool.le` which is more coherent with the rest of the standard library since it has type `bool -> bool -> Prop`. This generates possible clashes with `Nat.le`,  `Peano.le` or `Le.le` and also with the order on `R` so that additional qualification is required.
