### PR TITLE
overlay for coq/coq#12162 after merge of coq/coq#12008

### DIFF
--- a/model/Zmod/Zm.v
+++ b/model/Zmod/Zm.v
@@ -512,7 +512,7 @@ Section zm_ring_basics.
 
 
 Definition Zm_mult_ord (a:Zm)(h:nat) := (a[^]h[=][1]) /\
-  forall k:nat, (lt k h)->~(a[^]k[=][1]).
+  forall k:nat, (Peano.lt k h)->~(a[^]k[=][1]).
 
 
 


### PR DESCRIPTION
Because of coq/coq#12008 we have to take `lt` into account as well in coq/coq#12162.