### PR TITLE
Overlay for PR 12287

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -9,7 +9,7 @@ COQ_VERSION=`echo $COQ_VERSION_LINE | sed 's/The Coq Proof Assistant, version 8\
 DIRECTORIES="algebra complex coq_reals fta ftc liouville logic metrics model raster reals tactics transc order metric2 stdlib_omissions util classes ode"
 
 # Include constructive measure theory on version 8.12 and after
-if [ $COQ_VERSION -gt 11 ] ;
+if [ $COQ_VERSION -gt 12 ] ;
 then
     find $DIRECTORIES -name "*.v" >>Make
 else

--- a/reals/stdlib/CMTDirac.v
+++ b/reals/stdlib/CMTDirac.v
@@ -70,7 +70,7 @@ Proof.
       exists n. intros. unfold XminConst, Xop, partialApply.
       rewrite (DomainProp _ _ _ fL), CRmin_left.
       rewrite CRabs_right. unfold CRminus. rewrite CRplus_opp_r.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
       unfold CRminus. rewrite CRplus_opp_r. apply CRle_refl.
       apply (CRle_trans _ (CR_of_Q R (Z.of_nat n # 1))).
       apply CRlt_asym, H. apply CR_of_Q_le.
@@ -86,5 +86,5 @@ Proof.
       rewrite Nat2Pos.id. apply (Nat.le_trans _ _ _ H).
       apply le_S, le_refl. discriminate.
       apply CRmin_glb. apply CRabs_pos.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
 Defined.

--- a/reals/stdlib/CMTFullSets.v
+++ b/reals/stdlib/CMTFullSets.v
@@ -107,7 +107,7 @@ Proof.
     apply CRmult_morph. 2: reflexivity.
     rewrite CRabs_right. reflexivity. apply CRlt_asym.
     apply CRmult_lt_0_compat. apply pow_lt.
-    simpl. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+    simpl. apply CR_of_Q_lt. reflexivity.
     apply CRinv_0_lt_compat. exact denomPos.
     apply series_cv_scale. assumption. }
   exists (Build_IntegralRepresentation
@@ -124,7 +124,7 @@ Proof.
     assert (CRapart _ (CRpow (CR_of_Q _ (1#2)) n * CRinv _ (1 + sumAbsIFnk) (inr denomPos)) 0)
       as ddenomNonZero.
     { right. apply CRmult_lt_0_compat.
-      apply pow_lt. simpl. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+      apply pow_lt. simpl. apply CR_of_Q_lt. reflexivity.
       apply CRinv_0_lt_compat. exact denomPos. }
     destruct (domainInfiniteSumAbsScaleIncReverse _ _ _ x xdf ddenomNonZero) as [y _].
     exact (injF x y).
@@ -133,7 +133,7 @@ Proof.
     rewrite CRmult_comm. rewrite <- (CRmult_1_r (CRpow (CR_of_Q _ (1 # 2)) n)).
     do 2 rewrite CRmult_assoc.
     apply CRmult_le_compat_l. apply CRlt_asym, pow_lt.
-    simpl. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+    simpl. apply CR_of_Q_lt. reflexivity.
     rewrite CRmult_1_l. apply CRlt_asym.
     apply (CRmult_lt_reg_l (1+sumAbsIFnk)). assumption.
     rewrite <- CRmult_assoc. rewrite CRinv_r.
@@ -668,15 +668,15 @@ Proof.
     rewrite CRmult_assoc, CRinv_l, CRmult_1_r in majEpsN.
     2: exact H. apply CRlt_asym.
     apply (CRmult_lt_reg_r (CR_of_Q _ 2)).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+    apply CR_of_Q_lt; reflexivity.
     rewrite CRmult_assoc, <- (CR_of_Q_mult _ (1#2)).
     setoid_replace ((1 # 2) * 2)%Q with 1%Q.
-    2: reflexivity. rewrite CR_of_Q_one, CRmult_1_r.
+    2: reflexivity. rewrite CRmult_1_r.
     apply (CRmult_lt_reg_l (CR_of_Q _ (Z.pos (Pos.of_nat epsN) #1))).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+    apply CR_of_Q_lt; reflexivity.
     rewrite <- CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((Z.pos (Pos.of_nat epsN) # 1) * (1 # Pos.of_nat epsN))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_l. apply (CRlt_le_trans _ _ _ majEpsN).
+    rewrite CRmult_1_l. apply (CRlt_le_trans _ _ _ majEpsN).
     apply CRmult_le_compat_r. apply CRlt_asym, H.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden.
     do 2 rewrite Z.mul_1_r. destruct epsN. discriminate.
@@ -726,7 +726,6 @@ Proof.
     rewrite <- (CRmult_1_r eps).
     rewrite CRmult_assoc. apply CRmult_lt_compat_l.
     assumption. rewrite CRmult_1_l. apply (CRmult_lt_reg_l (CR_of_Q _ 2)).
-    rewrite <- CR_of_Q_zero.
     apply CR_of_Q_lt; reflexivity. rewrite <- CR_of_Q_mult.
     rewrite CRmult_1_r. apply CR_of_Q_lt. reflexivity.
     intro n. apply integralPositive. intros x xdf. rewrite applyXabs.
@@ -739,15 +738,15 @@ Proof.
     apply (CRle_lt_trans _ (CR_of_Q _ (1 # Pos.of_nat epsN))).
     apply limN. apply le_refl.
     apply (CRmult_lt_reg_r (CR_of_Q _ 2)).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+    apply CR_of_Q_lt; reflexivity.
     rewrite CRmult_assoc, <- (CR_of_Q_mult _ (1#2)).
     setoid_replace ((1 # 2) * 2)%Q with 1%Q.
-    2: reflexivity. rewrite CR_of_Q_one, CRmult_1_r.
+    2: reflexivity. rewrite CRmult_1_r.
     apply (CRmult_lt_reg_l (CR_of_Q _ (Z.pos (Pos.of_nat epsN) #1))).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+    apply CR_of_Q_lt; reflexivity.
     rewrite <- CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((Z.pos (Pos.of_nat epsN) # 1) * (1 # Pos.of_nat epsN))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_l. apply (CRlt_le_trans _ _ _ majEpsN).
+    rewrite CRmult_1_l. apply (CRlt_le_trans _ _ _ majEpsN).
     apply CRmult_le_compat_r. apply CRlt_asym, H.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden.
     do 2 rewrite Z.mul_1_r. destruct epsN. discriminate.
@@ -757,7 +756,7 @@ Proof.
     rewrite <- (CRmult_1_r eps), CRopp_mult_distr_r.
     rewrite CRmult_assoc, <- CRmult_plus_distr_l.
     apply CRmult_morph. rewrite CRmult_1_r. reflexivity. rewrite CRmult_1_l.
-    rewrite <- CR_of_Q_opp, <- CR_of_Q_one, <- CR_of_Q_plus.
+    rewrite <- CR_of_Q_opp, <- CR_of_Q_plus.
     apply CR_of_Q_morph. reflexivity.
     intros. rewrite Nat.add_succ_r. reflexivity.
     apply CR_cv_plus. assumption. apply CR_cv_const.
@@ -779,7 +778,7 @@ Definition CompleteRepresentation
                        + CRpow (CR_of_Q _ (1#2)) n) }.
 Proof.
   assert (0 < CR_of_Q (RealT (ElemFunc IS)) (1 # 2)) as halfPos.
-  { rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity. }
+  { apply CR_of_Q_lt. reflexivity. }
   exists (fun n:nat => let (df,_) := AbsRepresentation
        IS (fn n) (CRpow (CR_of_Q _ (1#2)) n) (fnInt n)
        (pow_lt (CR_of_Q _ (1 # 2)) n halfPos) in df).
@@ -1431,7 +1430,7 @@ Proof.
     (applyXminus (XminConst g (INR n)) (XminConst f (INR n))),
     (applyXminus g f), applyXminConst, applyXminConst.
     assert (0 <= @INR (RealT (ElemFunc IS)) n) as nPos.
-    { rewrite <- CR_of_Q_zero. apply CR_of_Q_le. unfold Qle, Qnum, Qden.
+    { apply CR_of_Q_le. unfold Qle, Qnum, Qden.
       do 2 rewrite Z.mul_1_r. apply Nat2Z.is_nonneg. }
     apply (CRle_trans _ _ _ (CRmin_contract _ _ _)).
     rewrite (DomainProp g x d d1).
@@ -1460,7 +1459,7 @@ Lemma Break_lt_3_eps :
 Proof.
   intros. exists ((b-a) * CR_of_Q R (1#4)). split.
   - rewrite <- (CRmult_0_l (CR_of_Q R (1#4))).
-    apply CRmult_lt_compat_r. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+    apply CRmult_lt_compat_r. apply CR_of_Q_lt. reflexivity.
     rewrite <- (CRplus_opp_r a). apply CRplus_lt_compat_r. exact H.
   - rewrite (CRmult_comm (b-a)), <- CRmult_assoc, <- CR_of_Q_mult.
     apply (CRplus_lt_reg_l _ (-a)). rewrite <- CRplus_assoc.
@@ -1468,7 +1467,7 @@ Proof.
     rewrite <- (CRmult_1_l (b + - a)).
     apply CRmult_lt_compat_r.
     rewrite <- (CRplus_opp_r a). apply CRplus_lt_compat_r. exact H.
-    rewrite <- CR_of_Q_one. apply CR_of_Q_lt. reflexivity.
+    apply CR_of_Q_lt. reflexivity.
 Qed.
 
 Lemma DiagNonNeg
@@ -1635,8 +1634,8 @@ Proof.
     rewrite CRmult_assoc.
     apply CRmult_lt_compat_l. exact epsPos.
     rewrite <- (CRmult_0_r (CR_of_Q _ (1#2))).
-    apply CRmult_lt_compat_l. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
-    apply pow_lt. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity. }
+    apply CRmult_lt_compat_l. apply CR_of_Q_lt. reflexivity.
+    apply pow_lt. apply CR_of_Q_lt. reflexivity. }
   pose (fun n => IntFn (let (r,_)
                          := AbsRepresentation
                               IS (hn n) (eps*CR_of_Q _ (1#2)*CRpow (CR_of_Q _ (1#2)) n)
@@ -1736,7 +1735,7 @@ Proof.
     apply (CR_cv_proper _ (CR_of_Q _ 2*(eps*CR_of_Q _ (1#2)))).
     apply series_cv_scale. apply GeoHalfTwo.
     rewrite CRmult_comm, CRmult_assoc, <- CR_of_Q_mult.
-    setoid_replace ((1#2) * 2)%Q with 1%Q. rewrite CR_of_Q_one, CRmult_1_r.
+    setoid_replace ((1#2) * 2)%Q with 1%Q. rewrite CRmult_1_r.
     reflexivity. reflexivity. destruct p.
     exists (x1, x0). unfold fst, snd. split. split.
     apply (series_cv_eq
@@ -1765,9 +1764,10 @@ Proof.
     rewrite <- CRplus_assoc in H2. apply CRplus_lt_reg_r in H2.
     apply (CRlt_trans _ (x1 + eps)).
     apply CRplus_lt_compat_l. exact c1. exact H2.
-    setoid_replace (CR_of_Q (RealT (ElemFunc IS)) 3) with (1+1+CRone (RealT (ElemFunc IS))).
+    setoid_replace (CR_of_Q (RealT (ElemFunc IS)) 3)
+      with (1+1+CR_of_Q (RealT (ElemFunc IS)) 1).
     do 2 rewrite CRmult_plus_distr_r. rewrite CRmult_1_l, CRplus_assoc.
-    reflexivity. rewrite <- CR_of_Q_one.
+    reflexivity. 
     do 2 rewrite <- CR_of_Q_plus. reflexivity.
   - destruct x0 as [cpx cpxF cpxFn cpxGn].
     simpl in xcv. destruct xcv, p, x0. simpl in p. destruct p.
@@ -1947,13 +1947,11 @@ Proof.
     rewrite (DomainProp _ y d1 d0), applyXabs.
     apply CRabs_triang_inv2.
     apply integralPositive. intros y ydf. apply CRmin_glb.
-    apply CRabs_pos. rewrite <- CR_of_Q_zero. apply CR_of_Q_le.
-    discriminate.
+    apply CRabs_pos. apply CR_of_Q_le. discriminate.
     rewrite <- CR_of_Q_plus. apply CR_of_Q_morph. rewrite Qinv_plus_distr.
     reflexivity.
   - apply IntegralNonNeg. intros y ydf. apply CRmin_glb.
-    apply CRabs_pos. rewrite <- CR_of_Q_zero. apply CR_of_Q_le.
-    discriminate.
+    apply CRabs_pos. apply CR_of_Q_le. discriminate.
 Qed.
 
 (* Theorem 1.18 of Bishop *)

--- a/reals/stdlib/CMTIntegrableFunctions.v
+++ b/reals/stdlib/CMTIntegrableFunctions.v
@@ -377,11 +377,11 @@ Proof.
     exists N. intros. specialize (cv (i*2)%nat).
     rewrite weaveSequencesSum in cv. rewrite Nat.div_mul in cv.
     setoid_replace (match (i * 2)%nat with
-           | 0%nat => CRzero R
+           | 0%nat => CR_of_Q R 0
            | S _ =>
                CRsum (fun _ : nat => 0)
                  (if Nat.even (i * 2) then Init.Nat.pred i else i)
-           end) with (CRzero R) in cv.
+           end) with (CR_of_Q R 0) in cv.
     rewrite CRplus_0_r in cv. apply cv. apply (le_trans _ i).
     assumption. rewrite mult_comm. simpl. rewrite <- (plus_0_r i).
     rewrite <- plus_assoc. apply Nat.add_le_mono_l. apply le_0_n.
@@ -517,7 +517,7 @@ Proof.
   rewrite <- CRopp_plus_distr.
   rewrite CRabs_opp. rewrite CRmult_1_l.
   rewrite CRplus_opp_r. rewrite CRabs_right.
-  rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. apply CRle_refl.
+  apply CR_of_Q_le. discriminate. apply CRle_refl.
   intros. rewrite <- CRopp_mult_distr_r, CRmult_1_r.
   reflexivity. assumption.
 Qed.
@@ -577,7 +577,7 @@ Proof.
   intros n. exists O. intros.
   rewrite sum_const. rewrite CRmult_0_l. unfold CRminus.
   rewrite CRplus_0_l, CRopp_0.
-  rewrite CRabs_right. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+  rewrite CRabs_right. apply CR_of_Q_le. discriminate.
   apply CRle_refl.
 Defined.
 
@@ -587,7 +587,7 @@ Lemma IntegrableZeroMaj : forall {IS : IntegrationSpace},
 Proof.
   split.
   - intros x [xn cv]. simpl. trivial.
-  - intros. destruct xD as [xn cv]. transitivity (CRzero (RealT (ElemFunc IS))).
+  - intros. destruct xD as [xn cv]. transitivity (CR_of_Q (RealT (ElemFunc IS)) 0).
     apply applyInfiniteSumAbs.
     apply (series_cv_eq (fun _ => 0)).
     intro n. unfold IntegralRepresentationZero, IntFn.
@@ -595,7 +595,7 @@ Proof.
     intros p. exists O. intros. rewrite sum_const.
     rewrite CRmult_0_l. unfold CRminus.
     rewrite CRplus_opp_r, CRabs_right.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le.
+    apply CR_of_Q_le.
     discriminate. apply CRle_refl. reflexivity.
 Qed.
 
@@ -1007,7 +1007,7 @@ Proof.
   destruct (Un_cv_nat_real _ s H ((s - a) * CR_of_Q R (1 # 2))) as [N H1].
   + apply CRmult_lt_0_compat. rewrite <- (CRplus_opp_r a).
     apply CRplus_lt_compat_r. exact H0.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+    apply CR_of_Q_lt. reflexivity.
   + exists N. specialize (H1 N (le_refl N)).
     rewrite CRabs_minus_sym in H1.
     apply (CRle_lt_trans (s - CRsum u N)) in H1.
@@ -1015,9 +1015,9 @@ Proof.
     rewrite CRmult_assoc in H1.
     rewrite <- CR_of_Q_mult in H1.
     setoid_replace ((1 # 2) * 2)%Q with 1%Q in H1. 2: reflexivity.
-    rewrite CR_of_Q_one, CRmult_1_r in H1.
+    rewrite CRmult_1_r in H1.
     assert ((s - CRsum u N) * CR_of_Q R 2 == s + s - CRsum u N -CRsum u N).
-    { rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_plus_distr_l.
+    { rewrite (CR_of_Q_plus R 1 1), CRmult_plus_distr_l.
       rewrite CRmult_1_r. unfold CRminus. do 3 rewrite CRplus_assoc.
       apply CRplus_morph. reflexivity. rewrite CRplus_comm, CRplus_assoc.
       reflexivity. }
@@ -1029,7 +1029,7 @@ Proof.
     apply (CRplus_lt_compat_r (CRsum u N)) in H1. rewrite CRplus_assoc in H1.
     rewrite CRplus_assoc in H1. rewrite CRplus_opp_l in H1. rewrite CRplus_0_r in H1.
     rewrite CRplus_0_l in H1. rewrite <- CRplus_assoc in H1.
-    apply CRltForget. assumption. rewrite <- CR_of_Q_zero.
+    apply CRltForget. assumption. 
     apply CR_of_Q_lt. reflexivity. apply CRle_abs.
 Qed.
 
@@ -1204,8 +1204,8 @@ Proof.
     with (CR_of_Q _ 2 * c).
   rewrite <- CRmult_assoc, <- CR_of_Q_mult.
   setoid_replace ((1 # 2) * 2)%Q with 1%Q.
-  rewrite CR_of_Q_one, CRmult_1_l. reflexivity. reflexivity.
-  rewrite (CR_of_Q_plus _ 1 1), CR_of_Q_one, CRmult_plus_distr_r.
+  rewrite CRmult_1_l. reflexivity. reflexivity.
+  rewrite (CR_of_Q_plus _ 1 1), CRmult_plus_distr_r.
   rewrite CRmult_1_l, CRplus_assoc. apply CRplus_morph. reflexivity.
   rewrite CRopp_plus_distr, <- CRplus_assoc, CRplus_opp_r.
   rewrite CRplus_0_l, CRopp_involutive. reflexivity.
@@ -1419,7 +1419,7 @@ Proof.
                          (CRsum (fun k => CRmax 0 (- partialApply (fn k) x (pxn k))) M)).
     { intros eps. exists M. intros. rewrite sum_truncate_above.
       unfold CRminus. rewrite CRplus_opp_r.
-      rewrite CRabs_right. rewrite <- CR_of_Q_zero. apply CR_of_Q_le.
+      rewrite CRabs_right. apply CR_of_Q_le.
       discriminate. apply CRle_refl. exact H4. }
     apply (series_cv_plus (fun n : nat =>
           (CRmax 0 (partialApply (fn n) x (pxn n)) +

--- a/reals/stdlib/CMTIntegrableSets.v
+++ b/reals/stdlib/CMTIntegrableSets.v
@@ -55,7 +55,7 @@ Definition CharacFunc {R : ConstructiveReals} {X : Set} (A : X -> Prop)
 Proof.
   apply (Build_PartialFunctionXY
            X (CRcarrier R) (CReq R) (fun x:X => { A x } + { ~A x })
-           (fun x dec => if dec then CRone R else CRzero R) ).
+           (fun x dec => if dec then CR_of_Q R 1 else CR_of_Q R 0) ).
   intros. destruct p,q.
   reflexivity. contradiction. contradiction. reflexivity.
 Defined.
@@ -81,7 +81,7 @@ Definition PartialFunctionBoolR
 Proof.
   apply (Build_PartialFunctionXY
            X (CRcarrier R) (CReq R) (Domain f)
-           (fun x dec => if partialApply f x dec then CRone R else CRzero R)).
+           (fun x dec => if partialApply f x dec then CR_of_Q R 1 else CR_of_Q R 0)).
   intros. rewrite (DomainProp f x p q). reflexivity.
 Defined. 
 
@@ -224,7 +224,6 @@ Proof.
       specialize (lcv 1%positive) as [n ncv].
       destruct (CRup_nat (1+l)) as [k kup].
       specialize (ncv (max n k) (Nat.le_max_l _ _)).
-      rewrite CR_of_Q_one in ncv.
       apply (CRle_trans _ _ _ (CRle_abs _)) in ncv.
       apply (CRplus_le_compat_r l) in ncv.
       unfold CRminus in ncv. rewrite CRplus_assoc, CRplus_opp_l, CRplus_0_r in ncv.
@@ -261,7 +260,7 @@ Proof.
   apply (CRmult_eq_reg_l (CR_of_Q R 2)). right. apply CR_of_Q_pos. reflexivity.
   rewrite <- CRmult_assoc, <- CR_of_Q_mult.
   setoid_replace (2 * (1 # 2))%Q with 1%Q. 2: reflexivity.
-  rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_1_l.
+  rewrite (CR_of_Q_plus R 1 1), CRmult_1_l.
   rewrite CRmult_plus_distr_r, CRmult_1_l.
   rewrite (DomainProp (fn n) x (fst (d,d0)) d0), (DomainProp (fn n) x d1 d0).
   reflexivity. apply applyXnegPartNonNeg. apply applyXposPartNonNeg.
@@ -693,7 +692,7 @@ Proof.
   intros. simpl. simpl in pcv.
   specialize (pcv p n (le_refl _) H0).
   assert (CR_of_Q R (1 # 2) < 1).
-  { rewrite <- CR_of_Q_one. apply CR_of_Q_lt. reflexivity. }
+  { apply CR_of_Q_lt. reflexivity. }
   destruct (xn p), (xn n). reflexivity. 3: reflexivity.
   - exfalso. unfold CRminus in pcv.
     rewrite CRopp_0, CRplus_0_r, CRabs_right in pcv.
@@ -744,7 +743,8 @@ Proof.
       destruct xD as [xn xcv]. destruct xG.
       simpl in xn.
       destruct (constructive_indefinite_ground_description_nat
-                    (fun n => (if xn n then 1 else 0) == CRone (RealT (ElemFunc IS)))) as [n ncv].
+                  (fun n => (if xn n then 1 else 0) == CR_of_Q (RealT (ElemFunc IS)) 1))
+        as [n ncv].
       intro n. destruct (xn n). left. reflexivity. right.
       intros [abs _]. apply abs, CRzero_lt_one.
       destruct e as [n ncv]. exists n.
@@ -752,7 +752,7 @@ Proof.
       destruct n. contradiction. apply n0. right. exact ncv.
       exists n. intros. destruct (xn i).
       unfold CRminus. rewrite CRplus_opp_r, CRabs_right.
-      2: apply CRle_refl. rewrite <- CR_of_Q_zero.
+      2: apply CRle_refl. 
       apply CR_of_Q_le; discriminate.
       exfalso. apply n0. apply applyUnionIterate. exists n.
       split. exact H0. destruct (xn n).
@@ -763,8 +763,7 @@ Proof.
       exists O. intros n0 _. destruct (xn n0). exfalso.
       apply n. apply applyUnionIterate in u. destruct u. exists x0. apply H0.
       unfold CRminus. rewrite CRplus_opp_r, CRabs_right.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le; discriminate.
-      apply CRle_refl.
+      apply CR_of_Q_le; discriminate. apply CRle_refl.
     + exists (existT _ i H0). exact cv.
 Defined.
 
@@ -811,7 +810,7 @@ Proof.
       destruct xG. exists O. intros n H0.
       destruct (xn n).
       unfold CRminus. rewrite CRplus_opp_r, CRabs_right.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le; discriminate. apply CRle_refl.
+      apply CR_of_Q_le; discriminate. apply CRle_refl.
       exfalso. apply n0. rewrite applyIntersectIterate. intros. apply a0.
 
       apply CharacFuncStationary in xcv. destruct xcv as [p pcv].
@@ -831,7 +830,7 @@ Proof.
       specialize (X (RealT (ElemFunc IS))).
       rewrite pcv in X. exact (CRlt_asym _ _ X X).
       unfold CRminus. rewrite CRplus_opp_r, CRabs_right.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le; discriminate. apply CRle_refl.
+      apply CR_of_Q_le; discriminate. apply CRle_refl.
     + exists (existT _ i H0). exact cv.
 Defined.
 
@@ -884,8 +883,8 @@ Proof.
       rewrite Nat.sub_0_r.
       setoid_replace (x - INR 0) with x. reflexivity.
       unfold INR. simpl. unfold CRminus.
-      rewrite CR_of_Q_zero, CRopp_0, CRplus_0_r.
-      reflexivity. rewrite H0. unfold INR. rewrite CR_of_Q_zero. apply H1.
+      rewrite CRopp_0, CRplus_0_r.
+      reflexivity. rewrite H0. unfold INR. apply H1.
     - intros. simpl. rewrite IHk. clear IHk.
       rewrite CRmin_plus.
       setoid_replace (CRmin x (INR (nk (S k))) + (x - CRmin x (INR (nk (S k)))))
@@ -896,7 +895,7 @@ Proof.
       rewrite CRmin_assoc.
       rewrite (CRmin_left x). reflexivity.
       apply (CRle_trans _ (0+x)). rewrite CRplus_0_l.
-      apply CRle_refl. apply CRplus_le_compat. rewrite <- CR_of_Q_zero.
+      apply CRle_refl. apply CRplus_le_compat. 
       apply CR_of_Q_le. unfold Qle; simpl. rewrite Z.mul_1_r.
       apply Nat2Z.is_nonneg. apply CRle_refl.
       unfold INR. rewrite <- CR_of_Q_plus. apply CR_of_Q_morph.
@@ -909,7 +908,7 @@ Proof.
   destruct (CRup_nat x) as [n nmaj]. exists n.
   intros. rewrite H2. rewrite CRmin_left.
   unfold CRminus. rewrite CRplus_opp_r, CRabs_right.
-  rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. apply CRle_refl.
+  apply CR_of_Q_le. discriminate. apply CRle_refl.
   apply (CRle_trans _ (INR n)). apply CRlt_asym, nmaj.
   apply CR_of_Q_le. unfold Qle; simpl.
   do 2 rewrite Z.mul_1_r. apply Nat2Z.inj_le.
@@ -977,12 +976,11 @@ Proof.
       rewrite applyXminConst. rewrite (DomainProp f x d1 d).
       apply CRmin_l.
       setoid_replace (partialApply (Xmult (CharacFunc A) f) x (right notInA, d0))
-        with (CRzero R).
+        with (CR_of_Q R 0).
       intro p. exists O. intros. rewrite sum_const, CRmult_0_l.
       unfold CRminus. rewrite CRplus_opp_r, CRabs_right.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. apply CRle_refl.
-      clear xD. destruct f; simpl.
-      apply CRmult_0_l.
+      apply CR_of_Q_le. discriminate. apply CRle_refl.
+      clear xD. destruct f; simpl. apply CRmult_0_l.
 Qed.
 
 (* Add zero before sequence un, if it does not already start with zero. *)
@@ -1015,7 +1013,7 @@ Proof.
   intros fInt fNonNeg AInt.
   assert (forall k : nat, 0 < CRpow (CR_of_Q (RealT (ElemFunc IS)) (1 # 2)) k) as boundPos.
   { intro k. apply pow_lt. simpl.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity. }
+    apply CR_of_Q_lt. reflexivity. }
   pose (StartZero (fun n => let (p,_) := ControlSubSeqCv _ _ (CRpow (CR_of_Q _ (1#2)))
              (IntegralTruncateLimit f fInt) boundPos n in p)) as nk.
   (* Cut f's non-negative graph horizontally, according to the nk *)
@@ -1045,7 +1043,7 @@ Proof.
     unfold fk.
     rewrite (applyXmin _ _ x H xdg). apply CRmin_glb.
     rewrite applyXscale. rewrite <- (CRmult_0_r (INR (nk (S (S n)) - nk (S n)))).
-    apply CRmult_le_compat_l. rewrite <- CR_of_Q_zero. apply CR_of_Q_le.
+    apply CRmult_le_compat_l. apply CR_of_Q_le.
     unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r. apply Nat2Z.is_nonneg.
     simpl. destruct H. apply CRlt_asym, CRzero_lt_one. apply CRle_refl.
     destruct xdg.
@@ -1067,16 +1065,16 @@ Proof.
     apply (CRle_trans _ (CRpow (CR_of_Q _ (1 # 2)) (S n))).
     apply CRlt_asym, c0.
     apply (CRmult_le_reg_l (CRpow (CR_of_Q _ 2) (S n))).
-    apply pow_lt. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+    apply pow_lt. apply CR_of_Q_lt. reflexivity.
     rewrite pow_mult. rewrite (pow_proper _ 1), pow_one.
     replace (CRpow (CR_of_Q _ 2) (S n))
       with (CR_of_Q (RealT (ElemFunc IS)) 2 * CRpow (CR_of_Q _ 2) n). 2: reflexivity.
     rewrite CRmult_assoc, pow_mult.
     rewrite (pow_proper _ 1), pow_one. rewrite CRmult_1_r.
-    rewrite <- CR_of_Q_one. apply CR_of_Q_le. discriminate. rewrite <- CR_of_Q_mult.
-    setoid_replace (2 * (1 # 2))%Q with 1%Q. apply CR_of_Q_one. reflexivity.
+    apply CR_of_Q_le. discriminate. rewrite <- CR_of_Q_mult.
+    setoid_replace (2 * (1 # 2))%Q with 1%Q. reflexivity. reflexivity.
     rewrite <- CR_of_Q_mult.
-    setoid_replace (2 * (1 # 2))%Q with 1%Q. apply CR_of_Q_one. reflexivity.
+    setoid_replace (2 * (1 # 2))%Q with 1%Q. reflexivity. reflexivity.
     destruct (ControlSubSeqCv
               (fun n0 : nat => Integral (IntegrableMinInt f n0 fInt))
               (Integral fInt) (CRpow (CR_of_Q _ (1 # 2)))

--- a/reals/stdlib/CMTMeasurableFunctions.v
+++ b/reals/stdlib/CMTMeasurableFunctions.v
@@ -89,7 +89,7 @@ Proof.
   exact (RestrictedIntegrable fInt Aint).
   apply CR_of_Q_pos. reflexivity.
   apply (CRlt_le_trans _ (CR_of_Q _ 0)). apply CR_of_Q_lt. reflexivity.
-  rewrite CR_of_Q_zero. apply CRle_refl.
+  apply CRle_refl.
 Qed.
 
 Lemma MeasurableConst
@@ -105,8 +105,8 @@ Proof.
     destruct xG. destruct xD. destruct d. apply CRmult_comm.
     contradiction. destruct d. contradiction. apply CRmult_comm.
   - apply IntegrableScale, Aint.
-  - rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
-  - rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+  - apply CR_of_Q_lt. reflexivity.
+  - apply CR_of_Q_lt. reflexivity.
 Qed.
 
 Definition MeasurableSet {IS : IntegrationSpace}
@@ -140,15 +140,13 @@ Proof.
     apply (CRle_trans _ 1). simpl. destruct xG.
     destruct d. destruct d0. rewrite CRmult_1_l. apply CRle_refl.
     rewrite CRmult_1_l. apply CRlt_asym, CRzero_lt_one. rewrite CRmult_0_l.
-    apply CRlt_asym, CRzero_lt_one. rewrite <- CR_of_Q_one.
+    apply CRlt_asym, CRzero_lt_one. 
     apply CR_of_Q_le. unfold Qle, Qnum, Qden. rewrite Z.mul_1_l, Z.mul_1_r.
     destruct k; discriminate.
-    apply (CRle_trans _ 0).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply (CRle_trans _ 0). apply CR_of_Q_le. discriminate.
     apply CRmin_glb. simpl. destruct xG, d. rewrite CRmult_1_l.
     destruct d0. apply CRlt_asym, CRzero_lt_one. apply CRle_refl.
-    rewrite CRmult_0_l. apply CRle_refl.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. }
+    rewrite CRmult_0_l. apply CRle_refl. apply CR_of_Q_le. discriminate. }
   split.
   - intros Ames B Bint. specialize (Ames B 1%positive Bint).
     refine (IntegrableFunctionExtensional _ _ _ Ames). split.
@@ -182,7 +180,7 @@ Proof.
   - exact (IntegrableSetIntersect _ _ Bint Aint).
   - apply CR_of_Q_pos. reflexivity.
   - apply (CRlt_le_trans _ (CR_of_Q _ 0)).
-    apply CR_of_Q_lt. reflexivity. rewrite CR_of_Q_zero. apply CRle_refl.
+    apply CR_of_Q_lt. reflexivity. apply CRle_refl.
 Qed.
 
 (* In finite integration spaces, like probability spaces, measurable is
@@ -204,13 +202,13 @@ Proof.
       simpl. destruct xD. destruct d.
       2: contradict n; exact (incl x a). destruct d0.
       rewrite CRmult_1_l, CRmin_left, CRmax_left. reflexivity.
-      rewrite <- CR_of_Q_one. apply CR_of_Q_le. discriminate.
-      rewrite CR_of_Q_one. apply CRle_refl. contradiction.
+      apply CR_of_Q_le. discriminate.
+      apply CRle_refl. contradiction.
     + (* not in A *)
       simpl. destruct xD. destruct d0. contradiction.
       rewrite CRmult_0_r, CRmin_left, CRmax_left. reflexivity.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
 Qed.
 
 Lemma TruncOpp : forall {R : ConstructiveReals} (x : CRcarrier R) (k : positive),
@@ -220,12 +218,12 @@ Lemma TruncOpp : forall {R : ConstructiveReals} (x : CRcarrier R) (k : positive)
              (CR_of_Q _ (Z.neg k # 1)).
 Proof.
   intros. destruct (CRltLinear R).
-  setoid_replace (-x) with (-CRone R * x).
+  setoid_replace (-x) with (-(1) * x).
   destruct (s (CR_of_Q R (Z.neg k # 1)) x 0).
-  rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+  apply CR_of_Q_lt. reflexivity.
   rewrite CRmax_left, (CRmin_left (- (1) * x)).
   - setoid_replace (CR_of_Q R (Z.neg k # 1))
-      with (-CRone R * CR_of_Q R (Z.pos k # 1)).
+      with (-(1) * CR_of_Q R (Z.pos k # 1)).
     rewrite CRmax_min_mult_neg. rewrite <- CRopp_mult_distr_l.
     rewrite CRmult_1_l. reflexivity.
     apply (CRplus_le_reg_l 1). rewrite CRplus_opp_r, CRplus_0_r.
@@ -240,19 +238,19 @@ Proof.
   - apply CRmin_glb. apply CRlt_asym, c. apply CR_of_Q_le. discriminate.
   - rewrite CRmin_left, (CRmax_left (CRmin (- (1) * x) (CR_of_Q R (Z.pos k # 1)))).
     setoid_replace (CR_of_Q R (Z.pos k # 1))
-      with (-CRone R * CR_of_Q R (Z.neg k # 1)).
+      with (-(1) * CR_of_Q R (Z.neg k # 1)).
     rewrite CRmin_max_mult_neg, <- CRopp_mult_distr_l, CRmult_1_l. reflexivity.
     apply (CRplus_le_reg_l 1). rewrite CRplus_opp_r, CRplus_0_r.
     apply CRlt_asym, CRzero_lt_one.
     rewrite <- CRopp_mult_distr_l, CRmult_1_l, <- CR_of_Q_opp.
     apply CR_of_Q_morph. reflexivity.
     apply CRmin_glb. apply (CRle_trans _ 0).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
     rewrite <- CRopp_mult_distr_l, CRmult_1_l, <- CRopp_0.
     apply CRopp_ge_le_contravar, CRlt_asym, c.
     apply CR_of_Q_le. discriminate.
     apply (CRle_trans _ 0). apply CRlt_asym, c.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
   - rewrite <- CRopp_mult_distr_l, CRmult_1_l. reflexivity.
 Qed.
 
@@ -269,11 +267,11 @@ Proof.
   rewrite (CRmin_left (CRmin 0 y)).
   - destruct (CRltLinear R).
     destruct (s (CR_of_Q R (Z.neg k # 1)) y 0).
-    + rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+    + apply CR_of_Q_lt. reflexivity.
     + rewrite (CRmax_left (CRmin y (CR_of_Q R (Z.pos k # 1)))).
       rewrite (CRmax_left (CRmin 0 y)).
       destruct (s 0 y (CR_of_Q R (Z.pos k # 1))).
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+      apply CR_of_Q_lt. reflexivity.
       rewrite CRmax_right, (CRmin_left 0 y). rewrite CRplus_0_r. reflexivity.
       apply CRlt_asym, c0. apply CRlt_asym, c0.
       rewrite (CRmin_left y), CRmin_left.
@@ -282,28 +280,26 @@ Proof.
       unfold CRminus. rewrite CRplus_assoc, <- (CRplus_comm (- CRabs R (y + - 0))).
       rewrite <- (CRplus_assoc (CRabs R (y + - 0))), CRplus_opp_r, CRplus_0_l.
       apply (CRmult_eq_reg_r (CR_of_Q R 2)).
-      left. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+      left. apply CR_of_Q_lt. reflexivity.
       rewrite CRmult_assoc, <- CR_of_Q_mult.
       setoid_replace ((1 # 2) * 2)%Q with 1%Q. 2: reflexivity.
-      rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_1_r, CRmult_plus_distr_l.
+      rewrite (CR_of_Q_plus R 1 1), CRmult_1_r, CRmult_plus_distr_l.
       rewrite CRmult_1_r. reflexivity.
-      apply CRmax_lub.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CRmax_lub. apply CR_of_Q_le. discriminate.
       apply CRlt_asym, c0. apply CRlt_asym, c0.
-      apply CRmin_glb.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CRmin_glb. apply CR_of_Q_le. discriminate.
       apply CRlt_asym, c. apply CRmin_glb.
       apply CRlt_asym, c. apply CR_of_Q_le. discriminate.
     + rewrite (CRmax_left 0 y). rewrite (CRmin_right 0 y).
       rewrite CRmin_left, CRplus_0_l. rewrite CRmin_left. reflexivity.
       apply (CRle_trans _ 0). apply CRlt_asym, c.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
       apply CRlt_asym, c. apply CRlt_asym, c.
   - apply (CRle_trans _ 0). apply CRmin_l.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
   - apply CRmin_glb. apply (CRle_trans _ 0).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. apply CRmax_l.
+    apply CR_of_Q_le. discriminate. apply CRmax_l.
     apply CR_of_Q_le. discriminate.
 Qed.
 
@@ -325,10 +321,10 @@ Proof.
   - split. intros x xdf. simpl. simpl in xdf. destruct xdf. split.
     apply p. apply p. intros. simpl.
     destruct xD, d, d0, d1, d2, xG.
-    setoid_replace (if d5 then CRone (RealT (ElemFunc IS)) else 0)
-      with (if d then CRone (RealT (ElemFunc IS)) else 0).
-    setoid_replace (if d0 then CRone (RealT (ElemFunc IS)) else 0)
-      with (if d then CRone (RealT (ElemFunc IS)) else 0).
+    setoid_replace (if d5 then CR_of_Q (RealT (ElemFunc IS)) 1 else 0)
+      with (if d then CR_of_Q (RealT (ElemFunc IS)) 1 else 0).
+    setoid_replace (if d0 then CR_of_Q (RealT (ElemFunc IS)) 1 else 0)
+      with (if d then CR_of_Q (RealT (ElemFunc IS)) 1 else 0).
     destruct d.
     + rewrite CRmult_1_l, CRmult_1_l, CRmult_1_l.
       rewrite (DomainProp f x d6 d1), (DomainProp f x d4 d1),
@@ -344,8 +340,8 @@ Proof.
       rewrite <- H. clear H. apply TruncPosNeg.
     + rewrite CRmult_0_l, CRmult_0_l, CRmult_0_l.
       rewrite CRmin_left, CRmax_left, CRplus_0_l, CRmult_0_r. reflexivity.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
     + destruct d0. destruct d. reflexivity. contradiction. destruct d.
       contradiction. reflexivity.
     + destruct d5. destruct d. reflexivity. contradiction. destruct d.
@@ -572,7 +568,7 @@ Proof.
       apply Rcauchy_complete_cv.
       intro p. exists n. intros. destruct (xnD i).
       unfold CRminus. rewrite CRplus_opp_r.
-      rewrite CRabs_right, <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      rewrite CRabs_right. apply CR_of_Q_le. discriminate.
       apply CRle_refl. exfalso. apply n0. repeat split.
       3: exact a.
       rewrite <- (CRopp_involutive x).
@@ -589,7 +585,7 @@ Proof.
       intros. destruct (xnD i). exfalso.
       destruct a, H2. contradiction.
       unfold CRminus. rewrite CRopp_0, CRplus_0_r.
-      rewrite CRabs_right. rewrite <- CR_of_Q_zero.
+      rewrite CRabs_right. 
       apply CR_of_Q_le. discriminate. apply CRle_refl.
 Qed.
 
@@ -679,7 +675,7 @@ Proof.
     rewrite CRmult_1_l, CRmult_1_r. apply CRmax_lub.
     apply CRmin_r. apply CR_of_Q_le. discriminate.
     destruct d. contradiction. rewrite CRmult_0_l, CRmult_0_r.
-    apply CRmax_lub. apply CRmin_l. rewrite <- CR_of_Q_zero.
+    apply CRmax_lub. apply CRmin_l. 
     apply CR_of_Q_le. discriminate.
     rewrite IntegralScale. apply CRle_refl. }
   destruct (CR_complete _ _ (cl _ (fun n => Integral (fnMes n A k Aint))
@@ -713,12 +709,12 @@ Proof.
     intro n. simpl. destruct (x1 n), d. rewrite CRmult_1_l. apply DomainProp.
     contradiction. apply H3. reflexivity.
   - setoid_replace (partialApply (Xmult (CharacFunc A) (XpointwiseLimit fn)) x0 (right n, d0))
-      with (CRzero (RealT (ElemFunc IS))).
+      with (CR_of_Q (RealT (ElemFunc IS)) 0).
     2: simpl; rewrite CRmult_0_l; reflexivity.
     apply (CR_cv_eq _ (fun _ => 0)). intros.
     simpl. destruct (x1 n0), d. contradiction. rewrite CRmult_0_l. reflexivity.
     intro p. exists O. intros. unfold CRminus.
-    rewrite CRplus_opp_r, CRabs_right, <- CR_of_Q_zero.
+    rewrite CRplus_opp_r, CRabs_right.
     apply CR_of_Q_le. discriminate. apply CRle_refl.
 Qed.
 
@@ -850,7 +846,7 @@ Proof.
     rewrite <- CRopp_mult_distr_l, CRmult_1_l, (DomainProp f x d1 d).
     rewrite CRplus_opp_r, CRabs_right. apply CRle_refl. apply CRle_refl.
     simpl. apply CRmin_glb. apply CRabs_pos.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
   - (* |f x| < t *)
     apply (CRle_trans _ (CRabs _ (partialApply f x d))).
     simpl. rewrite CRmult_0_l, CRmult_0_r, CRplus_0_r. apply CRle_refl.
@@ -861,7 +857,7 @@ Proof.
     apply (CRle_trans _ _ _ H0). apply CRlt_asym.
     apply (CRlt_le_trans _ _ _ tmin). apply CRmin_l.
   - apply IntegralNonNeg. intros x xdf. apply CRmin_glb.
-    apply CRabs_pos. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CRabs_pos. apply CR_of_Q_le. discriminate.
 Qed.
 
 Definition RestrictedMeasurable_pos
@@ -940,7 +936,7 @@ Proof.
       rewrite CRmult_0_r, CRplus_0_r, CRabs_right.
       apply CRabs_pos. apply CRle_refl.
     + apply (CRle_trans _ _ _ (IntegralDistance_triang _ _ _ _ fInt _)).
-      rewrite (CR_of_Q_plus _ 1 1), CR_of_Q_one, CRmult_plus_distr_l.
+      rewrite (CR_of_Q_plus _ 1 1), CRmult_plus_distr_l.
       rewrite CRmult_1_r. apply CRplus_le_compat. generalize (gnInt (S n)).
       intro i. simpl in i. destruct (Bn (S n)), p, i0.
       apply CRlt_asym, (CRlt_trans _ (CRpow (CR_of_Q (RealT (ElemFunc IS)) (1 # 2)) (S n))).
@@ -951,7 +947,7 @@ Proof.
                               * CRpow (CR_of_Q (RealT (ElemFunc IS)) (1 # 2)) n)).
       apply CRmult_lt_compat_r. apply pow_lt, CR_of_Q_pos. reflexivity.
       apply CR_of_Q_lt. reflexivity.
-      rewrite CR_of_Q_one, CRmult_1_l. apply CRle_refl.
+      rewrite CRmult_1_l. apply CRle_refl.
       generalize (gnInt n).
       intro i. simpl in i. destruct (Bn n), p, i0.
       apply CRlt_asym. refine (CRle_lt_trans _ _ _ _ c0).
@@ -981,13 +977,13 @@ Proof.
         simpl. rewrite (DomainProp f x d2 d0). clear d2.
         destruct d. destruct d1. unfold CRminus.
         rewrite CRplus_opp_r, CRabs_right.
-        rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. apply CRle_refl.
+        apply CR_of_Q_le. discriminate. apply CRle_refl.
         contradict n0. split. exact a. exists d0.
         apply CRlt_asym, (CRlt_trans _ _ _ c0), (CRlt_le_trans _ _ _ nmaj). 
         apply CRle_abs. destruct d1. destruct a. contradiction.
         unfold CRminus.
         rewrite CRmult_0_l, CRplus_opp_r, CRabs_right.
-        rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. apply CRle_refl.
+        apply CR_of_Q_le. discriminate. apply CRle_refl.
       * (* f x < 1 / 2p *)
         exists O. intros.
         apply (CRle_trans _ _ _ (CRabs_triang _ _)).
@@ -997,13 +993,11 @@ Proof.
         destruct dF, (x0 i). simpl. destruct d1.
         rewrite CRmult_1_l, CRabs_right, (DomainProp f x d2 d0).
         apply CRlt_asym, c. apply fPos. rewrite CRmult_0_l, CRabs_right.
-        rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-        apply CRle_refl. 
+        apply CR_of_Q_le. discriminate. apply CRle_refl. 
         rewrite CRabs_opp. simpl. destruct d.
         rewrite CRmult_1_l, CRabs_right. apply CRlt_asym, c.
         apply fPos. rewrite CRmult_0_l, CRabs_right.
-        rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-        apply CRle_refl. 
+        apply CR_of_Q_le. discriminate. apply CRle_refl. 
 Qed.
 
 Definition RestrictedMeasurable
@@ -1179,8 +1173,7 @@ Proof.
     destruct (IntegrableApproxSequence gen A Aint i).
     apply CRlt_asym, X.
     unfold CRminus in ncv. rewrite CRopp_0, CRplus_0_r, CRabs_right in ncv.
-    exact ncv. apply pow_le. rewrite <- CR_of_Q_zero.
-    apply CR_of_Q_le. discriminate.
+    exact ncv. apply pow_le. apply CR_of_Q_le. discriminate.
   - rewrite <- (CRplus_opp_r (MeasureSet Aint)).
     apply CRplus_le_compat_l, CRopp_ge_le_contravar.
     apply MeasureNonDecreasing. intros. apply applyUnionIterate in H0.
@@ -1317,8 +1310,8 @@ Proof.
       do 2 rewrite CRmult_1_l. rewrite (DomainProp f x d0 (snd (xkD 0%nat))).
       reflexivity. simpl. rewrite CRmult_0_l, CRmult_0_l.
       rewrite CRmin_left, CRmax_left. reflexivity.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. } 
+      apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate. } 
   destruct (series_cv_maj (fun k : nat => Integral (IntegrableAbs (fkInt k)))
                           (fun k => match k with
                                  | O => MeasureSet (BkInt O)
@@ -1341,11 +1334,11 @@ Proof.
     contradiction. contradiction.
     rewrite CRmult_0_l, CRmult_0_r. rewrite CRmin_left, CRmax_left, CRabs_right.
     apply CRle_refl. apply CRle_refl.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
     rewrite IntegralScale, CRmult_comm.
     destruct k. rewrite CRmult_comm. apply CRle_refl.
-    rewrite CRmult_comm. apply CRmult_le_compat_r. rewrite <- CR_of_Q_zero.
+    rewrite CRmult_comm. apply CRmult_le_compat_r. 
     apply CR_of_Q_le. discriminate. exact (BkMaj k).
     apply IntegralNonNeg. intros x xdf. apply CRabs_pos.
   - apply series_cv_scale.
@@ -1380,12 +1373,12 @@ Proof.
       clear n0. destruct e. apply applyInfiniteSumAbs. intro p.
       exists x0. intros. rewrite (fkDisjoint i0 x0 x _ dG).
       unfold CRminus. rewrite CRplus_opp_r, CRabs_right.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
       apply CRle_refl. exact H. exact H0.
       (* Outside A *)
       assert (~ A x).
       { intro abs. apply n0. split; assumption. }
-      clear n1 n0 i d0 h. transitivity (CRzero (RealT (ElemFunc IS))).
+      clear n1 n0 i d0 h. transitivity (CR_of_Q (RealT (ElemFunc IS)) 0).
       apply applyInfiniteSumAbs.
       apply (CR_cv_eq _ (fun _ => 0)). 2: apply CR_cv_const.
       intros. rewrite <- (CRmult_0_l (INR (S n0))).
@@ -1405,12 +1398,12 @@ Proof.
       destruct (IntegrableApproxSequence gen A Aint i).
       exact (proj1 (sa_inc _ _ _ _ x b)). 
       rewrite CRmult_0_l, CRmin_left, CRmax_left. reflexivity.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
       simpl. destruct dG, d. contradiction.
       rewrite CRmult_0_l, CRmin_left, CRmax_left. reflexivity.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
     + exists rep. apply PartialRestriction_refl. 
 Qed.
 
@@ -1504,7 +1497,7 @@ Proof.
     apply series_cv_scale. exact GeoHalfTwo.
     rewrite <- CRmult_assoc, <- CRmult_assoc, <- (CR_of_Q_mult _ 2).
     setoid_replace (2 * (1#2))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_l. reflexivity. reflexivity.
+    rewrite CRmult_1_l. reflexivity. reflexivity.
     destruct p. simpl in c0. apply CR_cv_opp in c.
     apply (CR_cv_eq (fun n : nat => MeasureSet
            (IntegrableSetIntersectIterate
@@ -1526,7 +1519,7 @@ Proof.
     apply CRplus_lt_compat_r. apply sa_mes.
     rewrite CRmult_1_r, CRmult_comm, <- CRmult_plus_distr_r, <- CR_of_Q_plus.
     setoid_replace ((1 # 2) + (1 # 2))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_l. apply CRle_refl. reflexivity.
+    rewrite CRmult_1_l. apply CRle_refl. reflexivity.
     intro n. apply CRopp_involutive. }
   assert (forall (x : X (ElemFunc IS)), (forall i : nat, Bi i x) -> A x).
   { intros. unfold Bi in H1. exact (sa_inc _ _ _ _ x (H1 O)). }
@@ -1577,7 +1570,7 @@ Proof.
              (fst x0)) x (snd xdf))).
       apply (CRle_trans _ _ _ (CRabs_triang _ _)).
       rewrite applyXplus, applyXscale, CRmult_0_l, CRplus_0_l.
-      rewrite applyXscale, (CR_of_Q_plus _ 1 1), CR_of_Q_one.
+      rewrite applyXscale, (CR_of_Q_plus _ 1 1).
       rewrite CRmult_plus_distr_r, CRmult_plus_distr_r, CRmult_1_l.
       apply CRplus_le_compat.
       destruct xdf, d1, d0, d0. simpl.
@@ -1594,10 +1587,10 @@ Proof.
       apply c. exact bSn.
       simpl. rewrite <- CRmult_assoc.
       rewrite <- CRmult_assoc. apply CRmult_le_compat_r.
-      apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply pow_le. apply CR_of_Q_le. discriminate.
       rewrite <- (CRmult_1_r eps), CRmult_assoc, CRmult_assoc.
       apply CRmult_le_compat_l. apply CRlt_asym, epsPos.
-      rewrite CRmult_1_l, <- CR_of_Q_one, <- CR_of_Q_mult.
+      rewrite CRmult_1_l, <- CR_of_Q_mult.
       apply CR_of_Q_le. discriminate.
       contradiction. 
       destruct xdf, d1, d1. simpl. rewrite CRmult_1_r, CRmult_1_l.
@@ -1607,9 +1600,8 @@ Proof.
       exact bn. apply CRmult_le_compat_l. apply CRlt_asym, epsPos.
       rewrite <- (CRmult_1_l (CRpow (CR_of_Q (RealT (ElemFunc IS)) (1 # 2)) n)).
       apply CRmult_le_compat_r.
-      apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-      rewrite <- CR_of_Q_one. apply CR_of_Q_le. discriminate.
-      contradiction.
+      apply pow_le. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate. contradiction.
       unfold CRminus. rewrite CRplus_assoc. 
       destruct xdf.
       rewrite (applyXminus (Xmult
@@ -1679,14 +1671,14 @@ Proof.
       rewrite <- (CRmult_1_l (CRpow (CR_of_Q _ (1 # 2)) j)).
       replace (S (x2 + j)) with (S x2 + j)%nat. 2: reflexivity.
       rewrite <- pow_plus_distr. apply CRmult_le_compat_r.
-      apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply pow_le. apply CR_of_Q_le. discriminate.
       apply (CRmult_le_reg_l (CRpow (CR_of_Q _ 2) (S x2))).
       apply pow_lt, CR_of_Q_pos. reflexivity. rewrite pow_mult.
       rewrite <- (pow_proper 1). rewrite pow_one, CRmult_1_r.
-      apply pow_R1_Rle. rewrite <- CR_of_Q_one. apply CR_of_Q_le. discriminate.
-      rewrite <- CR_of_Q_mult, <- CR_of_Q_one. apply CR_of_Q_morph. reflexivity.
+      apply pow_R1_Rle. apply CR_of_Q_le. discriminate.
+      rewrite <- CR_of_Q_mult. apply CR_of_Q_morph. reflexivity.
       apply CRmult_le_0_compat. 
-      apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply pow_le. apply CR_of_Q_le. discriminate.
       apply CRlt_asym, epsPos.
       (* Outside the intersection, 0 == 0. *)
       unfold sa_approx in n. apply (CR_cv_eq _ (fun _ => 0)).
@@ -1694,8 +1686,8 @@ Proof.
       contradiction. rewrite CRmult_0_l. reflexivity.
       apply (CR_cv_proper _ 0). apply CR_cv_const.
       simpl. rewrite CRmult_0_l, CRmin_left, CRmax_left. reflexivity.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
 Qed.
 
 (* The convergence in measure of a series of functions.
@@ -1850,7 +1842,7 @@ Proof.
       apply (CRle_trans _ (eps * CR_of_Q (RealT (ElemFunc IS)) (1 # 2) * 1)).
       2: rewrite CRmult_1_r; apply CRle_refl.
       apply CRmult_le_compat_l. apply CRmult_le_0_compat.
-      apply CRlt_asym, epsPos. rewrite <- CR_of_Q_zero.
+      apply CRlt_asym, epsPos. 
       apply CR_of_Q_le. discriminate.
       apply (CRmult_le_reg_l (MeasureSet idom_int0 + 1) _ _ H).
       rewrite CRmult_1_r, <- CRmult_assoc, CRinv_r, CRmult_1_l.
@@ -1859,7 +1851,7 @@ Proof.
       apply CRplus_le_compat_l. apply CRlt_asym, CRzero_lt_one.
     + rewrite <- CRmult_plus_distr_l, <- CR_of_Q_plus.
       setoid_replace ((1 # 2) + (1 # 2))%Q with 1%Q. 2: reflexivity.
-      rewrite CR_of_Q_one, CRmult_1_r. apply CRle_refl.
+      rewrite CRmult_1_r. apply CRle_refl.
 Qed.
 
 Lemma DominatedConvergence
@@ -1978,7 +1970,7 @@ Proof.
         destruct d. rewrite CRmult_1_l. destruct xdg.
         rewrite CRmult_1_r. apply CRmin_r. contradiction.
         rewrite CRmult_0_l. destruct xdg.
-        rewrite CRmult_1_r, <- CR_of_Q_zero. apply CR_of_Q_le.
+        rewrite CRmult_1_r. apply CR_of_Q_le.
         destruct n; discriminate. rewrite CRmult_0_r. apply CRle_refl.
         refine (CRle_trans _ _ _ _ nmaj).
         rewrite <- IntegralMinus, <- IntegralMinus. apply IntegralNonDecreasing.
@@ -2006,8 +1998,7 @@ Proof.
         apply CR_of_Q_pos. reflexivity.
         rewrite CRmult_assoc, <- CR_of_Q_mult.
         setoid_replace ((Z.of_nat (S n) # 1) * (1 # Pos.of_nat (S n)))%Q with 1%Q.
-        rewrite CR_of_Q_one, CRmult_1_r.
-        rewrite CRmult_assoc, <- CR_of_Q_mult.
+        rewrite CRmult_1_r, CRmult_assoc, <- CR_of_Q_mult.
         setoid_replace ((1 # 4) * (1 # Pos.of_nat (S n)))%Q
           with (1 # 4 * Pos.of_nat (S n))%Q.
         apply CRlt_asym, H0. reflexivity.
@@ -2032,8 +2023,7 @@ Proof.
         rewrite (DomainProp g x d1 d0), (DomainProp f x d4 d3).
         apply CRle_abs. rewrite <- CRmult_plus_distr_l, <- CR_of_Q_plus.
         setoid_replace ((1 # 2) + (1 # 2))%Q with 1%Q.
-        rewrite CR_of_Q_one, CRmult_1_r. apply CRle_refl.
-        reflexivity. }
+        rewrite CRmult_1_r. apply CRle_refl. reflexivity. }
   intro p.
   destruct (DominatedMeasureCvZero
               (fun n : nat => Xabs (Xminus (fn n) f))

--- a/reals/stdlib/CMTPositivity.v
+++ b/reals/stdlib/CMTPositivity.v
@@ -155,7 +155,7 @@ Proof.
   - simpl. rewrite Nat.add_0_r, pow_mult.
     rewrite (pow_proper (CR_of_Q R 2 * CR_of_Q R (1 # 2)) 1).
     apply pow_one. rewrite <- CR_of_Q_mult.
-    setoid_replace (2 * (1 # 2))%Q with 1%Q. apply CR_of_Q_one. reflexivity.
+    setoid_replace (2 * (1 # 2))%Q with 1%Q. reflexivity. reflexivity.
   - rewrite Nat.add_succ_r.
     transitivity (CRpow (CR_of_Q R 2) n * (CR_of_Q R (1 # 2) * CRpow (CR_of_Q R (1 # 2)) (n + p))).
     reflexivity. rewrite <- CRmult_assoc.
@@ -249,7 +249,7 @@ Proof.
     rewrite applyXscale. rewrite <- (CRmult_0_r (CRpow (CR_of_Q _ 2) (k/2))).
     apply CRmult_le_compat_l.
     apply CRlt_asym, pow_lt. simpl.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+    apply CR_of_Q_lt. reflexivity.
     apply nonNegSumFunc. intros. apply nonneg. }
   destruct (cont seq seqL seqPos) as [x xgood].
   - destruct (series_cv_maj
@@ -277,7 +277,7 @@ Proof.
                             + CRabs _ (CRsum (fun k : nat => I (fn k) (fnL k))
                                                 (pred (n (S (S n0)))) - l)))).
       apply CRmult_le_compat_l.
-      apply CRlt_asym, pow_lt. simpl. rewrite <- CR_of_Q_zero.
+      apply CRlt_asym, pow_lt. simpl. 
       apply CR_of_Q_lt. reflexivity.
       apply CRabs_triang. rewrite CRmult_plus_distr_l.
       apply (CRle_trans
@@ -285,7 +285,7 @@ Proof.
                   + (CRpow (CR_of_Q _ 2) n0) * CRpow (CR_of_Q _ (1#2)) (2 * (S n0) + 2) * alpha)).
       apply CRplus_le_compat.
       rewrite CRmult_assoc. apply CRmult_le_compat_l.
-      apply CRlt_asym, pow_lt. simpl. rewrite <- CR_of_Q_zero.
+      apply CRlt_asym, pow_lt. simpl. 
       apply CR_of_Q_lt. reflexivity.
       replace n1 with (pred (n (S n0))). 2: rewrite des; reflexivity.
       unfold n, PrependSeq, proj1_sig, pred.
@@ -294,7 +294,7 @@ Proof.
                                 lcv boundPos n0).
       apply CRlt_asym. rewrite CRabs_minus_sym. exact c.
       rewrite CRmult_assoc. apply CRmult_le_compat_l.
-      apply CRlt_asym, pow_lt. simpl. rewrite <- CR_of_Q_zero.
+      apply CRlt_asym, pow_lt. simpl. 
       apply CR_of_Q_lt. reflexivity.
       unfold n, PrependSeq, proj1_sig, pred.
       destruct (ControlSubSeqCv (CRsum (fun n2 : nat => I (fn n2) (fnL n2))) l
@@ -314,9 +314,9 @@ Proof.
       apply CRle_refl.
       do 2 rewrite <- CRmult_assoc.
       rewrite <- CRmult_plus_distr_r. apply CRmult_le_compat_r.
-      apply CRlt_asym, pow_lt. simpl. rewrite <- CR_of_Q_zero.
+      apply CRlt_asym, pow_lt. simpl. 
       apply CR_of_Q_lt. reflexivity.
-      rewrite <- CR_of_Q_mult, <- CR_of_Q_mult, <- CR_of_Q_plus, <- CR_of_Q_one.
+      rewrite <- CR_of_Q_mult, <- CR_of_Q_mult, <- CR_of_Q_plus.
       apply CR_of_Q_le. discriminate.
       rewrite Nat.add_comm. simpl. apply f_equal.
       rewrite <- (Nat.add_comm (S (n0 + 0))). simpl. apply f_equal.
@@ -333,7 +333,7 @@ Proof.
       apply le_S, le_refl. exact (ninc (S n0)).
       rewrite <- des. apply Nat.le_add_le_sub_r. apply ninc.
       apply CRlt_asym, pow_lt. simpl.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+      apply CR_of_Q_lt. reflexivity.
     + apply (CR_cv_proper _ (1*alpha)).
       apply series_cv_scale.
       apply (series_cv_eq (fun n0 : nat => CRpow (CR_of_Q _ (1 # 2)) n0 * CR_of_Q _ (1#2))).
@@ -341,7 +341,7 @@ Proof.
       apply (CR_cv_proper _ (CR_of_Q _ 2 * CR_of_Q _ (1#2))).
       apply series_cv_scale, GeoHalfTwo.
       rewrite <- CR_of_Q_mult. setoid_replace (2 * (1 # 2))%Q with 1%Q.
-      apply CR_of_Q_one. reflexivity. apply CRmult_1_l.
+      reflexivity. reflexivity. apply CRmult_1_l.
     + clear cont. exists (alpha * I Z ZL + (l + x)). destruct p. split.
       apply (series_cv_eq
                (PrependSeq (alpha * (I Z ZL))
@@ -398,11 +398,11 @@ Proof.
       apply (CRle_lt_trans _ (CRpow (CR_of_Q _ (1 # 2)) 0 * partialApply f x xf)).
       unfold CRpow. rewrite CRmult_1_l. apply CRle_refl.
       apply (CRlt_le_trans _ _ _ abs). apply CRmult_le_compat_l.
-      apply CRlt_asym, pow_lt. simpl. rewrite <- CR_of_Q_zero.
+      apply CRlt_asym, pow_lt. simpl. 
       apply CR_of_Q_lt; reflexivity.
       rewrite <- Nat.sub_1_r. rewrite Nat.add_0_r. apply sum_Rle. intros.
       rewrite Nat.add_comm. apply CRle_refl.
-      apply pow_lt. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+      apply pow_lt. apply CR_of_Q_lt. reflexivity.
     + apply PrependSeqSeries, series_cv_scale, GeoHalfTwo.
     + clear seqL. destruct p as [i _].
       pose proof (infinite_sum_assoc
@@ -443,7 +443,7 @@ Proof.
       simpl in H2. simpl. rewrite H2. apply CRle_refl. auto.
       apply cond_pos_sum. intros.
       rewrite <- (CRmult_0_r (CRpow (CR_of_Q _ 2) k)). apply CRmult_le_compat_l.
-      apply CRlt_asym, pow_lt. simpl. rewrite <- CR_of_Q_zero.
+      apply CRlt_asym, pow_lt. simpl. 
       apply CR_of_Q_lt; reflexivity. apply cond_pos_sum.
       intros. apply nonneg.
       intros.

--- a/reals/stdlib/CMTProductIntegral.v
+++ b/reals/stdlib/CMTProductIntegral.v
@@ -2102,8 +2102,8 @@ Proof.
   unfold Qeq, Qnum, Qden. rewrite Z.mul_1_l.
   rewrite Pos2Z.inj_mul, Z.mul_comm.
   unfold Z.of_nat. simpl. destruct n. exfalso.
-  simpl in nup. rewrite CR_of_Q_zero in nup. exact (CRabs_pos a nup).
-  rewrite Pos.of_nat_succ. reflexivity. rewrite <- CR_of_Q_zero.
+  simpl in nup. exact (CRabs_pos a nup).
+  rewrite Pos.of_nat_succ. reflexivity. 
   apply CR_of_Q_le. unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
   apply Zle_0_nat.
 Qed.
@@ -2152,7 +2152,7 @@ Proof.
     intros x0 xdf. simpl. apply (@IntegralNonNeg (IntegrationSpaceCast J)).
     intros x1 xdf0. simpl. destruct p.
     rewrite (c _ xdf0 (d _ xdf0)).
-    apply CRmin_glb. apply H. rewrite <- CR_of_Q_zero.
+    apply CRmin_glb. apply H. 
     apply CR_of_Q_le. discriminate.
   - intro n. generalize (ProdIntegrableSimplify l).
     induction l0. simpl (fold_right (CRplus _) 0
@@ -2180,8 +2180,7 @@ Proof.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden.
     do 2 rewrite Z.mul_1_l. apply Pos2Z.pos_le_pos, Pos2Nat.inj_le.
     rewrite Nat2Pos.id. 2: discriminate. apply (le_trans _ _ _ H1).
-    apply le_S, le_refl. rewrite <- CR_of_Q_zero.
-    apply CR_of_Q_le. discriminate.
+    apply le_S, le_refl. apply CR_of_Q_le. discriminate.
 Qed.
 
 Lemma ProductMinLimits
@@ -2208,8 +2207,8 @@ Proof.
        (LminIntStable i f
           (existT (fun l0 : list ProdIntegrable => PartialRestriction (ProdLFunc l0) f) l fL)) -
                     IElemProduct f (existT (fun l0 : list ProdIntegrable => PartialRestriction (ProdLFunc l0) f) l fL))
-      with (CRzero (RealT (ElemFunc I))).
-    rewrite CRabs_right. rewrite <- CR_of_Q_zero.
+      with (CR_of_Q (RealT (ElemFunc I)) 0).
+    rewrite CRabs_right. 
     apply CR_of_Q_le. discriminate. apply CRle_refl.
     rewrite <- (CRplus_opp_r (IElemProduct f (existT (fun l0 : list ProdIntegrable => PartialRestriction (ProdLFunc l0) f) l fL))).
     apply CRplus_morph. 2: reflexivity.

--- a/reals/stdlib/CMTReals.v
+++ b/reals/stdlib/CMTReals.v
@@ -458,13 +458,13 @@ Proof.
   { apply (CRmult_le_reg_r (CR_of_Q R 2)). apply CR_of_Q_pos. reflexivity.
     rewrite CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((1 # 2) * 2)%Q with 1%Q. 2: reflexivity.
-    rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_plus_distr_l, CRmult_1_r, CRmult_1_r.
+    rewrite (CR_of_Q_plus R 1 1), CRmult_plus_distr_l, CRmult_1_r, CRmult_1_r.
     apply CRplus_le_compat_l. exact lexy0. }
   assert ((x0+y0) * CR_of_Q R (1#2) <= y0).
   { apply (CRmult_le_reg_r (CR_of_Q R 2)). apply CR_of_Q_pos. reflexivity.
     rewrite CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((1 # 2) * 2)%Q with 1%Q. 2: reflexivity.
-    rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_plus_distr_l, CRmult_1_r, CRmult_1_r.
+    rewrite (CR_of_Q_plus R 1 1), CRmult_plus_distr_l, CRmult_1_r, CRmult_1_r.
     apply CRplus_le_compat_r. exact lexy0. }
   destruct (LocalizeIntegralSeries
               x0 y0 x0 ((x0+y0)*CR_of_Q R (1#2)) x1 lexy0 H (CRle_refl x0)).
@@ -490,7 +490,7 @@ Proof.
     rewrite CRmult_assoc, <- CR_of_Q_mult.
     rewrite CRmult_plus_distr_r, CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((1 # 2) * 2)%Q with 1%Q. 2: reflexivity.
-    rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_1_r, CRmult_1_r, CRmult_1_r.
+    rewrite (CR_of_Q_plus R 1 1), CRmult_1_r, CRmult_1_r, CRmult_1_r.
     rewrite (CRplus_comm x0), CRplus_assoc. apply CRplus_le_compat_l.
     rewrite CRmult_plus_distr_l, CRmult_1_r, <- CRplus_assoc, CRplus_opp_r.
     rewrite CRplus_0_l. apply CRle_refl. }
@@ -508,7 +508,7 @@ Proof.
     rewrite CRmult_plus_distr_r, CRmult_assoc, <- CR_of_Q_mult.
     rewrite CRmult_plus_distr_r, CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((1 # 2) * 2)%Q with 1%Q. 2: reflexivity.
-    rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_1_r, CRmult_1_r, CRmult_1_r.
+    rewrite (CR_of_Q_plus R 1 1), CRmult_1_r, CRmult_1_r, CRmult_1_r.
     rewrite (CRplus_comm x0), CRplus_assoc. apply CRplus_le_compat_l.
     rewrite CRmult_plus_distr_l, CRmult_1_r, <- CRplus_assoc, CRplus_opp_r.
     rewrite CRplus_0_l. apply CRle_refl.
@@ -524,7 +524,7 @@ Proof.
     rewrite CRmult_assoc, <- CR_of_Q_mult.
     rewrite CRmult_plus_distr_r, CRopp_mult_distr_l, CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((1 # 2) * 2)%Q with 1%Q. 2: reflexivity.
-    rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_1_r, CRmult_1_r, CRmult_1_r.
+    rewrite (CR_of_Q_plus R 1 1), CRmult_1_r, CRmult_1_r, CRmult_1_r.
     rewrite CRopp_plus_distr.
     rewrite (CRplus_comm (-x0)), <- CRplus_assoc. apply CRplus_le_compat_r.
     rewrite CRmult_plus_distr_l, CRmult_1_r, CRplus_assoc, CRplus_opp_r.
@@ -535,7 +535,7 @@ Proof.
     rewrite CRopp_plus_distr, CRmult_plus_distr_r, CRopp_mult_distr_l, CRmult_assoc, <- CR_of_Q_mult.
     rewrite CRopp_mult_distr_l, CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((1 # 2) * 2)%Q with 1%Q. 2: reflexivity.
-    rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_1_r, CRmult_1_r, CRmult_1_r.
+    rewrite (CR_of_Q_plus R 1 1), CRmult_1_r, CRmult_1_r, CRmult_1_r.
     rewrite (CRplus_comm (-x0)), <- CRplus_assoc. apply CRplus_le_compat_r.
     rewrite CRmult_plus_distr_l, CRmult_1_r, CRplus_assoc, CRplus_opp_r.
     rewrite CRplus_0_r. apply CRle_refl.
@@ -569,7 +569,7 @@ Lemma CSUCposPointApproxSequenceLength
             == (b-a) * CR_of_Q R (/2^Z.of_nat n)).
 Proof.
   induction n.
-  - simpl. rewrite CR_of_Q_one, CRmult_1_r. reflexivity.
+  - simpl. rewrite CRmult_1_r. reflexivity.
   - rewrite Nat2Z.inj_succ. unfold Z.succ. rewrite Qpower_plus.
     simpl. destruct (CSUCposPointApproxStep n (CSUCposPointApproxSequence n)); simpl.
     destruct a0, H0. unfold Qdiv.
@@ -587,8 +587,7 @@ Lemma CSUCposPointApproxSequenceCvZero
 Proof.
   intros n.
   destruct (CRup_nat (b - a)) as [i imaj].
-  destruct i. exfalso.
-  simpl in imaj. rewrite CR_of_Q_zero in imaj.
+  destruct i. exfalso. simpl in imaj. 
   rewrite <- (CRplus_opp_r a) in imaj.
   apply CRplus_lt_reg_r in imaj. contradiction.
   destruct (@GeoCvZero R (Pos.of_nat (S i)*n)%positive) as [p pmaj].
@@ -701,7 +700,7 @@ Proof.
   assert (0 < p)%nat.
   { unfold INR in qpPos. destruct p. 2: apply le_n_S, le_0_n.
     exfalso. contradict qpPos. apply (CRle_trans _ (CR_of_Q R 0)).
-    apply CR_of_Q_le. discriminate. rewrite CR_of_Q_zero. apply CRle_refl. }
+    apply CR_of_Q_le. discriminate. apply CRle_refl. }
   destruct (CSUCposPointApproxSequenceCvZero (Pos.of_nat p)) as [i imaj].
   specialize (imaj i (le_refl i)). specialize (H i).
   destruct (CSUCposPointApproxSequence i); unfold x,y in imaj.
@@ -736,7 +735,7 @@ Proof.
   apply (CRmult_lt_reg_r (INR p)).
   exact qpPos.
   apply (CRle_lt_trans _ 1). 2: exact pmaj.
-  unfold INR. rewrite <- CR_of_Q_mult, <- CR_of_Q_one. apply CR_of_Q_le.
+  unfold INR. rewrite <- CR_of_Q_mult. apply CR_of_Q_le.
   unfold Qmult, Qle, Qden, Qnum. rewrite Z.mul_1_l, Z.mul_1_l, Pos.mul_1_r.
   rewrite Z.mul_1_r. rewrite <- positive_nat_Z.
   rewrite Nat2Pos.id. apply Z.le_refl. intro abs1.
@@ -998,7 +997,7 @@ Proof.
                f (XminConst f (INR (n + k))) fL feq).
     unfold TotalizeFunc. apply DomainProp.
     exists O. intros. unfold CRminus. rewrite CRplus_opp_r.
-    rewrite CRabs_right. rewrite <- CR_of_Q_zero. apply CR_of_Q_le; discriminate.
+    rewrite CRabs_right. apply CR_of_Q_le; discriminate.
     apply CRle_refl.
   - intros p.
     destruct (CRup_nat ((CSUC_high f fL - CSUC_low f fL )
@@ -1018,19 +1017,19 @@ Proof.
       apply (CRmult_le_compat_r (CR_of_Q R (1 # p))) in kmaj.
       rewrite CRmult_assoc, <- CR_of_Q_mult in kmaj.
       setoid_replace ((Z.pos p # 1) * (1 # p))%Q with 1%Q in kmaj.
-      rewrite CR_of_Q_one, CRmult_1_r in kmaj.
+      rewrite CRmult_1_r in kmaj.
       apply (CRmult_le_reg_l (CR_of_Q R (Z.of_nat (S n) #1))).
       apply CR_of_Q_pos; reflexivity.
       rewrite <- CRmult_assoc, <- CR_of_Q_mult.
       setoid_replace ((Z.of_nat (S n) # 1) * (1 # Pos.of_nat (S n)))%Q with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_l.
+      rewrite CRmult_1_l.
       apply (CRle_trans _ (INR k * CR_of_Q R (1#p))).
       apply (CRle_trans _ (CSUC_high f fL - CSUC_low f fL)).
       2: apply kmaj.
       unfold LminConstStable. rewrite <- CSUC_transport_low.
       rewrite <- CSUC_transport_high. destruct f, fL; apply CRle_refl.
       apply CRmult_le_compat_r.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le; discriminate.
+      apply CR_of_Q_le; discriminate.
       apply CR_of_Q_le. unfold Qle, Qnum, Qden.
       do 2 rewrite Z.mul_1_r. apply Nat2Z.inj_le, le_S, H.
       unfold Qmult, Qeq, Qnum, Qden.
@@ -1038,7 +1037,7 @@ Proof.
       rewrite <- positive_nat_Z, Nat2Pos.id. reflexivity. discriminate.
       unfold Qmult, Qeq, Qnum, Qden.
       rewrite Z.mul_1_r, Z.mul_1_r, Z.mul_1_l, Pos.mul_1_l. reflexivity.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
     + unfold IntegralCSUC.
       apply (UC_integral_pos
                (TotalizeFunc (CRcarrier R)
@@ -1051,7 +1050,7 @@ Proof.
       assert (Domain (Xabs f) x0).
       { destruct fL,f; apply CSUC_fullDomain0. }
       rewrite applyXminConst. apply CRmin_glb.
-      2: rewrite <- CR_of_Q_zero; apply CR_of_Q_le; discriminate.
+      2: apply CR_of_Q_le; discriminate.
       destruct f; apply CRabs_pos.
 Qed.
 
@@ -1060,7 +1059,7 @@ Lemma OneCSUC_IS_CSUC :
     Is_CSUC_func (PartializeFunc (CRcarrier R)
                                  (CSUCUnitTrapeze 0 0 1 (CRzero_lt_one R))).
 Proof.
-  intro R. assert (-(1) <= CRone R).
+  intro R. assert (-(1) <= CR_of_Q R 1).
   { apply (CRle_trans _ (-0)).
     apply CRopp_ge_le_contravar, CRlt_asym, CRzero_lt_one.
     rewrite CRopp_0. apply CRlt_asym, CRzero_lt_one. }
@@ -1089,10 +1088,10 @@ Lemma IntegralOneCSUC
                  OneCSUC_IS_CSUC == 1.
 Proof.
   intro R.
-  transitivity (CRone R + 0 - 0).
+  transitivity (CR_of_Q R 1 + 0 - 0).
   rewrite <- (CSUCUnitTrapezeInt 0 0 1 (CRzero_lt_one R) (CRle_refl 0)).
   (* IntegralCSUC is between CR_of_Q (-1) and CR_of_Q 1 *)
-  assert (-(1) <= CRone R).
+  assert (-(1) <= CR_of_Q R 1).
   { apply (CRle_trans _ (-0)).
     apply CRopp_ge_le_contravar, CRlt_asym, CRzero_lt_one.
     rewrite CRopp_0. apply CRlt_asym, CRzero_lt_one. }
@@ -1100,7 +1099,7 @@ Proof.
              (CSUCUnitTrapeze 0 0 1 (CRzero_lt_one R))
              (0-1) (0+1) (-(1)) 1 _ _ _ H).
   apply UC_integral_extens. reflexivity.
-  unfold CRminus. rewrite CRplus_0_l, <- CR_of_Q_one, <- CR_of_Q_opp.
+  unfold CRminus. rewrite CRplus_0_l, <- CR_of_Q_opp.
   apply CR_of_Q_morph. reflexivity.
   rewrite CRplus_0_l. reflexivity.
   unfold CRminus. rewrite CRplus_assoc, CRplus_opp_r, CRplus_0_r. reflexivity.
@@ -1171,7 +1170,7 @@ Proof.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
     rewrite Nat2Pos.id. apply (le_trans _ _ _ H0). rewrite Nat.add_comm.
     apply le_S, le_S, le_refl. intro abs. rewrite Nat.add_comm in abs. discriminate.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
     rewrite CRmult_0_l. reflexivity. rewrite CRplus_0_r. reflexivity. }
   assert (CR_cv R (fun n => a + (b - a) * CR_of_Q R (1 # Pos.of_nat (n + 2))) a)
     as cv_left.
@@ -1195,7 +1194,7 @@ Proof.
     exists (max x1 x2). intros.
     specialize (c i). specialize (c0 i).
     simpl. rewrite CSUCTrapezePlateau. unfold CRminus.
-    rewrite CRplus_opp_r, CRabs_right. rewrite <- CR_of_Q_zero.
+    rewrite CRplus_opp_r, CRabs_right. 
     apply CR_of_Q_le. discriminate. apply CRle_refl.
     split; apply CRlt_asym. apply c. apply (le_trans _ (max x1 x2)).
     apply Nat.le_max_l. exact H2. apply c0.
@@ -1213,8 +1212,7 @@ Proof.
     rewrite <- (CRmult_1_r (-a + b)).
     rewrite CRmult_assoc. apply CRmult_le_compat_l.
     rewrite <- (CRplus_opp_l a). apply CRplus_le_compat_l, CRlt_asym, H.
-    rewrite CRmult_1_l.
-    rewrite <- CR_of_Q_one. apply CR_of_Q_le.
+    rewrite CRmult_1_l. apply CR_of_Q_le.
     unfold Qle,Qnum,Qden. rewrite Z.mul_1_r, Z.mul_1_l.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
     rewrite Nat2Pos.id. rewrite Nat.add_comm. apply le_n_S, le_n_S, le_0_n.
@@ -1293,7 +1291,7 @@ Proof.
         rewrite <- (CRmult_1_r (-a+b)), (CRplus_comm (-a)).
         apply CRmult_le_compat_l.
         rewrite <- (CRplus_opp_r a). apply CRplus_le_compat_r. apply CRlt_asym, H.
-        rewrite <- CR_of_Q_one. apply CR_of_Q_le.
+        apply CR_of_Q_le.
         unfold Qle, Qnum, Qden. rewrite Z.mul_1_r, Z.mul_1_l.
         apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
         rewrite Nat2Pos.id. rewrite Nat.add_comm. apply le_n_S, le_0_n.
@@ -1312,8 +1310,7 @@ Proof.
         setoid_replace (-b+a) with (-(b-a)). apply CRopp_ge_le_contravar.
         rewrite <- (CRmult_1_r (b-a)).
         apply CRmult_le_compat_l. rewrite <- (CRplus_opp_r a).
-        apply CRplus_le_compat_r, CRlt_asym, H.
-        rewrite <- CR_of_Q_one. apply CR_of_Q_le.
+        apply CRplus_le_compat_r, CRlt_asym, H. apply CR_of_Q_le.
         unfold Qle, Qnum, Qden. rewrite Z.mul_1_r, Z.mul_1_l.
         apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
         rewrite Nat2Pos.id. rewrite Nat.add_comm. apply le_n_S, le_0_n.
@@ -1398,7 +1395,7 @@ Proof.
                  < b + CR_of_Q R (1 # Pos.of_nat n)) as ltabn.
   { intro n. apply (CRle_lt_trans _ (a + 0)).
     rewrite <- CRopp_0. apply CRplus_le_compat_l, CRopp_ge_le_contravar.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
     apply (CRle_lt_trans _ (b+0)). apply CRplus_le_compat_r, H.
     apply CRplus_lt_compat_l, CR_of_Q_pos. reflexivity. }
   assert (CR_cv R (fun i : nat => CR_of_Q R (1 # Pos.of_nat i)) 0) as invCv.
@@ -1408,7 +1405,7 @@ Proof.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le. rewrite Nat2Pos.id.
     exact H0. destruct i. exfalso. inversion H0.
     pose proof (Pos2Nat.is_pos p). rewrite H2 in H1. inversion H1.
-    discriminate. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. }
+    discriminate. apply CR_of_Q_le. discriminate. }
   destruct (@IntegrableSetCountableIntersect
               IntSpaceCSUCFunctions
               (fun n x => CRltProp R (a - CR_of_Q _ (1 # Pos.of_nat n)) x

--- a/reals/stdlib/CMTbase.v
+++ b/reals/stdlib/CMTbase.v
@@ -224,15 +224,15 @@ Proof.
       rewrite (DomainProp (XnegPart f) x _ (xG, xG)).
       rewrite (applyXnegPartMin f x xG), <- CRopp_mult_distr_l.
       rewrite CRmult_1_l, CRopp_involutive, CRmin_sym.
-      apply CRmin_morph. reflexivity. rewrite <- CR_of_Q_zero. reflexivity.
-  - apply LminConstStable. rewrite <- CR_of_Q_zero.
+      apply CRmin_morph. reflexivity. reflexivity.
+  - apply LminConstStable. 
     apply CR_of_Q_lt. reflexivity. exact H.
 Qed.
 
 Lemma invSuccRealPositive : forall {R : ConstructiveReals} (n : nat),
     0 < CR_of_Q R (1# Pos.of_nat (S n)).
 Proof.
-  intros R n. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+  intros R n. apply CR_of_Q_lt. reflexivity.
 Qed.
 
 Definition ElemIntegralContinuous
@@ -403,7 +403,7 @@ Proof.
     + intros n. exists O. intros.
       rewrite CRabs_right.
       rewrite sum_eq_R0. unfold CRminus.
-      rewrite CRplus_opp_r, <- CR_of_Q_zero.
+      rewrite CRplus_opp_r.
       apply CR_of_Q_le. discriminate.
       intro k. apply Izero_is_zero. unfold CRminus.
       rewrite CRopp_0, CRplus_0_r.
@@ -492,7 +492,7 @@ Proof.
     destruct f; simpl. apply CRmult_morph. reflexivity. apply DomainProp. }
   apply (Build_IntegrationSpace
            ElemSub Isub H0 H1 (Ione IS) H).
-  - unfold Isub. transitivity (CRone (RealT (ElemFunc IS))).
+  - unfold Isub. transitivity (CR_of_Q (RealT (ElemFunc IS)) 1).
     rewrite <- (IoneInt IS).
     apply IExtensional. intros.
     destruct (Ione IS); simpl. apply DomainProp. reflexivity.

--- a/reals/stdlib/CMTprofile.v
+++ b/reals/stdlib/CMTprofile.v
@@ -81,12 +81,12 @@ Proof.
     rewrite pow_plus_distr, Nat.add_comm. simpl.
     rewrite <- CRmult_plus_distr_r, <- CR_of_Q_plus, Qinv_plus_distr.
     setoid_replace (1 + 1 # 2)%Q with 1%Q. 2: reflexivity.
-    rewrite CR_of_Q_one, CRmult_1_l. reflexivity.
+    rewrite CRmult_1_l. reflexivity.
     apply (CR_cv_proper _ (CR_of_Q R 2 * CRpow (CR_of_Q R (1 # 2)) (S N))).
     apply series_cv_scale. apply GeoHalfTwo. simpl.
     rewrite <- CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace (2 * (1 # 2))%Q with 1%Q. 2: reflexivity.
-    rewrite CR_of_Q_one, CRmult_1_l. reflexivity.
+    rewrite CRmult_1_l. reflexivity.
   - exists x. exact c.
 Qed.
 
@@ -198,7 +198,7 @@ Proof.
     simpl. apply le_n_S. rewrite Nat.add_comm. apply le_n_S, le_0_n.
     discriminate.
   - apply (CRlt_le_trans _ (t* CR_of_Q _ 1)).
-    2: rewrite CR_of_Q_one, CRmult_1_r; apply CRle_refl.
+    2: rewrite CRmult_1_r; apply CRle_refl.
     apply CRmult_lt_compat_l. exact tPos. apply CR_of_Q_lt.
     apply (Qplus_lt_l _ _ ((1 # Pos.of_nat (2 * S n))-1)).
     ring_simplify. reflexivity.
@@ -221,8 +221,8 @@ Proof.
     apply le_S. apply (le_trans _ (i+0)).
     rewrite Nat.add_comm. apply le_refl.
     apply Nat.add_le_mono_l, le_0_n.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-  - unfold Qminus. rewrite CR_of_Q_plus, CR_of_Q_opp, CR_of_Q_one.
+    apply CR_of_Q_le. discriminate.
+  - unfold Qminus. rewrite CR_of_Q_plus, CR_of_Q_opp.
     unfold CRminus. rewrite CRplus_comm, <- CRplus_assoc, CRplus_opp_l.
     rewrite CRplus_0_l. reflexivity.
 Qed.
@@ -252,9 +252,9 @@ Proof.
   rewrite applyXscale.
   setoid_replace (partialApply
        (Xminus (XminConst f t) (XminConst f (t * CR_of_Q R (1 - (1 # Pos.of_nat (2 * S i)))))) x
-       (xnD i)) with (CRzero R).
+       (xnD i)) with (CR_of_Q R 0).
   rewrite CRmult_0_r. unfold CRminus. rewrite CRplus_opp_r, CRabs_right.
-  rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. apply CRle_refl.
+  apply CR_of_Q_le. discriminate. apply CRle_refl.
   destruct (xnD i).
   rewrite (applyXminus (XminConst f t)
                        (XminConst f (t * CR_of_Q R (1 - (1 # Pos.of_nat (2 * S i))))) x).
@@ -602,15 +602,15 @@ Proof.
        (StepApprox f
           (t * CR_of_Q (RealT (ElemFunc IS)) (1 - (1 # Pos.of_nat (2 * S i0)))) t
           (snd (StepApproxBetween t tPos i0))) x (xnD i0))
-          with (CRzero (RealT (ElemFunc IS))).
+          with (CR_of_Q (RealT (ElemFunc IS)) 0).
         simpl. unfold CRminus. rewrite CRplus_opp_r, CRabs_right.
-        rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+        apply CR_of_Q_le. discriminate.
         apply CRle_refl. unfold StepApprox. rewrite applyXscale.
         setoid_replace (partialApply
     (Xminus (XminConst f t)
        (XminConst f
           (t * CR_of_Q (RealT (ElemFunc IS)) (1 - (1 # Pos.of_nat (2 * S i0)))))) x
-    (xnD i0) ) with (CRzero (RealT (ElemFunc IS))).
+    (xnD i0) ) with (CR_of_Q (RealT (ElemFunc IS)) 0).
         rewrite CRmult_0_r. reflexivity. destruct (xnD i0).
         rewrite (applyXminus (XminConst f t)
                              (XminConst f (t * CR_of_Q (RealT (ElemFunc IS)) (1 - (1 # Pos.of_nat (2 * S i0))))) ).
@@ -820,7 +820,7 @@ Proof.
     rewrite CRplus_0_r. exact (fst H).
     apply CRplus_le_compat_l. rewrite CRmult_assoc.
     apply CRmult_le_0_compat.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. unfold Qle, Qnum, Qden.
+    apply CR_of_Q_le. unfold Qle, Qnum, Qden.
     do 2 rewrite Z.mul_1_r. apply Zle_0_nat. apply CRlt_asym, H0.
   - apply CRplus_lt_compat_l.
     apply CRmult_lt_compat_r. apply pow_lt, CR_of_Q_pos. reflexivity.
@@ -842,7 +842,7 @@ Proof.
   2: apply CR_of_Q_morph; reflexivity.
   rewrite <- CRmult_plus_distr_r.
   rewrite CRmult_assoc. apply CRmult_morph. 2: reflexivity.
-  rewrite <- CR_of_Q_one, <- CR_of_Q_plus.
+  rewrite <- CR_of_Q_plus.
   apply CR_of_Q_morph. rewrite Qinv_plus_distr.
   unfold Qeq, Qnum, Qden. do 2 rewrite Z.mul_1_r.
   replace 1%Z with (Z.of_nat 1).
@@ -853,7 +853,7 @@ Lemma pow_nat : forall {R : ConstructiveReals} (a n : nat),
   CR_of_Q R (Z.of_nat (a ^ n) # 1) == CRpow (CR_of_Q R (Z.of_nat a # 1)) n.
 Proof.
   induction n.
-  - simpl. rewrite CR_of_Q_one. reflexivity.
+  - reflexivity.
   - simpl.
     setoid_replace (Z.of_nat (a * a ^ n) # 1)
       with ((Z.of_nat a # 1) * (Z.of_nat (a ^ n) # 1))%Q.
@@ -870,10 +870,10 @@ Proof.
   split.
   - apply (CRle_trans _ (a+0)). rewrite CRplus_0_r. apply CRle_refl.
     apply CRplus_le_compat_l. apply CRmult_le_0_compat.
-    apply CRmult_le_0_compat. rewrite <- CR_of_Q_zero.
+    apply CRmult_le_0_compat. 
     apply CR_of_Q_le. destruct i; discriminate.
     rewrite <- (CRplus_opp_r a). apply CRplus_le_compat_r, H.
-    apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply pow_le. apply CR_of_Q_le. discriminate.
   - unfold BinarySubdiv. apply (CRplus_le_reg_l (-a)).
     rewrite <- CRplus_assoc, CRplus_opp_l, CRplus_0_l.
     rewrite (CRplus_comm (-a)), <- (CRmult_comm (b-a)), <- (CRmult_1_r (b+-a)).
@@ -888,7 +888,7 @@ Proof.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden.
     rewrite Z.mul_1_r, Z.mul_1_r. apply Nat2Z.inj_le, H0.
     rewrite <- (pow_nat 2). apply CRle_refl.
-    rewrite <- CR_of_Q_mult, <- CR_of_Q_one. apply CR_of_Q_morph. reflexivity.
+    rewrite <- CR_of_Q_mult. apply CR_of_Q_morph. reflexivity.
 Qed.
 
 Lemma BinarySubdivRight
@@ -907,7 +907,7 @@ Proof.
   rewrite (pow_proper (CR_of_Q R (/ 2) * CR_of_Q R 2) 1).
   rewrite pow_one, CRmult_1_r.
   apply (pow_nat 2).
-  rewrite <- CR_of_Q_mult, <- CR_of_Q_one. apply CR_of_Q_morph. reflexivity.
+  rewrite <- CR_of_Q_mult. apply CR_of_Q_morph. reflexivity.
 Qed.
 
 Fixpoint FindCrossingPoint {R : ConstructiveReals}
@@ -1042,7 +1042,7 @@ Proof.
       apply CRmult_le_compat_l. apply CRlt_asym, CRlt_minus, ltab.
       simpl (CRpow (CR_of_Q (RealT (ElemFunc IS)) (/ 2)) (S n)).
       rewrite <- CRmult_assoc. apply CRmult_le_compat_r.
-      apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply pow_le. apply CR_of_Q_le. discriminate.
       rewrite <- CR_of_Q_mult. apply CR_of_Q_le.
       apply Qle_shift_div_l. reflexivity.
       unfold Qmult, Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
@@ -1056,7 +1056,7 @@ Proof.
       apply CRmult_le_compat_l. apply CRlt_asym, CRlt_minus, ltab.
       simpl (CRpow (CR_of_Q (RealT (ElemFunc IS)) (/ 2)) (S n)).
       rewrite <- CRmult_assoc. apply CRmult_le_compat_r.
-      apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply pow_le. apply CR_of_Q_le. discriminate.
       rewrite <- CR_of_Q_mult. apply CR_of_Q_le.
       apply Qle_shift_div_l. reflexivity.
       unfold Qmult, Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
@@ -1116,7 +1116,7 @@ Proof.
       apply CRmult_le_compat_l. apply CRlt_asym, CRlt_minus, ltab.
       simpl (CRpow (CR_of_Q (RealT (ElemFunc IS)) (/ 2)) (S n)).
       rewrite <- CRmult_assoc. apply CRmult_le_compat_r.
-      apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply pow_le. apply CR_of_Q_le. discriminate.
       rewrite <- CR_of_Q_mult. apply CR_of_Q_le.
       apply Qle_shift_div_r. reflexivity.
       unfold Qmult, Qle, Qnum, Qden. rewrite Z.mul_1_r, Z.mul_1_r.
@@ -1128,7 +1128,7 @@ Proof.
       apply CRmult_le_compat_l. apply CRlt_asym, CRlt_minus, ltab.
       simpl (CRpow (CR_of_Q (RealT (ElemFunc IS)) (/ 2)) (S n)).
       rewrite <- CRmult_assoc. apply CRmult_le_compat_r.
-      apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply pow_le. apply CR_of_Q_le. discriminate.
       rewrite <- CR_of_Q_mult. apply CR_of_Q_le.
       apply Qle_shift_div_r. reflexivity.
       unfold Qmult, Qle, Qnum, Qden. rewrite Z.mul_1_r, Z.mul_1_r.
@@ -1168,7 +1168,7 @@ Proof.
     apply BinarySubdivInside. apply CRlt_asym, ltab. exact l.
     apply CRplus_le_compat_l. apply CRmult_le_0_compat.
     apply CRlt_asym, CRlt_minus, ltab. apply pow_le.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
     apply CRlt_asym, ltab.
   - destruct s. subst i. rewrite BinarySubdivRight. 2: apply CRlt_asym, ltab.
     destruct (le_lt_dec (2^S n) (S j)).
@@ -1187,14 +1187,12 @@ Proof.
       rewrite (pow_proper (CR_of_Q (RealT (ElemFunc IS)) (/ 2) *
                            CR_of_Q (RealT (ElemFunc IS)) (Z.of_nat 2 # 1)) 1).
       rewrite pow_one, <- pow_nat, CRmult_1_r.
-      rewrite <- CR_of_Q_one, <- CR_of_Q_plus.
-      apply CR_of_Q_le.
+      rewrite <- CR_of_Q_plus. apply CR_of_Q_le.
       unfold Qplus, Qle, Qnum, Qden. do 4 rewrite Z.mul_1_r.
       replace 1%Z with (Z.of_nat 1). rewrite <- Nat2Z.inj_add.
       apply Nat2Z.inj_le. rewrite Nat.add_comm. exact l1.
       reflexivity.
-      rewrite <- CR_of_Q_mult, <- CR_of_Q_one. apply CR_of_Q_morph.
-      reflexivity.
+      rewrite <- CR_of_Q_mult. apply CR_of_Q_morph. reflexivity.
     + exfalso. pose proof (CRlt_trans _ _ _ c1 c).
       apply (StepApproxDiscretizeRefineIncr
                f fInt a b eta aPos ltab aeta beta n (S j) (2^n)).
@@ -1218,8 +1216,8 @@ Proof.
         simpl (CRpow (CR_of_Q (RealT (ElemFunc IS)) (/ 2)) (S n)).
         apply CRmult_le_compat_l. apply CRlt_asym, CRlt_minus, ltab.
         rewrite <- CRmult_assoc. apply CRmult_le_compat_r.
-        apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-        rewrite <- CR_of_Q_one, <- CR_of_Q_plus, <- CR_of_Q_mult. apply CR_of_Q_le.
+        apply pow_le. apply CR_of_Q_le. discriminate.
+        rewrite <- CR_of_Q_plus, <- CR_of_Q_mult. apply CR_of_Q_le.
         apply Qle_shift_div_l. reflexivity.
         unfold Qplus, Qmult, Qle, Qnum, Qden.
         do 4 rewrite Z.mul_1_r.
@@ -1255,8 +1253,7 @@ Proof.
     apply BinarySubdivInside. apply CRlt_asym, ltab. exact l0.
     apply CRplus_le_compat_l. apply CRmult_le_0_compat.
     apply CRlt_asym, CRlt_minus, ltab. apply pow_le.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-    apply CRlt_asym, ltab.
+    apply CR_of_Q_le. discriminate. apply CRlt_asym, ltab.
   - destruct s0.
     subst j. rewrite BinarySubdivRight. 2: apply CRlt_asym, ltab.
     destruct (le_lt_dec (2^n) i).
@@ -1275,15 +1272,13 @@ Proof.
       rewrite (pow_proper (CR_of_Q (RealT (ElemFunc IS)) (/ 2) *
                            CR_of_Q (RealT (ElemFunc IS)) (Z.of_nat 2 # 1)) 1).
       rewrite pow_one, <- pow_nat, CRmult_1_r.
-      rewrite <- CR_of_Q_one, <- CR_of_Q_plus.
-      apply CR_of_Q_le.
+      rewrite <- CR_of_Q_plus. apply CR_of_Q_le.
       unfold Qplus, Qle, Qnum, Qden. do 4 rewrite Z.mul_1_r.
       replace 1%Z with (Z.of_nat 1). rewrite <- Nat2Z.inj_add.
       apply Nat2Z.inj_le. apply (le_trans _ i _ l1).
       rewrite Nat.add_comm. apply le_S, le_refl.
       reflexivity.
-      rewrite <- CR_of_Q_mult, <- CR_of_Q_one. apply CR_of_Q_morph.
-      reflexivity.
+      rewrite <- CR_of_Q_mult. apply CR_of_Q_morph. reflexivity.
     + exfalso. pose proof (CRlt_trans _ _ _ c1 c0).
       apply (StepApproxDiscretizeRefineDecr
                f fInt a b eta aPos ltab aeta beta n (2^S n) (S i)).
@@ -1306,8 +1301,8 @@ Proof.
         simpl (CRpow (CR_of_Q (RealT (ElemFunc IS)) (/ 2)) (S n)).
         apply CRmult_le_compat_l. apply CRlt_asym, CRlt_minus, ltab.
         rewrite <- CRmult_assoc. apply CRmult_le_compat_r.
-        apply pow_le. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
-        rewrite <- CR_of_Q_one, <- CR_of_Q_plus, <- CR_of_Q_mult. apply CR_of_Q_le.
+        apply pow_le. apply CR_of_Q_le. discriminate.
+        rewrite <- CR_of_Q_plus, <- CR_of_Q_mult. apply CR_of_Q_le.
         apply Qle_shift_div_r. reflexivity.
         unfold Qplus, Qmult, Qle, Qnum, Qden.
         do 4 rewrite Z.mul_1_r.
@@ -1529,7 +1524,7 @@ Proof.
     setoid_replace
       ((Z.of_nat q # Pos.of_nat (S k)) * (Z.of_nat (S k) # Pos.of_nat q))%Q
       with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_l. reflexivity.
+    rewrite CRmult_1_l. reflexivity.
     unfold Qmult, Qeq, Qnum, Qden.
     rewrite Z.mul_1_l, Z.mul_1_r, Z.mul_comm.
     rewrite Pos2Z.inj_mul. apply f_equal2.
@@ -1572,7 +1567,7 @@ Proof.
       apply CRmult_le_compat_l. apply CRlt_asym, CRlt_minus, ltab.
       rewrite <- (CRmult_1_l (CRpow (CR_of_Q (RealT (ElemFunc IS)) (1 # 2)) n)).
       simpl. apply CRmult_le_compat_r. apply pow_le, CRlt_asym, CR_of_Q_pos.
-      reflexivity. rewrite <- CR_of_Q_one. apply CR_of_Q_le. discriminate.
+      reflexivity. apply CR_of_Q_le. discriminate.
     - pose proof (FindCrossingPointDecr
              f fInt a b (ext_eta ext)
              (Fni n O - CR_of_Q _ (Z.of_nat (S k) # Pos.of_nat q) * epsilonPrime)
@@ -1617,7 +1612,7 @@ Proof.
       apply (CRle_trans _ ( Fni n 0%nat - 1 * epsilonPrime)).
       apply CRplus_le_compat_l, CRopp_ge_le_contravar.
       apply CRmult_le_compat_r. apply CRlt_asym, epsilonPrimePos.
-      rewrite <- CR_of_Q_one. apply CR_of_Q_le.
+      apply CR_of_Q_le.
       unfold Qle, Qnum, Qden. rewrite Z.mul_1_r, Z.mul_1_l.
       simpl (Z.of_nat (S k)). apply Pos2Z.pos_le_pos.
       rewrite Pos.of_nat_succ. apply Pos2Nat.inj_le.
@@ -1687,7 +1682,7 @@ Proof.
       apply (CRle_lt_trans _ epsilonPrime). 2: exact (snd p).
       rewrite <- CRmult_assoc, <- CR_of_Q_mult.
       setoid_replace ((Z.of_nat q # 1) * (Z.of_nat 1 # Pos.of_nat q))%Q with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_l. apply CRle_refl.
+      rewrite CRmult_1_l. apply CRle_refl.
       unfold Qmult, Qeq, Qnum, Qden. simpl. do 2 rewrite Z.mul_1_r.
       destruct q. exfalso; exact (qnz (eq_refl _)). simpl (Z.of_nat (S q)).
       apply f_equal. apply (Pos.of_nat_succ). }
@@ -1712,7 +1707,7 @@ Proof.
       destruct (H2 m O), p0, p0. unfold StepApproxDiscretize. destruct x0.
       exfalso. contradict mcv. apply (CRle_trans _ (a+0)).
       unfold BinarySubdiv.
-      rewrite CR_of_Q_zero, CRmult_0_l, CRmult_0_l, CRplus_assoc.
+      rewrite CRmult_0_l, CRmult_0_l, CRplus_assoc.
       apply CRplus_le_compat_l.
       rewrite CRplus_0_l, <- CRopp_mult_distr_r, <- CRopp_0.
       apply CRopp_ge_le_contravar, CRmult_le_0_compat.
@@ -1802,7 +1797,7 @@ Proof.
         clear l c1. contradict mcv.
         apply (CRle_trans _ (a-0)). unfold BinarySubdiv, CRminus.
         rewrite CRplus_assoc. apply CRplus_le_compat_l.
-        rewrite CR_of_Q_zero, CRmult_0_l, CRmult_0_l, CRplus_0_l.
+        rewrite CRmult_0_l, CRmult_0_l, CRplus_0_l.
         apply CRopp_ge_le_contravar.
         apply CRlt_asym, CRmult_lt_0_compat.
         apply pow_lt, CR_of_Q_pos. reflexivity.
@@ -1890,7 +1885,7 @@ Proof.
   2: rewrite CRmult_1_r, CRplus_comm; apply CRmin_l.
   apply CRmult_lt_compat_l. apply CRmin_lt. apply CRlt_minus, (fst H).
   apply CRlt_minus, (snd H).
-  rewrite <- CR_of_Q_one. apply CR_of_Q_lt. reflexivity.
+  apply CR_of_Q_lt. reflexivity.
   apply (CRlt_le_trans _ (x+0)). apply CRplus_lt_compat_l.
   rewrite <- CRopp_0. apply CRopp_gt_lt_contravar.
   apply CRmult_lt_0_compat. apply CRmin_lt.
@@ -1904,13 +1899,13 @@ Proof.
   apply (CRle_lt_trans _ (CRmin (x - a) (b - x) * CR_of_Q R (1 # 2))).
   rewrite <- CRplus_assoc, CRplus_opp_l, CRplus_0_l. apply CRle_refl.
   apply (CRle_lt_trans _ ((b - x) * CR_of_Q R (1 # 2))).
-  apply CRmult_le_compat_r. rewrite <- CR_of_Q_zero.
+  apply CRmult_le_compat_r. 
   apply CR_of_Q_le. discriminate. apply CRmin_r.
   apply (CRlt_le_trans _ ((b-x)*CR_of_Q _ 1)).
   apply CRmult_lt_compat_l. apply CRlt_minus. exact (snd H).
   apply CR_of_Q_lt. reflexivity.
   rewrite CRplus_comm, <- (CRmult_1_r (b + - x)).
-  rewrite CR_of_Q_one. apply CRle_refl. 
+  apply CRle_refl. 
 Qed.
 
 Lemma FindJumpPointsCountable
@@ -1943,16 +1938,16 @@ Proof.
     unfold CRminus. rewrite CRplus_assoc, CRplus_opp_l, CRplus_0_r.
     rewrite <- CRmult_plus_distr_l, <- CR_of_Q_plus.
     setoid_replace ((1 # 2) + (1 # 2))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_r. apply CRle_refl. reflexivity.
+    rewrite CRmult_1_r. apply CRle_refl. reflexivity.
     apply (CRle_lt_trans _ (an n * CR_of_Q _ (1#2))).
     apply (CRplus_le_reg_r (an n * CR_of_Q (RealT (ElemFunc IS)) (1 # 2))).
     unfold CRminus. rewrite CRplus_assoc, CRplus_opp_l, CRplus_0_r.
     rewrite <- CRmult_plus_distr_l, <- CR_of_Q_plus.
     setoid_replace ((1 # 2) + (1 # 2))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_r. apply CRle_refl. reflexivity.
+    rewrite CRmult_1_r. apply CRle_refl. reflexivity.
     rewrite <- (CRmult_1_r (an n)), CRmult_assoc.
     apply CRmult_lt_compat_l. exact (anPos n).
-    rewrite CRmult_1_l, <- CR_of_Q_one. apply CR_of_Q_lt. reflexivity. }
+    rewrite CRmult_1_l. apply CR_of_Q_lt. reflexivity. }
   assert (forall n:nat, 0 < bn n < bn n + an n*CR_of_Q _ (1#2)) as orderAfter.
   { split. exact (CRlt_trans _ (an n) _ (anPos n) (ltabn n)).
     apply (CRle_lt_trans _ (bn n + 0)).
@@ -1982,7 +1977,7 @@ Proof.
     apply CRlt_asym in c.
     apply (CRmult_le_compat_r (CR_of_Q _ (1 # Pos.of_nat n))) in c.
     rewrite CRmult_assoc, CRinv_l, CRmult_1_r in c. exact c.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. }
+    apply CR_of_Q_le. discriminate. }
   assert (forall n:nat, intAfter n <= intBefore n) as orderInt.
   { intro n.
     apply (StepApproxIntegralIncr
@@ -2002,7 +1997,7 @@ Proof.
           (CR_of_Q (RealT (ElemFunc IS)) (1 # Pos.of_nat n))
           (inr (CR_of_Q_pos (1 # Pos.of_nat n) eq_refl)))).
     apply CRlt_asym in c.
-    intro abs. rewrite abs, CR_of_Q_zero in c.
+    intro abs. rewrite abs in c.
     apply (CRmult_le_compat_r (CR_of_Q (RealT (ElemFunc IS)) (1 # Pos.of_nat n))) in c.
     rewrite CRmult_assoc, CRinv_l, CRmult_1_r, CRmult_0_l in c.
     apply (CRplus_le_compat _ _ _ _ (orderInt n)) in c.
@@ -2010,7 +2005,7 @@ Proof.
     rewrite CRplus_assoc, CRplus_assoc, CRplus_opp_l, CRplus_comm in c.
     rewrite CRplus_assoc in c. apply CRplus_le_reg_l in c.
     rewrite CRplus_0_l in c. apply c. apply CRzero_lt_one.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. }
+    apply CR_of_Q_le. discriminate. }
   assert (forall n:nat, bn n < bn n + an n*CR_of_Q _ (1#2)).
   { intro n. apply (CRle_lt_trans _ (bn n + 0)). rewrite CRplus_0_r.
     apply CRle_refl. apply CRplus_lt_compat_l. apply CRmult_lt_0_compat.
@@ -2049,7 +2044,7 @@ Proof.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
     rewrite Nat2Pos.id. apply (le_trans _ _ _ H3).
     apply le_S, le_refl. discriminate.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate. }
+    apply CR_of_Q_le. discriminate. }
   destruct (CR_cv_open_above an x 0 stepCv H2) as [i imaj].
   destruct (CRup_nat x) as [j jmaj].
   specialize (imaj (max n (max i j))
@@ -2082,13 +2077,12 @@ Proof.
   do 2 rewrite Z.mul_1_l. apply Pos2Z.pos_le_pos.
   rewrite Nat2Pos.inj_max. apply Pos.le_max_l.
   apply (CRmult_lt_compat_l eps) in nmaj. rewrite CRinv_r in nmaj.
-  destruct n. exfalso. rewrite CR_of_Q_zero, CRmult_0_r in nmaj.
+  destruct n. exfalso. rewrite CRmult_0_r in nmaj.
   contradict nmaj. apply CRlt_asym, CRzero_lt_one.
   apply (CRmult_lt_reg_r (CR_of_Q (RealT (ElemFunc IS)) (Z.of_nat (S n) # 1))).
   apply CR_of_Q_pos. reflexivity. rewrite <- CR_of_Q_mult.
   setoid_replace ((1 # Pos.of_nat (S n)) * (Z.of_nat (S n) # 1))%Q with 1%Q.
-  rewrite CR_of_Q_one. exact nmaj.
-  unfold Qmult, Qeq, Qnum, Qden.
+  exact nmaj. unfold Qmult, Qeq, Qnum, Qden.
   rewrite Z.mul_1_l, Z.mul_1_l, Z.mul_1_r, Pos.mul_1_r.
   simpl (Z.of_nat (S n)). apply f_equal. rewrite Pos.of_nat_succ.
   reflexivity. exact H4.

--- a/reals/stdlib/ConstructiveCauchyIntegral.v
+++ b/reals/stdlib/ConstructiveCauchyIntegral.v
@@ -471,10 +471,10 @@ Proof.
            R a b
            (fun n:nat => a + (b-a) * CR_of_Q R (Z.of_nat n # Pos.of_nat (S last))) last).
   setoid_replace (Z.of_nat 0 # Pos.of_nat (S last))%Q with 0%Q.
-  rewrite CR_of_Q_zero, CRmult_0_r, CRplus_0_r.
+  rewrite CRmult_0_r, CRplus_0_r.
   reflexivity. reflexivity.
   setoid_replace (Z.of_nat (S last) # Pos.of_nat (S last))%Q with 1%Q.
-  rewrite CR_of_Q_one, CRmult_1_r. unfold CRminus.
+  rewrite CRmult_1_r. unfold CRminus.
   rewrite CRplus_comm, CRplus_assoc, CRplus_opp_l.
   rewrite CRplus_0_r. reflexivity.
   unfold Qeq, Qnum, Qden. rewrite Z.mul_1_r, Z.mul_1_l.
@@ -505,14 +505,14 @@ Proof.
   - intros. unfold PartitionMesh, IntervalEquiPartition, ipt_seq.
     setoid_replace (Z.of_nat 0 # Pos.of_nat (S last))%Q with 0%Q.
     2: reflexivity.
-    rewrite CR_of_Q_zero, CRmult_0_r, CRplus_0_r.
+    rewrite CRmult_0_r, CRplus_0_r.
     unfold CRminus. rewrite CRplus_assoc, <- (CRplus_comm (-a)), <- CRplus_assoc.
     rewrite CRplus_opp_r, CRplus_0_l.
     rewrite CRmax_left. reflexivity. rewrite <- (CRmult_0_r (b-a)).
     apply CRmult_le_compat_l.
     rewrite <- (CRplus_opp_r a). apply CRplus_le_compat.
     exact leab. apply CRle_refl.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    apply CR_of_Q_le. discriminate.
   - intros.
     specialize (IHn last leab).
     unfold IntervalEquiPartition, ipt_seq.
@@ -593,7 +593,7 @@ Proof.
   intros. intros n.
   (* eps = / INR (S (2 * n)) * / (b - a) *)
   assert (0 < CR_of_Q R (Z.pos (2*n) # 1) * (1+b-a)) as invStepPos.
-  { apply CRmult_lt_0_compat. rewrite <- CR_of_Q_zero.
+  { apply CRmult_lt_0_compat.
     apply CR_of_Q_lt. reflexivity.
     apply (CRlt_le_trans _ (1+0)). rewrite CRplus_0_r. apply CRzero_lt_one.
     unfold CRminus. rewrite CRplus_assoc. apply CRplus_le_compat_l.
@@ -662,11 +662,11 @@ Proof.
     apply (CRmult_lt_compat_r (cont_mod _ stepPos)) in pmaj.
     rewrite CRmult_assoc, CRinv_l, CRmult_1_r in pmaj.
     apply (CRmult_lt_reg_l (INR (S p))).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+    apply CR_of_Q_lt; reflexivity.
     rewrite CRmult_comm, CRmult_assoc. unfold INR.
     rewrite <- CR_of_Q_mult.
     setoid_replace ((1 # Pos.of_nat (S p)) * (Z.of_nat (S p) # 1))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_r. apply (CRlt_le_trans _ _ _ pmaj).
+    rewrite CRmult_1_r. apply (CRlt_le_trans _ _ _ pmaj).
     apply CRmult_le_compat_r. apply CRlt_asym, c.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
     apply Nat2Z.inj_le, le_S, le_refl.
@@ -687,11 +687,11 @@ Proof.
     apply (CRmult_lt_compat_r (cont_mod _ stepPos)) in pmaj.
     rewrite CRmult_assoc, CRinv_l, CRmult_1_r in pmaj.
     apply (CRmult_lt_reg_l (INR (S p))).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+    apply CR_of_Q_lt; reflexivity.
     rewrite CRmult_comm, CRmult_assoc. unfold INR.
     rewrite <- CR_of_Q_mult.
     setoid_replace ((1 # Pos.of_nat (S p)) * (Z.of_nat (S p) # 1))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_r. apply (CRlt_le_trans _ _ _ pmaj).
+    rewrite CRmult_1_r. apply (CRlt_le_trans _ _ _ pmaj).
     apply CRmult_le_compat_r. apply CRlt_asym, c.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
     apply Nat2Z.inj_le, le_S, le_refl.
@@ -708,9 +708,9 @@ Proof.
     rewrite <- (CRmult_comm (1 + b - a)), CRmult_assoc.
     rewrite <- CR_of_Q_mult.
     setoid_replace ((Z.pos (2 * n) # 1) * (1 # n))%Q with 2%Q.
-    rewrite CRmult_comm, <- CR_of_Q_one, <- CR_of_Q_plus.
-    apply CRmult_le_compat_r. rewrite <- CR_of_Q_zero.
-    apply CR_of_Q_le. discriminate. rewrite CR_of_Q_one.
+    rewrite CRmult_comm, <- CR_of_Q_plus.
+    apply CRmult_le_compat_r. 
+    apply CR_of_Q_le. discriminate. 
     rewrite <- (CRplus_0_l (b-a)).
     unfold CRminus. rewrite CRplus_assoc.
     apply CRplus_le_compat_r. apply CRlt_asym, CRzero_lt_one.
@@ -751,7 +751,7 @@ Lemma UC_compare_integrals_limit
 Proof.
   intros.
   assert (forall k:nat, 0 < CR_of_Q R (1 # Pos.of_nat (S k))) as kPos.
-  { intros. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity. }
+  { intros. apply CR_of_Q_lt. reflexivity. }
   assert (forall k:nat,
              let (q,_) := CRup_nat ((b-a) * (CRinv R (cont_mod _ (kPos k)) (inr ((fst fCont) _ (kPos k))))) in
              CRabs _
@@ -813,11 +813,11 @@ Proof.
       apply (CRmult_lt_compat_r (cont_mod _ (kPos k))) in qmaj.
       rewrite CRmult_assoc, CRinv_l, CRmult_1_r in qmaj.
       apply (CRmult_lt_reg_l (INR (S q))).
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+      apply CR_of_Q_lt; reflexivity.
       rewrite CRmult_comm, CRmult_assoc. unfold INR.
       rewrite <- CR_of_Q_mult.
       setoid_replace ((1 # Pos.of_nat (S q)) * (Z.of_nat (S q) # 1))%Q with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_r. apply (CRlt_le_trans _ _ _ qmaj).
+      rewrite CRmult_1_r. apply (CRlt_le_trans _ _ _ qmaj).
       apply CRmult_le_compat_r. apply CRlt_asym. destruct fCont. apply c.
       apply CR_of_Q_le. unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
       apply Nat2Z.inj_le, le_S, le_refl.
@@ -884,7 +884,7 @@ Proof.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_l.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
     rewrite Nat2Pos.id. apply (le_trans _ _ _ H1), le_S, le_refl.
-    discriminate. rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+    discriminate. apply CR_of_Q_le. discriminate.
     unfold CRminus.
     rewrite CRplus_comm, <- CRplus_assoc, CRplus_opp_l, CRplus_0_l.
     reflexivity.
@@ -1034,20 +1034,20 @@ Proof.
                                * (c + - a)) * CR_of_Q R (1 # Pos.of_nat (S n))))).
     rewrite sum_scale, CRmult_comm.
     rewrite CRabs_mult, CRabs_right.
-    2: rewrite <- CR_of_Q_zero; apply CR_of_Q_le; discriminate.
+    2: apply CR_of_Q_le; discriminate.
     apply (CRle_trans _ (CR_of_Q R (1 # Pos.of_nat (S n)) *
                          CRsum (fun k => CRabs R (f (a + (b + - a) * CR_of_Q R (Z.of_nat k # Pos.of_nat (S n))) * (b-a) -
         f (a + (c + - a) * CR_of_Q R (Z.of_nat k # Pos.of_nat (S n))) * (c-a))) n)).
     apply CRmult_le_compat_l.
-    rewrite <- CR_of_Q_zero; apply CR_of_Q_le; discriminate.
+    apply CR_of_Q_le; discriminate.
     apply multiTriangleIneg.
     apply (CRle_trans _ (CR_of_Q R (1 # Pos.of_nat (S n)) * CRsum (fun _ => eps) n)).
     + (* Prove that each element of the sum is lower than eps. *)
       apply CRmult_le_compat_l.
-      rewrite <- CR_of_Q_zero; apply CR_of_Q_le; discriminate.
+      apply CR_of_Q_le; discriminate.
       apply sum_Rle. intros.
       assert (CR_of_Q R (Z.of_nat k # Pos.of_nat (S n)) <= 1) as inInterval.
-      { rewrite <- CR_of_Q_one. apply CR_of_Q_le.
+      { apply CR_of_Q_le.
         unfold Qle, Qnum, Qden. rewrite Z.mul_1_r, Z.mul_1_l.
         destruct k. discriminate. unfold Z.of_nat.
         apply Pos2Z.pos_le_pos. rewrite Pos.of_nat_succ. apply Pos2Nat.inj_le.
@@ -1068,7 +1068,7 @@ Proof.
       apply (CRle_trans _ (a + 0)). rewrite CRplus_0_r. apply CRle_refl.
       apply CRplus_le_compat_l. apply CRmult_le_0_compat.
       rewrite <- (CRplus_opp_r a). apply CRplus_le_compat_r. exact leab.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le.
+      apply CR_of_Q_le.
       unfold Qle; simpl. rewrite Z.mul_1_r. apply Nat2Z.is_nonneg.
       apply (CRplus_le_reg_l (-a)). rewrite <- CRplus_assoc, CRplus_opp_l, CRplus_0_l.
       rewrite <- (CRmult_1_r (-a+b)), (CRplus_comm (-a)).
@@ -1097,7 +1097,7 @@ Proof.
       apply CRmult_le_compat_l. rewrite <- (CRplus_opp_r b).
       apply CRplus_le_compat_r. exact (fst leac).
       rewrite CRabs_right. exact inInterval.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. unfold Qle; simpl.
+      apply CR_of_Q_le. unfold Qle; simpl.
       rewrite Z.mul_1_r. apply Nat2Z.is_nonneg.
       rewrite <- (CRplus_opp_r b).
       apply CRplus_le_compat_r. exact (fst leac).
@@ -1117,13 +1117,13 @@ Proof.
       apply (CRle_trans _ _ _ leab). exact (fst leac).
       rewrite <- CRmult_plus_distr_l, <- CR_of_Q_plus.
       rewrite Qinv_plus_distr. setoid_replace (1 + 1 # 2)%Q with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_r. apply CRle_refl. reflexivity.
+      rewrite CRmult_1_r. apply CRle_refl. reflexivity.
       unfold CRminus. rewrite CRplus_assoc. apply CRplus_morph. reflexivity.
       rewrite <- CRplus_assoc, CRplus_opp_l, CRplus_0_l. reflexivity.
     + rewrite sum_const. rewrite CRmult_comm, CRmult_assoc.
       unfold INR. rewrite <- CR_of_Q_mult.
       setoid_replace ((Z.of_nat (S n) # 1) * (1 # Pos.of_nat (S n)))%Q with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_r. apply CRle_refl.
+      rewrite CRmult_1_r. apply CRle_refl.
       unfold Z.of_nat. rewrite Pos.of_nat_succ.
       unfold Qeq. simpl. do 2 rewrite Pos.mul_1_r. reflexivity.
     + intros. unfold CRminus. unfold CRminus in addSub.
@@ -1911,7 +1911,7 @@ Proof.
   assert (0 < CR_of_Q R (1 # 4*n) * CRinv R (1+CR_of_Q R c - CR_of_Q R a) (inr invStepPos))
     as stepPos.
   {  apply CRmult_lt_0_compat.
-     rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+     apply CR_of_Q_lt; reflexivity.
      apply CRinv_0_lt_compat. exact invStepPos. }
   destruct (CRup_nat ((CR_of_Q R c-CR_of_Q R a) * CRinv R (cont_mod _ stepPos) (inr ((fst fCont) _ stepPos))))
     as [p pmaj].
@@ -1964,10 +1964,10 @@ Proof.
       2: apply (fst fCont).
       rewrite CRmult_assoc, CRinv_l, CRmult_1_r in pmaj.
       apply (CRmult_lt_reg_r (CR_of_Q R (Z.of_nat (S i0) # 1))).
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+      apply CR_of_Q_lt; reflexivity.
       rewrite CRmult_assoc, <- CR_of_Q_mult.
       setoid_replace ((1 # Pos.of_nat (S i0)) * (Z.of_nat (S i0) # 1))%Q with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_r. apply (CRlt_le_trans _ _ _ pmaj).
+      rewrite CRmult_1_r. apply (CRlt_le_trans _ _ _ pmaj).
       rewrite CRmult_comm. apply CRmult_le_compat_l.
       apply CRlt_asym, (fst fCont). apply CR_of_Q_le.
       unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r. apply Nat2Z.inj_le, le_S, H.
@@ -1985,11 +1985,11 @@ Proof.
       rewrite CRmult_assoc, CRinv_l, CRmult_1_r in qmaj.
       apply (CRmult_lt_reg_r
                (CR_of_Q R (Z.of_nat (S (Init.Nat.max i q)) # 1))).
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+      apply CR_of_Q_lt; reflexivity.
       rewrite CRmult_assoc, <- CR_of_Q_mult.
       setoid_replace ((1 # Pos.of_nat (S (Init.Nat.max i q))) * (Z.of_nat (S (Init.Nat.max i q)) # 1))%Q
         with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_r. apply (CRlt_le_trans _ _ _ qmaj).
+      rewrite CRmult_1_r. apply (CRlt_le_trans _ _ _ qmaj).
       rewrite CRmult_comm. apply CRmult_le_compat_l.
       apply CRlt_asym, (fst fCont). apply CR_of_Q_le.
       unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
@@ -2003,11 +2003,11 @@ Proof.
       rewrite CRmult_assoc, CRinv_l, CRmult_1_r in rmaj.
       apply (CRmult_lt_reg_r
                (CR_of_Q R (Z.of_nat (S (Init.Nat.max j r)) # 1))).
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+      apply CR_of_Q_lt; reflexivity.
       rewrite CRmult_assoc, <- CR_of_Q_mult.
       setoid_replace ((1 # Pos.of_nat (S (Init.Nat.max j r))) * (Z.of_nat (S (Init.Nat.max j r)) # 1))%Q
         with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_r. apply (CRlt_le_trans _ _ _ rmaj).
+      rewrite CRmult_1_r. apply (CRlt_le_trans _ _ _ rmaj).
       rewrite CRmult_comm. apply CRmult_le_compat_l.
       apply CRlt_asym, (fst fCont). apply CR_of_Q_le.
       unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
@@ -2024,12 +2024,12 @@ Proof.
       setoid_replace (CR_of_Q R (1 # 4 * n) * (1 + 1))
         with (CR_of_Q R (1 # 2 * n)).
       rewrite CRmult_comm. apply CRmult_le_compat_r.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
       rewrite <- (CRplus_0_l (CR_of_Q R c - CR_of_Q R a)).
       unfold CRminus. rewrite CRplus_assoc.
       apply CRplus_le_compat_r.
       exact (CRlt_asym 0 1 (CRzero_lt_one R)).
-      rewrite <- CR_of_Q_one, <- (CR_of_Q_plus R 1 1), <- CR_of_Q_mult.
+      rewrite <- (CR_of_Q_plus R 1 1), <- CR_of_Q_mult.
       apply CR_of_Q_morph. unfold Qeq, Qnum, Qden. simpl.
       rewrite Pos.mul_1_r. reflexivity.
   - unfold conc.
@@ -2198,14 +2198,14 @@ Proof.
       apply CRlt_asym, CR_of_Q_pos. reflexivity. rewrite CRmult_1_l.
       unfold INR. rewrite CRmult_comm, <- CRmult_assoc. rewrite <- CR_of_Q_mult.
       setoid_replace ((Z.of_nat (S n0) # 1) * (1 # Pos.of_nat (S n0)))%Q with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_l. apply (CRmult_le_reg_r (b-a+1) _ _ H0).
+      rewrite CRmult_1_l. apply (CRmult_le_reg_r (b-a+1) _ _ H0).
       rewrite CRmult_assoc, CRinv_l, CRmult_1_r, CRmult_1_l.
       apply (CRle_trans _ (b-a + 0)). rewrite CRplus_0_r. apply CRle_refl.
       apply CRplus_le_compat_l. apply CRlt_asym, CRzero_lt_one.
       unfold Z.of_nat. rewrite Pos.of_nat_succ.
       unfold Qeq. simpl. do 2 rewrite Pos.mul_1_r. reflexivity.
       apply CRmult_le_0_compat.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_le. discriminate.
+      apply CR_of_Q_le. discriminate.
       rewrite <- (CRplus_opp_r a). apply CRplus_le_compat_r. exact leab.
     + intros.
       rewrite (addSub (an i) ((b + - a) * CR_of_Q R (Z.of_nat (S i0) # Pos.of_nat (S n0))) ((b + - a) * CR_of_Q R (Z.of_nat i0 # Pos.of_nat (S n0)))).
@@ -2346,13 +2346,13 @@ Proof.
   assert (a-a <= c-a).
   { apply CRplus_le_compat_r, leac. }
   assert (CR_of_Q R 0 <= c-a).
-  { rewrite CR_of_Q_zero, <- (CRplus_opp_r a). exact H. }
+  { rewrite <- (CRplus_opp_r a). exact H. }
   rewrite (UC_integral_translate f a c (-a) _ H).
   rewrite (UC_integral_bound_proper
              _ (a+-a) (c+-a) (CR_of_Q R 0) (c+-a)
              cont_mod _ _ H0).
   assert (CR_of_Q R 0 <= b-a).
-  { rewrite CR_of_Q_zero, <- (CRplus_opp_r a).
+  { rewrite <- (CRplus_opp_r a).
     apply CRplus_le_compat_r. exact leab. }
   assert (b-a <= c-a).
   { apply CRplus_le_compat_r. exact lebc. }
@@ -2363,10 +2363,10 @@ Proof.
     { apply CRplus_le_compat_r. exact leab. }
     rewrite (UC_integral_translate f a b (-a) _ H3).
     apply UC_integral_bound_proper.
-    rewrite CRplus_opp_r, CR_of_Q_zero. reflexivity. reflexivity.
+    rewrite CRplus_opp_r. reflexivity. reflexivity.
   - rewrite (UC_integral_translate f b c (-a) _ H2).
     apply UC_integral_bound_proper. reflexivity. reflexivity.
-  - rewrite CRplus_opp_r, CR_of_Q_zero. reflexivity.
+  - rewrite CRplus_opp_r. reflexivity.
   - reflexivity.
 Qed.
 
@@ -2393,12 +2393,12 @@ Proof.
   rewrite (CRsum_eq _ (fun k => c * (b-a) * CR_of_Q R (1# Pos.of_nat (S i)))).
   rewrite sum_const.
   setoid_replace (c * (b - a) * CR_of_Q R (1 # Pos.of_nat (S i)) * INR (S i) + - ((b + - a) * c))
-    with (CRzero R).
-  rewrite CRabs_right. rewrite <- CR_of_Q_zero. apply CR_of_Q_le; discriminate.
+    with (CR_of_Q R 0).
+  rewrite CRabs_right. apply CR_of_Q_le; discriminate.
   apply CRle_refl. unfold INR.
   rewrite CRmult_assoc, <- CR_of_Q_mult.
   setoid_replace ((1 # Pos.of_nat (S i)) * (Z.of_nat (S i) # 1))%Q with 1%Q.
-  rewrite CR_of_Q_one, CRmult_1_r, CRmult_comm.
+  rewrite CRmult_1_r, CRmult_comm.
   unfold CRminus. rewrite CRplus_opp_r. reflexivity.
   unfold Qmult, Qeq, Qnum, Qden.
   do 2 rewrite Z.mul_1_l. rewrite Z.mul_1_r, Pos.mul_1_r.
@@ -2432,7 +2432,6 @@ Proof.
   apply CRmult_le_compat_l.
   rewrite <- (CRplus_opp_r a). apply CRplus_le_compat.
   exact leab. apply CRle_refl.
-  rewrite <- CR_of_Q_zero.
   apply CR_of_Q_le. unfold Qle, Qnum, Qden.
   rewrite Z.mul_0_l, Z.mul_1_r. apply Nat2Z.is_nonneg.
   apply (CRplus_le_reg_l (-a)).
@@ -2440,7 +2439,7 @@ Proof.
   rewrite <- (CRmult_1_r (-a+b)), (CRplus_comm (-a)).
   apply CRmult_le_compat_l.
   rewrite <- (CRplus_opp_r a). apply CRplus_le_compat.
-  exact leab. apply CRle_refl. rewrite <- CR_of_Q_one.
+  exact leab. apply CRle_refl. 
   apply CR_of_Q_le. unfold Qle, Qnum, Qden.
   rewrite Z.mul_1_r, Z.mul_1_l. rewrite <- positive_nat_Z.
   rewrite Nat2Pos.id. apply Nat2Z.inj_le, le_S, H1. discriminate.
@@ -2502,7 +2501,7 @@ Proof.
     rewrite CRplus_0_r. apply CRle_refl.
     apply CRplus_le_compat_l. rewrite <- (CRmult_0_r (b-a)).
     apply CRmult_le_compat_l.
-    apply (CRle_minus a b), leab. rewrite <- CR_of_Q_zero.
+    apply (CRle_minus a b), leab. 
     apply CR_of_Q_le. unfold Qle, Qnum, Qden.
     rewrite Z.mul_0_l, Z.mul_1_r. apply Nat2Z.is_nonneg.
     apply (CRplus_le_reg_l (-a)).
@@ -2510,7 +2509,7 @@ Proof.
     rewrite <- (CRmult_1_r (-a+b)), (CRplus_comm (-a)).
     apply CRmult_le_compat_l.
     rewrite <- (CRplus_opp_r a). apply CRplus_le_compat.
-    exact leab. apply CRle_refl. rewrite <- CR_of_Q_one.
+    exact leab. apply CRle_refl. 
     apply CR_of_Q_le. unfold Qle, Qnum, Qden.
     rewrite Z.mul_1_r, Z.mul_1_l. rewrite <- positive_nat_Z.
     rewrite Nat2Pos.id. apply Nat2Z.inj_le, le_S, H0. discriminate. }
@@ -2702,7 +2701,8 @@ Proof.
       rewrite sum_scale, (CRmult_comm (CRsum (fun n0 => INR n0) n)).
       rewrite sum_INR.
       rewrite CRmult_assoc.
-      setoid_replace (CR_of_Q R (1 # Pos.of_nat (S n)) * INR (S n)) with (CRone R).
+      setoid_replace (CR_of_Q R (1 # Pos.of_nat (S n)) * INR (S n))
+        with (CR_of_Q R 1).
       rewrite CRmult_1_r. apply CRplus_morph. reflexivity.
       rewrite <- (CRmult_comm ((b - a) * (b - a) * CR_of_Q R (1 # 2))).
       rewrite CRmult_assoc. rewrite (CRmult_assoc ((b-a)*(b-a))).
@@ -2718,7 +2718,7 @@ Proof.
       rewrite Pos2Z.inj_mul. apply f_equal2. 2: reflexivity.
       rewrite <- positive_nat_Z. rewrite Nat2Pos.id. reflexivity.
       discriminate. discriminate. discriminate.
-      unfold INR. rewrite <- CR_of_Q_mult, <- CR_of_Q_one. apply CR_of_Q_morph.
+      unfold INR. rewrite <- CR_of_Q_mult. apply CR_of_Q_morph.
       unfold Qmult, Qeq, Qnum, Qden. rewrite Pos.mul_1_r.
       rewrite Z.mul_1_l, Z.mul_1_l, Z.mul_1_r.
       rewrite <- positive_nat_Z. rewrite Nat2Pos.id. reflexivity.
@@ -2765,8 +2765,8 @@ Proof.
     unfold Qle,Qnum,Qden. do 2 rewrite Z.mul_1_l.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
     rewrite Nat2Pos.id. apply le_S,H. discriminate.
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_le; discriminate.
-    unfold CRminus. rewrite <- CR_of_Q_one, <- CR_of_Q_opp, <- CR_of_Q_plus.
+    apply CR_of_Q_le; discriminate.
+    unfold CRminus. rewrite <- CR_of_Q_opp, <- CR_of_Q_plus.
     apply CR_of_Q_morph. unfold Qopp,Qplus,Qeq,Qnum,Qden.
     apply f_equal2. 2: reflexivity.
     rewrite Z.mul_1_l, Z.mul_1_r.
@@ -2784,11 +2784,11 @@ Proof.
     rewrite CRplus_assoc, CRplus_opp_l, CRplus_0_r.
     rewrite <- CRopp_mult_distr_l. reflexivity.
     apply (CRmult_eq_reg_r (CR_of_Q R 2)).
-    left. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt; reflexivity.
+    left. apply CR_of_Q_lt; reflexivity.
     rewrite CRmult_plus_distr_r.
     rewrite CRmult_assoc, CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((1#2)*2)%Q with 1%Q. 2: reflexivity.
-    rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_1_r, CRmult_1_r.
+    rewrite (CR_of_Q_plus R 1 1), CRmult_1_r, CRmult_1_r.
     rewrite CRmult_plus_distr_l. rewrite CRmult_1_r. rewrite CRplus_assoc.
     apply CRplus_morph. reflexivity. unfold CRminus.
     rewrite CRplus_comm, CRplus_assoc, CRplus_opp_l.
@@ -2922,17 +2922,17 @@ Proof.
     rewrite (CRplus_comm (eta*eta)), <- CRplus_assoc, <- CRplus_assoc.
     rewrite <- CRmult_plus_distr_l, <- CR_of_Q_plus, Qinv_plus_distr.
     setoid_replace (1+1#2)%Q with 1%Q. 2: reflexivity.
-    rewrite CR_of_Q_one, CRmult_1_r, <- CRopp_mult_distr_l.
+    rewrite CRmult_1_r, <- CRopp_mult_distr_l.
     rewrite CRplus_opp_l, CRplus_0_l. reflexivity.
     unfold CRminus. rewrite CRmult_comm, CRmult_plus_distr_l.
     rewrite <- CRmult_assoc, <- CRmult_assoc, <- CR_of_Q_mult.
-    setoid_replace ((1#2)*2)%Q with 1%Q. rewrite CR_of_Q_one, CRmult_1_l.
+    setoid_replace ((1#2)*2)%Q with 1%Q. rewrite CRmult_1_l.
     rewrite CRplus_comm, CRmult_comm, CRopp_mult_distr_l, (CRmult_comm a eta).
     reflexivity. reflexivity.
     unfold CRminus. rewrite CRmult_comm, CRmult_plus_distr_l.
     rewrite <- CR_of_Q_opp, <- CRmult_assoc, <- CRmult_assoc, <- CR_of_Q_mult.
     setoid_replace ((1#2)*-(2))%Q with (-(1))%Q.
-    rewrite CR_of_Q_opp, CR_of_Q_one, <- CRopp_mult_distr_l, CRmult_1_l.
+    rewrite CR_of_Q_opp, <- CRopp_mult_distr_l, CRmult_1_l.
     rewrite CRplus_comm, CRmult_comm, CRopp_mult_distr_l.
     rewrite (CRopp_mult_distr_r eta b), (CRmult_comm eta (-b)).
     reflexivity. reflexivity.
@@ -2941,7 +2941,7 @@ Proof.
     rewrite <- CRplus_assoc, CRplus_opp_r, CRplus_0_l.
     rewrite CRmult_plus_distr_r, CRopp_plus_distr, <- CRplus_assoc.
     apply CRplus_morph. 2: reflexivity.
-    rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one.
+    rewrite (CR_of_Q_plus R 1 1).
     rewrite <- (CRopp_mult_distr_l), CRmult_plus_distr_r, CRmult_1_l.
     rewrite <- (CRopp_mult_distr_l), CRmult_plus_distr_r.
     rewrite CRopp_plus_distr, (CRmult_comm eta). reflexivity.
@@ -2952,7 +2952,7 @@ Proof.
     rewrite CRopp_mult_distr_l, CRopp_involutive.
     rewrite CRopp_mult_distr_r, CRopp_involutive.
     rewrite CRopp_mult_distr_l, CRopp_involutive, <- CRplus_assoc.
-    apply CRplus_morph. rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one.
+    apply CRplus_morph. rewrite (CR_of_Q_plus R 1 1).
     rewrite CRmult_plus_distr_r, CRmult_1_l, CRmult_plus_distr_r.
     rewrite (CRmult_comm eta a). reflexivity.
     rewrite CRopp_mult_distr_r. reflexivity.

--- a/reals/stdlib/ConstructiveDiagonal.v
+++ b/reals/stdlib/ConstructiveDiagonal.v
@@ -423,7 +423,7 @@ Qed.
 Lemma powerPositive : forall {R : ConstructiveReals} (n:nat),
     (0 < CRpow (CR_of_Q R 2) n).
 Proof.
-  intros. apply pow_lt. simpl. rewrite <- CR_of_Q_zero.
+  intros. apply pow_lt. simpl. 
   apply CR_of_Q_lt. reflexivity.
 Qed.
 
@@ -464,10 +464,10 @@ Proof.
     apply (CRmult_lt_compat_l eps) in maj. 2: exact H.
     rewrite CRinv_r in maj.
     apply (CRmult_lt_reg_l (CR_of_Q R (Z.pos (Pos.of_nat epsN) # 1))).
-    rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+    apply CR_of_Q_lt. reflexivity.
     rewrite <- CR_of_Q_mult.
     setoid_replace ((Z.pos (Pos.of_nat epsN) # 1) * (1 # Pos.of_nat epsN))%Q with 1%Q.
-    rewrite CRmult_comm. rewrite CR_of_Q_one.
+    rewrite CRmult_comm. 
     apply (CRlt_le_trans _ _ _ maj).
     apply CRmult_le_compat_l_half. exact H.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden.
@@ -477,7 +477,7 @@ Proof.
     unfold Qmult, Qeq, Qnum, Qden. do 2 rewrite Z.mul_1_r. reflexivity.
   - destruct (DiagTruncateRect _ u sumCol eps n H H0) as [pp geo].
     assert (0 < CRpow (CR_of_Q R (1#2)) (S n)).
-    { apply pow_lt. simpl. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity. }
+    { apply pow_lt. simpl. apply CR_of_Q_lt. reflexivity. }
     destruct (CRup_nat (CRinv R eps (inr H) * (CRinv R (CRpow (CR_of_Q R (1#2)) (S n))) (inr H1)))
       as [epsN maj].
     specialize (H0 (S n) (Pos.of_nat epsN)) as [p lim].
@@ -494,16 +494,17 @@ Proof.
       apply (CRmult_lt_compat_l eps) in maj. 2: exact H.
       rewrite <- CRmult_assoc, CRinv_r, CRmult_1_l in maj.
       apply (CRmult_lt_compat_l (CRpow (CR_of_Q R (1 # 2)) (S n))) in maj.
-      2: apply pow_lt; rewrite <- CR_of_Q_zero; apply CR_of_Q_lt; reflexivity.
+      2: apply pow_lt; apply CR_of_Q_lt; reflexivity.
       rewrite CRinv_r in maj.
       apply (CRmult_lt_reg_l (CR_of_Q R (Z.pos (Pos.of_nat epsN) # 1))).
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+      apply CR_of_Q_lt. reflexivity.
       rewrite <- CR_of_Q_mult.
-      setoid_replace ((Z.pos (Pos.of_nat epsN) # 1) * (1 # Pos.of_nat epsN))%Q with 1%Q.
-      rewrite CR_of_Q_one. apply (CRlt_le_trans _ _ _ maj).
+      setoid_replace ((Z.pos (Pos.of_nat epsN) # 1) * (1 # Pos.of_nat epsN))%Q
+        with 1%Q.
+      apply (CRlt_le_trans _ _ _ maj).
       rewrite CRmult_comm. rewrite <- CRmult_assoc.
       apply CRmult_le_compat_r. apply CRlt_asym, pow_lt.
-      simpl. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt.
+      simpl. apply CR_of_Q_lt.
       reflexivity. rewrite CRmult_comm. apply CRmult_le_compat_r.
       apply CRlt_asym, H.
       apply CR_of_Q_le. unfold Qle, Qnum, Qden.
@@ -556,7 +557,7 @@ Proof.
       (CRsum (diagSeq (fun i j : nat => CRabs _ (u i j))) (diagPlane 0 (S n + p)) - sAbs
        + (sAbs - CRsum (diagSeq (fun i j : nat => CRabs _ (u i j))) (diagPlane 0 n))).
   apply (CRle_lt_trans _ _ _ (CRabs_triang _ _)).
-  rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_plus_distr_l, CRmult_1_r.
+  rewrite (CR_of_Q_plus R 1 1), CRmult_plus_distr_l, CRmult_1_r.
   apply CRplus_le_lt_compat. apply CRlt_asym.
   apply (H (diagPlane 0 (S n + p))).
   unfold diagPlane. rewrite plus_0_l. rewrite plus_0_l.
@@ -596,7 +597,7 @@ Proof.
   { intro n. unfold diagSeq. destruct (diagPlaneInv n). apply CRabs_pos. }
   assert (0 < eps * CRpow (CR_of_Q R (1#2)) 3) as eighthEpsPos.
   { apply CRmult_lt_0_compat. assumption. apply pow_lt.
-    simpl. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity. }
+    simpl. apply CR_of_Q_lt. reflexivity. }
   destruct (H0 (eps * CRpow (CR_of_Q R (1#2)) 3) eighthEpsPos) as [Nabs H2].
   pose proof (DiagTriangleShift Nabs) as tShift.
   destruct (diagPlaneInv Nabs) as [i j] eqn:desNabs.
@@ -611,7 +612,7 @@ Proof.
     apply CRlt_asym.
     destruct (DiagTruncateRect u sumCol (eps * CRpow (CR_of_Q R (1#2)) 4) n) as [p geo].
     apply CRmult_lt_0_compat. assumption. apply pow_lt.
-    simpl. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+    simpl. apply CR_of_Q_lt. reflexivity.
     intros. apply H1.
     setoid_replace (CRsum sumCol n - CRsum (diagSeq u) (diagPlane 0 n))
       with (CRsum sumCol n - CRsum (fun k => (CRsum (u k) (p+(n-k)))) n
@@ -641,12 +642,12 @@ Proof.
       setoid_replace (CRpow (CR_of_Q R (1 # 2)) 3)
         with (CRpow (CR_of_Q R (1 # 2)) 4 * CR_of_Q R 2).
       apply CRmult_lt_compat_l. apply pow_lt. simpl.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+      apply CR_of_Q_lt. reflexivity.
       apply GeoHalfBelowTwo.
       setoid_replace (CRpow (CR_of_Q R (1 # 2)) 4)
         with (CR_of_Q R (1#2) * CRpow (CR_of_Q R (1 # 2)) 3). 2: reflexivity.
       rewrite CRmult_comm, <- CRmult_assoc, <- (CR_of_Q_mult _ 2).
-      setoid_replace (2 * (1 # 2))%Q with 1%Q. rewrite CR_of_Q_one, CRmult_1_l.
+      setoid_replace (2 * (1 # 2))%Q with 1%Q. rewrite CRmult_1_l.
       reflexivity. reflexivity.
       intros. apply CRmult_comm.
     + destruct p.
@@ -655,8 +656,8 @@ Proof.
       unfold CRminus.
       rewrite CRplus_opp_r. rewrite CRabs_right. 2: apply CRle_refl.
       apply CRmult_lt_0_compat. apply CRmult_lt_0_compat.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
-      assumption. apply pow_lt. simpl. rewrite <- CR_of_Q_zero.
+      apply CR_of_Q_lt. reflexivity.
+      assumption. apply pow_lt. simpl. 
       apply CR_of_Q_lt. reflexivity.
       simpl. rewrite diagSumTriangle. reflexivity.
       setoid_replace (CRsum (fun k : nat => CRsum (u k) (S p + (n - k))) n)
@@ -680,7 +681,7 @@ Proof.
               + (s - CRsum (diagSeq u) (diagPlane 0 n))).
       apply (CRle_trans _ _ _ (CRabs_triang _ _)).
       unfold INR. simpl (Z.of_nat 2 # 1).
-      rewrite (CR_of_Q_plus R 1 1), CR_of_Q_one, CRmult_plus_distr_r, CRmult_1_l.
+      rewrite (CR_of_Q_plus R 1 1), CRmult_plus_distr_r, CRmult_1_l.
       rewrite CRmult_plus_distr_r.
       apply CRplus_le_compat.
       apply (CRle_trans _ (sAbs - CRsum (fun n0 : nat => CRabs _ (diagSeq u n0))
@@ -721,7 +722,7 @@ Proof.
       apply (le_trans _ (diagPlane 0 n)); assumption. rewrite <- (CRmult_comm (CR_of_Q R 2)).
       rewrite CRmult_assoc. apply CRmult_lt_compat_r. apply CRmult_lt_0_compat.
       assumption. apply pow_lt. simpl.
-      rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+      apply CR_of_Q_lt. reflexivity.
       apply CR_of_Q_lt. reflexivity.
       setoid_replace (@INR R 6) with (@INR R 2 + @INR R 4).
       do 2 rewrite CRmult_plus_distr_r. reflexivity.
@@ -743,7 +744,7 @@ Proof.
       reflexivity.
     + setoid_replace (@INR R 7) with (1 + @INR R 6).
       do 2 rewrite CRmult_plus_distr_r. rewrite CRmult_1_l. reflexivity.
-      unfold INR. rewrite <- CR_of_Q_one, <- CR_of_Q_plus. apply CR_of_Q_morph.
+      unfold INR. rewrite <- CR_of_Q_plus. apply CR_of_Q_morph.
       rewrite Qinv_plus_distr. reflexivity.
     + unfold CRminus. rewrite CRplus_assoc. apply CRplus_morph.
       reflexivity. rewrite <- CRplus_assoc, CRplus_opp_l, CRplus_0_l. reflexivity.
@@ -767,10 +768,10 @@ Proof.
     setoid_replace (INR 7 * eps + eps) with (eps * INR 8).
     rewrite CRmult_assoc. unfold INR. rewrite <- CR_of_Q_mult.
     setoid_replace ((Z.of_nat 8 # 1) * (1 # 8))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_r. reflexivity. reflexivity.
+    rewrite CRmult_1_r. reflexivity. reflexivity.
     setoid_replace (@INR R 8) with (1 + @INR R 7).
     rewrite CRmult_plus_distr_l, CRmult_1_r, CRplus_comm, CRmult_comm. reflexivity.
-    unfold INR. rewrite <- CR_of_Q_one, <- CR_of_Q_plus.
+    unfold INR. rewrite <- CR_of_Q_plus.
     apply CR_of_Q_morph. reflexivity.
     unfold CRpow. rewrite CRmult_1_r.
     do 2 rewrite <- CR_of_Q_mult. apply CR_of_Q_morph. reflexivity.
@@ -814,7 +815,7 @@ Proof.
   intros n.
   destruct (cvSumCol (2*n)%positive) as [N H1].
   assert (0 < CR_of_Q R (1 # 4*n)) as quarterEpsPos.
-  { rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity. }
+  { apply CR_of_Q_lt. reflexivity. }
   destruct (DiagTruncateRect u sumCol (CR_of_Q R (1 # 4*n)) N quarterEpsPos cvCol)
     as [p H2].
   exists (diagPlane 0 (N+p)). intros.
@@ -880,7 +881,7 @@ Qed.
 
 Lemma Rlt_0_half : forall {R : ConstructiveReals}, 0 < CR_of_Q R (1#2).
 Proof.
-  intro R. rewrite <- CR_of_Q_zero. apply CR_of_Q_lt. reflexivity.
+  intro R. apply CR_of_Q_lt. reflexivity.
 Qed.
 
 Fixpoint FindPointInSubdivision (Pn : nat -> nat) (n : nat)

--- a/reals/stdlib/ConstructivePartialFunctions.v
+++ b/reals/stdlib/ConstructivePartialFunctions.v
@@ -690,10 +690,10 @@ Proof.
                   (partialApply f x xdf + partialApply (Xabs f) x xdf))
     with (partialApply f x xdf + partialApply f x xdf).
   rewrite <- (CRmult_1_l (partialApply f x xdf)), <- CRmult_plus_distr_r.
-  rewrite <- CRmult_assoc, CRmult_1_l, <- CR_of_Q_one, <- CR_of_Q_plus.
+  rewrite <- CRmult_assoc, CRmult_1_l, <- CR_of_Q_plus.
   rewrite <- CR_of_Q_mult.
   setoid_replace ((1 # 2) * (1+1))%Q with 1%Q.
-  rewrite CR_of_Q_one. apply CRmult_1_l.
+  apply CRmult_1_l.
   reflexivity. rewrite CRplus_comm, CRplus_assoc.
   apply CRplus_morph. reflexivity.
   rewrite CRopp_plus_distr. rewrite CRopp_involutive.

--- a/reals/stdlib/ConstructiveUniformCont.v
+++ b/reals/stdlib/ConstructiveUniformCont.v
@@ -126,7 +126,7 @@ Proof.
       rewrite CRabs_opp. rewrite CRabs_right.
       rewrite <- (CRmult_1_r (cont_mod (- f x) abs)).
       rewrite CRmult_assoc. apply CRmult_lt_compat_l. apply c0.
-      rewrite CRmult_1_l. rewrite <- CR_of_Q_one. apply CR_of_Q_lt; reflexivity.
+      rewrite CRmult_1_l. apply CR_of_Q_lt; reflexivity.
       apply CRlt_asym.
       apply CRmult_lt_0_compat. apply c0.
       apply CR_of_Q_pos; reflexivity.
@@ -149,7 +149,7 @@ Proof.
       rewrite CRabs_right. rewrite <- (CRmult_1_r (cont_mod (- f x) abs)).
       rewrite CRmult_assoc. apply CRmult_lt_compat_l. apply c0.
       rewrite CRmult_1_l.
-      rewrite <- CR_of_Q_one. apply CR_of_Q_lt; reflexivity.
+      apply CR_of_Q_lt; reflexivity.
       apply CRlt_asym.
       apply CRmult_lt_0_compat. apply c0.
       apply CR_of_Q_pos; reflexivity.
@@ -172,7 +172,7 @@ Proof.
       rewrite CRabs_opp. rewrite CRabs_right.
       rewrite <- (CRmult_1_r (cont_mod (f x) abs)).
       rewrite CRmult_assoc. apply CRmult_lt_compat_l. apply c0.
-      rewrite CRmult_1_l. rewrite <- CR_of_Q_one. apply CR_of_Q_lt; reflexivity.
+      rewrite CRmult_1_l. apply CR_of_Q_lt; reflexivity.
       apply CRlt_asym.
       apply CRmult_lt_0_compat. apply c0.
       apply CR_of_Q_pos; reflexivity.
@@ -193,7 +193,7 @@ Proof.
         with (cont_mod (f x) abs * CR_of_Q R (1#2)).
       rewrite CRabs_right. rewrite <- (CRmult_1_r (cont_mod (f x) abs)).
       rewrite CRmult_assoc. apply CRmult_lt_compat_l. apply c0.
-      rewrite CRmult_1_l. rewrite <- CR_of_Q_one. apply CR_of_Q_lt; reflexivity.
+      rewrite CRmult_1_l. apply CR_of_Q_lt; reflexivity.
       apply CRlt_asym.
       apply CRmult_lt_0_compat. apply c0.
       apply CR_of_Q_pos; reflexivity.
@@ -248,7 +248,7 @@ Proof.
     apply H1. apply CRmin_r.
     rewrite <- CRmult_plus_distr_l, <- CR_of_Q_plus.
     setoid_replace ((1 # 2) + (1#2))%Q with 1%Q.
-    rewrite CR_of_Q_one, CRmult_1_r.
+    rewrite CRmult_1_r.
     reflexivity. reflexivity.
     unfold CRminus. do 2 rewrite CRplus_assoc. apply CRplus_morph.
     reflexivity. rewrite CRplus_comm, CRopp_plus_distr.
@@ -479,7 +479,7 @@ Lemma pow_inject_Q : forall {R : ConstructiveReals} (q : Q) (n : nat),
      -> (CR_of_Q R (q ^ Z.of_nat n) == CRpow (CR_of_Q R q) n).
 Proof.
   induction n.
-  - intros. simpl. apply CR_of_Q_one.
+  - intros. reflexivity.
   - intros. rewrite Nat2Z.inj_succ. unfold Z.succ. rewrite Qpower_plus.
     rewrite CR_of_Q_mult, IHn. simpl. apply CRmult_comm. exact H. exact H.
 Qed.
@@ -987,7 +987,7 @@ Qed.
 Lemma S_INR : forall {R : ConstructiveReals} (n:nat),
     INR (S n) == @INR R n + 1.
 Proof.
-  intros R n. unfold INR. rewrite <- CR_of_Q_one, <- CR_of_Q_plus.
+  intros R n. unfold INR. rewrite <- CR_of_Q_plus.
   apply CR_of_Q_morph. rewrite Qinv_plus_distr.
   unfold Qeq, Qnum, Qden. do 2 rewrite Z.mul_1_r.
   fold (1 + n)%nat.
@@ -1000,7 +1000,7 @@ Lemma sum_INR :
     == INR n * (INR (S n)) * CR_of_Q R (1#2).
 Proof.
   induction n.
-  - unfold CRsum, INR, Z.of_nat. rewrite CR_of_Q_zero, CRmult_0_l, CRmult_0_l.
+  - unfold CRsum, INR, Z.of_nat. rewrite CRmult_0_l, CRmult_0_l.
     reflexivity.
   - transitivity (CRsum INR n + @INR R (S n)).
     reflexivity. rewrite IHn. clear IHn.
@@ -1016,10 +1016,9 @@ Proof.
     rewrite CRmult_assoc, <- CR_of_Q_mult.
     rewrite CRmult_assoc, <- (CR_of_Q_mult _ (1#2)).
     setoid_replace ((1 # 2) * 2)%Q with 1%Q. 2: reflexivity.
-    rewrite CR_of_Q_one.
     do 2 rewrite CRmult_1_r. rewrite (CR_of_Q_plus R 1 1).
     do 2 rewrite S_INR. rewrite CRplus_assoc.
-    rewrite CR_of_Q_one. reflexivity.
+    reflexivity.
 Qed.
 
 Lemma CSUCTrapeze_CSUC
@@ -1113,7 +1112,7 @@ Proof.
   { induction k.
     - intros. inversion H1. unfold INR, Z.of_nat.
       rewrite (UniformContProper f fMod fUC _ a).
-      apply CRle_refl. rewrite CR_of_Q_zero.
+      apply CRle_refl. 
       rewrite CRmult_0_l. rewrite CRmult_0_l, CRplus_0_r. reflexivity.
     - intros. apply Nat.le_succ_r in H1. destruct H1.
       apply (CRle_trans _ (maxou k) _ (IHk H1)). apply CRmax_l.
@@ -1152,14 +1151,13 @@ Proof.
     apply CRmult_le_compat_l. apply CRlt_asym, (fst fUC).
     rewrite <- (CRplus_0_l (CR_of_Q R 2)), <- CRplus_assoc.
     apply CRplus_le_compat. 2: apply CRle_refl.
-    rewrite CRplus_0_r. rewrite <- CR_of_Q_zero. apply CR_of_Q_le.
+    rewrite CRplus_0_r. apply CR_of_Q_le.
     unfold Qle,Qnum,Qden. simpl. rewrite Z.mul_1_r. exact H3.
     apply CRle_minus. exact H1.
     rewrite (UniformContProper
                f fMod fUC _ (a + INR 0 * fMod 1 (CRzero_lt_one R) * CR_of_Q R (1#2))).
     apply CRplus_le_compat. 2: apply CRle_refl.
     apply maxouSpec, le_0_n. unfold INR, Z.of_nat.
-    rewrite CR_of_Q_zero.
     rewrite CRmult_0_l, CRmult_0_l, CRplus_0_r. reflexivity.
   - (* 0 < i *)
     apply CRltForget.
@@ -1185,7 +1183,7 @@ Proof.
       2: rewrite CRmult_comm; apply CRle_refl.
       do 2 rewrite CRmult_assoc. rewrite <- CR_of_Q_mult.
       setoid_replace ((1 # 2) * 2)%Q with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_r, CRmult_comm. apply CRle_refl. reflexivity.
+      rewrite CRmult_1_r, CRmult_comm. apply CRle_refl. reflexivity.
       unfold CRminus. rewrite CRopp_plus_distr, <- CRplus_assoc.
       apply (CRle_minus (CR_of_Q R (i # 1) * fMod 1 (CRzero_lt_one R) * CR_of_Q R (1 # 2))
                         (x - a)).
@@ -1193,7 +1191,7 @@ Proof.
       apply CR_of_Q_pos; reflexivity.
       do 2 rewrite CRmult_assoc. rewrite <- CR_of_Q_mult.
       setoid_replace ((1 # 2) * 2)%Q with 1%Q.
-      rewrite CR_of_Q_one, CRmult_1_r. exact H4. reflexivity.
+      rewrite CRmult_1_r. exact H4. reflexivity.
     + clear H5. apply CRplus_le_compat. 2: apply CRle_refl.
       unfold INR in maxouSpec.
       destruct i. exfalso; inversion H3. 2: exfalso; inversion H3.
@@ -1204,7 +1202,7 @@ Proof.
       2: apply (fst fUC).
       assert ((x-a)*CR_of_Q R 2 <= (b-a)*CR_of_Q R 2).
       { apply CRmult_le_compat_r.
-        rewrite <- CR_of_Q_zero. apply CR_of_Q_le; discriminate.
+        apply CR_of_Q_le; discriminate.
         apply CRplus_le_compat. exact H2. apply CRle_refl. }
       apply (CRlt_le_trans _ _ _ H4) in H5. clear H4.
       apply (CRlt_trans _ _ _ H5) in kmaj. clear H5.
@@ -1310,7 +1308,7 @@ Proof.
       rewrite CRmult_comm, CRmult_assoc, CRinv_l, CRmult_1_r.
       rewrite <- (CRmult_1_r eps), CRmult_assoc.
       apply CRmult_le_compat_l. apply CRlt_asym, epsPos.
-      rewrite CRmult_1_l, <- CR_of_Q_one. apply CR_of_Q_le; discriminate.
+      rewrite CRmult_1_l. apply CR_of_Q_le; discriminate.
 
       unfold CRminus. rewrite CRmult_0_l, CRplus_0_l, CRplus_0_l.
       apply CRopp_mult_distr_l.
@@ -1353,7 +1351,7 @@ Proof.
         rewrite CRmult_1_r. apply CRle_refl.
       * rewrite <- CRmult_plus_distr_l, <- CR_of_Q_plus.
         setoid_replace ((1#2) + (1#2))%Q with 1%Q.
-        rewrite CR_of_Q_one, CRmult_1_r. reflexivity. reflexivity.
+        rewrite CRmult_1_r. reflexivity. reflexivity.
       * unfold CRminus. do 2 rewrite CRmult_plus_distr_l.
         rewrite CRplus_assoc. apply CRplus_morph.
         apply CRmult_comm. rewrite <- CRplus_assoc, (CRmult_comm (g x)).
@@ -1385,7 +1383,7 @@ Proof.
         rewrite CRmult_1_r.
         rewrite <- (CRmult_1_r eps), CRmult_assoc.
         apply CRmult_le_compat_l. apply CRlt_asym, epsPos.
-        rewrite CRmult_1_l, <- CR_of_Q_one. apply CR_of_Q_le; discriminate.
+        rewrite CRmult_1_l. apply CR_of_Q_le; discriminate.
         rewrite CRmult_0_l. unfold CRminus. do 2 rewrite CRplus_0_l.
         rewrite CRopp_mult_distr_l. reflexivity.
       * rewrite c,c. do 2 rewrite CRmult_0_l.


### PR DESCRIPTION
Replace CRzero and CRone by CR_of_Q. Temporarily disable constructive measure theory until PR 12287 is merged in Coq.