### PR TITLE
Remove Qpos and gball from metric spaces

### DIFF
--- a/metric2/Classification.v
+++ b/metric2/Classification.v
@@ -31,28 +31,29 @@ At the lowest level a metric space is stable if its ball relation is
 double negation stable.  Arguablely this could be made a requirement
 of metric spaces. *)
 Definition stableMetric (ms:MetricSpace) :=
- forall e (x y:ms), ~~(ball e x y) -> ball e x y.
+ forall (e:Q) (x y:ms), ~~(ball e x y) -> ball e x y.
 
 Lemma stableEq : forall (ms:MetricSpace) (stable:stableMetric ms) (x y:ms),
  ~~(st_eq x y) -> st_eq x y.
 Proof.
  intros ms stable x y Hxy.
  apply ball_eq.
- intros e.
- apply stable.
+ intros e epos.
+ apply (stable e).
  revert Hxy.
  cut (st_eq x y -> ball (m:=ms) e x y).
   tauto.
  intros H.
  apply (ball_wd ms eq_refl _ _ H y y (reflexivity y)).
- apply ball_refl.
+ apply ball_refl. apply Qlt_le_weak, epos.
 Qed.
 
 (** At the next level up a metric space is located if you can choose
 between ball d x y and ~ball e x y for e < d.  Every located metric
 is a stable metric. *)
 Definition locatedMetric (ms:MetricSpace) :=
- forall (e d:Qpos) (x y:ms), proj1_sig e < proj1_sig d -> {ball d x y}+{~ball e x y}.
+  forall (e d:Q) (x y:ms),
+    e < d -> {ball d x y}+{~ball e x y}.
 
 (** At the top level a metric space is decidable if its ball relation
 is decidable.  Every decidable metric is a located metric. *)
@@ -65,7 +66,8 @@ Proof.
  intros ms H e d x y Hed.
  destruct (H e x y).
   left.
-  abstract ( apply ball_weak_le with e; try assumption; apply Qlt_le_weak; assumption).
+  abstract ( apply ball_weak_le with e;
+             try assumption; apply Qlt_le_weak; assumption).
  right; assumption.
 Defined.
 
@@ -74,10 +76,9 @@ Lemma located_stable : forall ms,
 Proof.
  intros ms H e x y Hxy.
  apply ball_closed.
- intros d.
- destruct (H e (Qpos_plus e d) x y); try (assumption || contradiction).
- destruct e,d; simpl.
- apply (Qplus_lt_l _ _ (-x0)). ring_simplify. exact q0.
+ intros d dpos.
+ destruct (H e (e+d) x y); try (assumption || contradiction).
+ apply (Qplus_lt_l _ _ (-e)). ring_simplify. exact dpos.
 Qed.
 (* begin hide *)
 Hint Resolve decidable_located located_stable : classification.

--- a/metric2/Classified.v
+++ b/metric2/Classified.v
@@ -93,11 +93,13 @@ Local Existing Instance mspc_setoid.
 
   Next Obligation. Proof with auto.
    constructor; try apply _.
-      intro e. apply mspc_refl.
-      simpl. destruct e. simpl. apply Qlt_le_weak, q.
-     intros. apply (mspc_triangle e1 e2 a b c)...
-    intros. apply mspc_closed...
-   apply mspc_eq.
+   - intros e epos. apply mspc_refl, epos.
+   - intros. apply (mspc_triangle e1 e2 a b c)...
+   - intros. apply mspc_closed...
+     intros. apply H1. apply Qpos_ispos.
+   - intros. apply mspc_eq. intro e. apply H1. apply Qpos_ispos.
+   - intros. apply Qnot_lt_le. intro abs.
+     destruct H0. exact (mspc_ball_negative0 e abs a b H1).
   Qed.
 
   (** .. which obviously have the same carrier: *)
@@ -290,9 +292,9 @@ Instance: ∀ X: MetricSpace, MetricSpaceBall X := λ X, @genball X _ (@ball X).
 Instance class_from_MetricSpace (X: MetricSpace): MetricSpaceClass X.
 Proof.
  apply genball_MetricSpace; try apply _.
-     apply msp_refl, X.
+     (* apply msp_refl, X.
     apply msp_sym, X.
-(*   apply msp_triangle, X.
+   apply msp_triangle, X.
   apply msp_eq, X.
  apply msp_closed, X.
 Qed.*)
@@ -959,8 +961,12 @@ Next Obligation. Proof with auto.
   destruct q...
   apply <- (ball_genball (@ball X) q)...
  pose proof (uniformlyContinuous f e a b H1).
- apply ball_genball...
- apply _.
+ apply (@ball_genball Y (@st_eq Y) _
+                      (fun q => ball (proj1_sig q))).
+ 2: auto.
+ intros x y H4 z t H5 u v H6.
+ unfold QposEq in H4. rewrite H4. 
+ rewrite H5, H6. reflexivity.
 Qed.
 
 (** Conversely, if we have a UniformlyContinuousFunction (between bundled metric spaces) and project
@@ -988,8 +994,12 @@ Section unwrap_uc.
    set (mu e) in *.
    destruct q...
    simpl.
-   apply ball_genball...
-   apply _.
+   apply (@ball_genball X (@st_eq X) _
+                      (fun q => ball (proj1_sig q))).
+   2: auto.
+   intros x y H4 z t H5 u v H6.
+   unfold QposEq in H4. rewrite H4. 
+   rewrite H5, H6. reflexivity.
   Qed.
 
 End unwrap_uc.

--- a/metric2/Complete.v
+++ b/metric2/Complete.v
@@ -1,5 +1,6 @@
 (*
 Copyright © 2006-2008 Russell O’Connor
+Copyright © 2020 Vincent Semeria
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this proof and associated documentation files (the "Proof"), to deal in
@@ -48,7 +49,7 @@ property.
 *)
 
 Definition is_RegularFunction (x:QposInf -> X) : Prop :=
- forall (e1 e2:Qpos), ball (m:=X) (e1 + e2) (x e1) (x e2).
+ forall (e1 e2:Qpos), ball (m:=X) (proj1_sig e1 + proj1_sig e2) (x e1) (x e2).
 
 (** A regular function consists of an approximation function, and
 a proof that the approximations are coherent. *)
@@ -61,7 +62,7 @@ Record RegularFunction : Type :=
  so we make a smart constructor that just takes a Qpos->X. *)
 
 Definition is_RegularFunction_noInf (x: Qpos -> X): Prop :=
-  forall e1 e2 : Qpos, ball (e1 + e2) (x e1) (x e2).
+  forall e1 e2 : Qpos, ball (proj1_sig e1 + proj1_sig e2) (x e1) (x e2).
 
 Section mkRegularFunction.
 
@@ -84,46 +85,44 @@ End mkRegularFunction.
 (** Regular functions form a metric space *)
 Definition regFunEq (f g : RegularFunction) :=
   forall (e1 e2 : Qpos),
-    ball (m:=X) (e1 + e2) (approximate f e1) (approximate g e2).
+    ball (m:=X) (proj1_sig e1 + proj1_sig e2) (approximate f e1) (approximate g e2).
 
 Lemma regFunEq_e : forall (f g : RegularFunction),
-    (forall e : Qpos, ball (m:=X) (e + e) (approximate f e) (approximate g e)) -> (regFunEq f g).
+    (forall e : Qpos, ball (m:=X) (proj1_sig e + proj1_sig e) (approximate f e) (approximate g e)) -> (regFunEq f g).
 Proof.
  unfold regFunEq.
  intros f g H e1 e2.
  apply ball_closed.
- intros d.
- assert (0 < (1#4)) as quarterPos. reflexivity.
- assert (QposEq (e1 + e2 + d)%Qpos
-                ((e1 + (exist _ _ quarterPos *d)
-                  + ((exist _ _ quarterPos*d) + (exist _ _ quarterPos*d))
-                  +((exist _ _ quarterPos*d)+e2)))%Qpos).
- { unfold QposEq; simpl; ring. }
- rewrite H0. clear H0.
+ intros d dpos.
+ setoid_replace (proj1_sig e1 + proj1_sig e2 + d)
+   with ((proj1_sig e1 + ((1#4) *d)
+          + (((1#4)*d) + ((1#4)*d))
+          +(((1#4)*d)+proj1_sig e2)))
+   by (simpl; ring).
   eapply ball_triangle.
    eapply ball_triangle.
-    apply regFun_prf.
-   apply H.
-  apply regFun_prf.
+    apply (regFun_prf _ e1 ((1#4)*exist _ _ dpos)%Qpos).
+   apply (H ((1 # 4) * exist (Qlt 0) d dpos)%Qpos).
+  apply (regFun_prf _ ((1 # 4) * exist (Qlt 0) d dpos)%Qpos e2).
 Qed.
 
 Lemma regFunEq_e_small : forall (f g : RegularFunction) (E:Qpos),
-    (forall (e:Qpos), proj1_sig e <= proj1_sig E -> ball (m:=X) (e+e) (approximate f e) (approximate g e)) -> (regFunEq f g).
+    (forall (e:Qpos), proj1_sig e <= proj1_sig E -> ball (m:=X) (proj1_sig e+ proj1_sig e) (approximate f e) (approximate g e)) -> (regFunEq f g).
 Proof.
  intros f g E H.
  apply regFunEq_e.
  intros e.
  apply ball_closed.
- intros d.
+ intros d dpos.
  assert (0 < (1#4)) as quarterPos. reflexivity. 
- set (e':=Qpos_min (exist _ _ quarterPos*d) E).
- apply ball_weak_le with ((e+e')+(e'+e')+(e'+e))%Qpos.
+ set (e':=Qpos_min (exist _ _ quarterPos*exist _ _ dpos) E).
+ apply ball_weak_le with (proj1_sig ((e+e')+(e'+e')+(e'+e))%Qpos).
  apply (Qle_trans _
-                  (proj1_sig ((e+exist _ _ quarterPos*d)
-                   +(exist _ _ quarterPos*d+exist _ _ quarterPos*d)
-                   +(exist _ _ quarterPos*d+e))%Qpos)).
+                  (proj1_sig ((e+exist _ _ quarterPos*exist _ _ dpos)
+                   +(exist _ _ quarterPos*exist _ _ dpos+exist _ _ quarterPos*exist _ _ dpos)
+                   +(exist _ _ quarterPos*exist _ _ dpos+e))%Qpos)).
  - simpl. ring_simplify. apply Qplus_le_r.
-   apply (Qle_trans _ ((4#1) * proj1_sig (Qpos_mult (exist (Qlt 0) (1 # 4) quarterPos) d))).
+   apply (Qle_trans _ ((4#1) * ((1 # 4) * d))).
    2: simpl; ring_simplify; apply Qle_refl.
    apply Qmult_le_l. reflexivity. apply Qpos_min_lb_l. 
  - simpl. ring_simplify. apply Qle_refl.
@@ -140,59 +139,56 @@ Proof.
  split.
  - unfold Reflexive.
    intros; apply regFunEq_e; intros; apply ball_refl.
+   apply (Qpos_nonneg (e+e)).
  - unfold Symmetric, regFunEq.
   intros.
   apply ball_sym.
-  assert (QposEq (e1+e2)%Qpos (e2+e1)%Qpos).
-  { unfold QposEq; simpl; ring. }
-  rewrite H0. apply H.
+  rewrite Qplus_comm. apply H.
  - unfold Transitive, regFunEq.
  intros.
  apply ball_closed.
  intros.
- pose (exist (Qlt 0) (1#2) eq_refl) as half.
- assert (QposEq (e1+e2+d)%Qpos ((e1 + half*d) + (half*d+e2))%Qpos).
- { unfold QposEq; simpl; ring. }
- rewrite H1. clear H1.
+ setoid_replace (proj1_sig e1 + proj1_sig e2 + d)
+   with ((proj1_sig e1 + (1#2)*d) + ((1#2)*d+proj1_sig e2))
+   by (simpl; ring).
   eapply ball_triangle.
-   apply H.
-  apply H0.
+   apply (H e1 ((1#2)*exist _ _ H1)%Qpos).
+  apply (H0 ((1#2)*exist _ _ H1)%Qpos e2).
 Qed.
 
 Definition regFun_Setoid := Build_RSetoid regFun_is_setoid.
 
-Definition regFunBall e (f g : RegularFunction) :=
-forall d1 d2, ball (m:=X) (d1+e+d2)%Qpos (approximate f d1) (approximate g d2).
+Definition regFunBall (e:Q) (f g : RegularFunction) :=
+  forall d1 d2, ball (m:=X) (proj1_sig d1+e+ proj1_sig d2)
+                (approximate f (Qpos2QposInf d1)) (approximate g (Qpos2QposInf d2)).
 
-Lemma regFunBall_wd : forall (e1 e2:Qpos), (QposEq e1 e2) ->
+Lemma regFunBall_wd : forall (e1 e2:Q), (e1 == e2) ->
             forall (x1 x2 : regFun_Setoid), (st_eq x1 x2) ->
             forall (y1 y2 : regFun_Setoid), (st_eq y1 y2) ->
             (regFunBall e1 x1 y1 <-> regFunBall e2 x2 y2).
 Proof.
- assert (forall x1 x2 : Qpos, QposEq x1 x2 -> forall x3 x4 : RegularFunction , regFunEq x3 x4 ->
+ assert (forall x1 x2 : Q, x1 == x2 -> forall x3 x4 : RegularFunction , regFunEq x3 x4 ->
    forall x5 x6 : RegularFunction , regFunEq x5 x6 -> (regFunBall x1 x3 x5 -> regFunBall x2 x4 x6)).
   unfold regFunBall.
   unfold regFunEq.
   intros a1 a2 Ha f1 f2 Hf g1 g2 Hg H d1 d2.
-  assert (QposEq (d1 + a2 + d2) (d1 + a1 + d2)).
-  { unfold QposEq in Ha; unfold QposEq; simpl; rewrite Ha; reflexivity. }
-  rewrite H0. 
-  clear H0 a2 Ha.
+  setoid_replace (proj1_sig d1 + a2 + proj1_sig d2)
+    with (proj1_sig d1 + a1 + proj1_sig d2)
+    by (unfold QposEq in Ha; simpl; rewrite Ha; reflexivity).
+  clear a2 Ha.
   apply ball_closed.
-  intros d.
-  assert (0 < (1#4)) as quarterPos. reflexivity. 
-  assert (QposEq (d1 + a1 + d2 + d)
-                 ((exist _ _ quarterPos*d+d1)
-          +(exist _ _ quarterPos*d + a1 + exist _ _ quarterPos*d)
-          +(exist _ _ quarterPos*d+d2))).
-  { unfold QposEq; simpl; ring. }
- rewrite H0. clear H0.
+  intros d dpos.
+  setoid_replace (proj1_sig d1 + a1 + proj1_sig d2 + d)
+    with (((1#4)*d+ proj1_sig d1)
+          +((1#4)*d + a1 + (1#4)*d)
+          +((1#4)*d+ proj1_sig d2))
+    by (simpl; ring).
   eapply ball_triangle.
    eapply ball_triangle.
     apply ball_sym.
-    apply Hf.
-   apply H.
-  apply Hg.
+    apply (Hf ((1#4)*exist _ _ dpos)%Qpos).
+   apply (H ((1#4)*exist _ _ dpos)%Qpos ((1#4)*exist _ _ dpos)%Qpos).
+  apply (Hg ((1#4)*exist _ _ dpos)%Qpos d2).
  intros; split.
   intros; eapply H.
      apply H0.
@@ -216,44 +212,45 @@ Lemma regFun_is_MetricSpace : is_MetricSpace regFun_Setoid regFunBall.
 Proof.
  unfold regFunBall.
  split.
-     intros e f d1 d2.
-     assert (QposEq (d1 + e + d2) (d1+d2+e)).
-     { unfold QposEq; simpl; ring. }
-     rewrite H. clear H.
-     apply ball_weak.
-     apply regFun_prf.
-    intros e f g H d1 d2.
+ - intros e epos f d1 d2.
+   rewrite <- Qplus_assoc, (Qplus_comm e), Qplus_assoc.
+   apply ball_weak. exact epos.
+   apply regFun_prf.
+ - intros e f g H d1 d2.
     apply ball_sym.
-    assert (QposEq (d1 + e + d2) (d2+e+d1)).
-    { unfold QposEq; simpl; ring. }
-    rewrite H0. clear H0.
+    rewrite Qplus_comm, <- (Qplus_comm e), Qplus_assoc.
     apply H.
-   intros e1 e2 a b c Hab Hbc d1 d2.
+ - intros e1 e2 a b c Hab Hbc d1 d2.
    apply ball_closed.
-   intros d3.
-   assert (0 < (1#2)) as halfPos. reflexivity. 
-   assert (QposEq (d1+(e1+e2)+d2+d3)
-                  ((d1 + e1 + exist _ _ halfPos*d3)+(exist _ _ halfPos*d3 + e2 + d2))).
-    { unfold QposEq; simpl; ring. }
-    rewrite H. clear H.
+   intros d3 dpos.
+   setoid_replace (proj1_sig d1+(e1+e2)+proj1_sig d2+d3)
+     with ((proj1_sig d1 + e1 + (1#2)*d3)+((1#2)*d3 + e2 + proj1_sig d2))
+     by (simpl; ring).
    eapply ball_triangle.
-    apply Hab.
-   apply Hbc.
-  intros e a b H d1 d2.
+    apply (Hab d1 ((1#2)*exist _ _ dpos)%Qpos).
+   apply (Hbc ((1#2)*exist _ _ dpos)%Qpos).
+ - intros e a b H d1 d2.
   apply ball_closed.
-  intros d.
-  assert (QposEq (d1+e+d2+d) (d1 + (e+d) + d2)).
-  { unfold QposEq; simpl; ring. }
-  rewrite H0. clear H0.
+  intros d dpos.
+  setoid_replace (proj1_sig d1+e+ proj1_sig d2+d)
+    with (proj1_sig d1 + (e+d) + proj1_sig d2)
+    by (simpl; ring).
   auto.
- unfold regFunEq.
- intros a b H e1 e2.
- apply ball_closed.
- intros d.
- assert (QposEq (e1+e2+d) (e1+d+e2)).
- { unfold QposEq; simpl; ring. }
- rewrite H0. clear H0. 
- auto.
+ - intros a b H e1 e2.
+   apply ball_closed.
+   intros d dpos.
+   rewrite <- Qplus_assoc, <- (Qplus_comm d), Qplus_assoc. apply H, dpos.
+ - intros. apply Qnot_lt_le. intro abs.
+   assert (0 < -e * (1#3)).
+   { apply (Qmult_lt_l _ _ (3#1)). reflexivity.
+     apply (Qplus_lt_l _ _ e).
+     ring_simplify. apply (Qlt_le_trans _ _ _ abs).
+     discriminate. }
+   specialize (H (exist _ _ H0) (exist _ _ H0)). simpl in H.
+   apply msp_nonneg in H. 2: apply X.
+   ring_simplify in H. apply (Qlt_not_le _ _ abs).
+   apply (Qmult_le_l _ _ (3#9)). reflexivity.
+   rewrite Qmult_0_r. exact H.
 Qed.
 
 (** We define the completion of a metric space to be the space of
@@ -263,12 +260,14 @@ Build_MetricSpace regFunBall_wd regFun_is_MetricSpace.
 
 (** The ball of regular functions is related to the underlying ball
 in ways that you would expect. *)
-Lemma regFunBall_ball : forall (x y:Complete) (e0 e1 e2:Qpos), ball e0 (approximate x e1) (approximate y e2) -> ball (e1 + e0 + e2) x y.
+Lemma regFunBall_ball : forall (x y:Complete) (e0 : Q) (e1 e2:Qpos),
+    ball e0 (approximate x e1) (approximate y e2)
+    -> ball (proj1_sig e1 + e0 + proj1_sig e2) x y.
 Proof.
  intros x y e0 e1 e2 H d1 d2.
- assert (QposEq (d1+(e1+e0+e2)+d2) ((d1+e1)+e0+(e2+d2))).
- { unfold QposEq; simpl; ring. }
- rewrite H0. clear H0.
+ setoid_replace (proj1_sig d1+(proj1_sig e1+e0+proj1_sig e2)+proj1_sig d2)%Q
+   with ((proj1_sig d1+proj1_sig e1)+e0+(proj1_sig e2+proj1_sig d2))
+   by (simpl; ring).
   eapply ball_triangle.
    eapply ball_triangle.
     apply regFun_prf.
@@ -276,20 +275,23 @@ Proof.
   apply regFun_prf.
 Qed.
 
-Lemma regFunBall_e : forall (x y:Complete) e, (forall d, ball (d + e + d) (approximate x d) (approximate y d)) -> ball e x y.
+Lemma regFunBall_e : forall (x y:Complete) (e:Q),
+    (forall d:Qpos, ball (proj1_sig d + e + proj1_sig d)
+                    (approximate x d) (approximate y d))
+    -> ball e x y.
 Proof.
  intros x y e H.
  apply ball_closed.
- intros d.
- assert (0 < (1#4)) as quarterPos. reflexivity. 
- assert (QposEq (e + d)
-                (exist _ _ quarterPos*d
-         + (exist _ _ quarterPos*d+e+exist _ _ quarterPos*d)
-         + exist _ _ quarterPos*d)).
- { unfold QposEq; simpl; ring. }
- rewrite H0. clear H0.
- apply regFunBall_ball.
- apply H.
+ intros d dpos.
+ setoid_replace (e + d)
+   with ((1#4)*d + ((1#4)*d+ e+(1#4)*d) + (1#4)*d)
+   by (simpl; ring).
+ apply (regFunBall_ball
+          x y 
+          ((1 # 4) * d + e + (1 # 4) * d)%Q
+          ((1#4)*exist _ _ dpos)%Qpos
+          ((1#4)*exist _ _ dpos)%Qpos ).
+ apply (H ((1#4)*(exist _ _ dpos))%Qpos).
 Qed.
 
 (**
@@ -300,6 +302,7 @@ Lemma Cunit_fun_prf (x:X) : is_RegularFunction (fun _ => x).
 Proof.
  intros d1 d2.
  apply ball_refl.
+ apply (Qpos_nonneg (d1+d2)).
 Qed.
 
 Definition Cunit_fun (x:X) : Complete :=
@@ -311,8 +314,8 @@ Proof.
  simpl in *.
  assert (QposEq (d1+e+d2) (e+(d1+d2))).
  { unfold QposEq; simpl; ring. }
- rewrite H. clear H.
- apply ball_weak.
+ unfold QposEq in H. rewrite H. clear H.
+ apply ball_weak. apply Qpos_nonneg.
  assumption.
 Qed.
 
@@ -320,40 +323,43 @@ Definition Cunit : X --> Complete :=
 Build_UniformlyContinuousFunction Cunit_prf.
 
 (** This injection preserves the metric *)
-Lemma ball_Cunit : forall e a b, ball e (Cunit a) (Cunit b) <-> ball e a b.
+Lemma ball_Cunit : forall (e:Q) a b,
+    ball e (Cunit a) (Cunit b) <-> ball e a b.
 Proof.
- intros e a b.
- simpl.
- unfold regFunBall.
- simpl.
- split.
-  intros H.
-  do 2 (apply ball_closed; intro).
-  assert (QposEq (e+d+d0) (d+e+d0)).
- { unfold QposEq; simpl; ring. }
- rewrite H0. clear H0.
- apply H.
- intros H d1 d2.
- apply Cunit_prf.
- assumption.
+  intros e a b. split.
+  - intros. simpl in H.
+    do 2 (apply ball_closed; intros).
+    rewrite <- (Qplus_comm d).
+    apply (H (exist _ _ H0) (exist _ _ H1)).
+  - intros H d1 d2.
+    pose proof (msp_nonneg (msp X) _ _ _ H).
+    apply Qle_lteq in H0. destruct H0.
+    apply (Cunit_prf (exist _ _ H0)). exact H.
+    rewrite <- H0, Qplus_0_r.
+    rewrite <- H0 in H. apply gball_0 in H.
+    simpl. rewrite H. apply ball_refl.
+    apply (Qpos_nonneg (d1+d2)).
 Qed.
 
 Lemma Cunit_eq : forall a b, st_eq (Cunit a) (Cunit b) <-> st_eq a b.
 Proof.
  intros a b.
  do 2 rewrite <- ball_eq_iff.
- split; intros H e; [rewrite <- ball_Cunit | rewrite -> ball_Cunit]; apply H.
+ split; intros H e epos; [rewrite <- (ball_Cunit e) | rewrite -> (ball_Cunit e)];
+ apply H; assumption.
 Qed.
 
-Lemma ball_approx_r : forall (x:Complete) e, ball e x (Cunit (approximate x e)).
+Lemma ball_approx_r : forall (x:Complete) (e:Qpos),
+    ball (proj1_sig e) x (Cunit (approximate x e)).
 Proof.
  intros x e d1 d2.
  simpl.
- apply ball_weak.
+ apply ball_weak. apply Qpos_nonneg.
  apply regFun_prf.
 Qed.
 
-Lemma ball_approx_l : forall (x:Complete) e, ball e (Cunit (approximate x e)) x.
+Lemma ball_approx_l : forall (x:Complete) (e:Qpos),
+    ball (proj1_sig e) (Cunit (approximate x e)) x.
 Proof.
  (* Set Firstorder Depth 6.
  firstorder fail with ball_sym ball_approx_r.
@@ -378,13 +384,15 @@ Proof.
 Qed.
 
 Lemma regFunBall_Cunit (e: Qpos) (x: Complete) (y: X):
-  regFunBall e x (Cunit y) <-> (forall d: Qpos, ball (d + e) (approximate x d) y).
+  regFunBall (proj1_sig e) x (Cunit y)
+  <-> (forall d: Qpos, ball (proj1_sig d + proj1_sig e) (approximate x d) y).
 Proof with auto.
  unfold regFunBall.
   split; intros.
   apply ball_closed.
   simpl in *...
- apply ball_weak...
+  intros. apply (H d (exist _ _ H0)).
+  apply ball_weak... apply Qpos_nonneg.
 Qed.
 
 Lemma regFun_prf_ex :
@@ -403,7 +411,8 @@ Arguments is_RegularFunction [X].
 
 Arguments Cunit {X}.
 
-Add Parametric Morphism X : (@Cunit_fun X) with signature (@st_eq _) ==> (@st_eq _) as Cunit_wd.
+Add Parametric Morphism X : (@Cunit_fun X)
+    with signature (@st_eq _) ==> (@st_eq _) as Cunit_wd.
 Proof.
  exact (@uc_wd _ _ Cunit).
 Qed.
@@ -416,13 +425,11 @@ Lemma lift_eq_complete {X Y : MetricSpace} (f g : Complete X --> Complete Y) :
   (forall x : X, st_eq (f (Cunit x)) (g (Cunit x)))
   -> (forall x : Complete X, st_eq (f x) (g x)).
 Proof.
-intros A x. apply ball_eq; intro e.
+intros A x. apply ball_eq; intros e epos.
 pose (exist (Qlt 0) (1#2) eq_refl) as half.
-set (e2 := (half * e)%Qpos).
+set (e2 := (half * exist _ _ epos)%Qpos).
 set (d := QposInf_min (mu f e2) (mu g e2)).
-assert (QposEq e (e2 + e2)).
-{ unfold QposEq; simpl; ring. }
-rewrite H. clear H.
+setoid_replace e with (proj1_sig (e2+e2)%Qpos) by (simpl; ring).
 apply ball_triangle with (b := f (Cunit (approximate x d))).
 + apply (UniformContinuity.uc_prf f).
   apply (ball_ex_weak_le _ d); [apply QposInf_min_lb_l | apply ball_ex_approx_r].
@@ -450,7 +457,7 @@ Lemma fasterIsRegular : is_RegularFunction (fun e => (approximate x (QposInf_bin
 Proof.
  intros e1 e2.
  simpl.
- apply ball_weak_le with (f e1 + f e2)%Qpos.
+ apply ball_weak_le with (proj1_sig (f e1 + f e2)%Qpos).
  simpl. apply Qplus_le_compat. apply Hf. apply Hf.
  apply regFun_prf.
 Qed.
@@ -462,7 +469,7 @@ Proof.
  apply regFunEq_e.
  intros e.
  simpl.
- apply ball_weak_le with (f e + e)%Qpos.
+ apply ball_weak_le with (proj1_sig (f e + e)%Qpos).
  simpl. apply Qplus_le_l. apply Hf.
  apply regFun_prf.
 Qed.
@@ -480,7 +487,9 @@ Qed.
 Definition QreduceApprox := faster Qpos_red QreduceApprox_prf.
 
 Lemma QreduceApprox_Eq : st_eq QreduceApprox x.
-Proof (fasterIsEq _ _).
+Proof.
+  apply (fasterIsEq _ _).
+Qed.
 (** In particular, halving the error of the approximation is a common
 case. *)
 Lemma doubleSpeed_prf : forall (e:Qpos),
@@ -499,7 +508,9 @@ Definition doubleSpeed
   := faster (Qpos_mult (exist (Qlt 0) (1#2) eq_refl)) doubleSpeed_prf.
 
 Lemma doubleSpeed_Eq : st_eq doubleSpeed x.
-Proof (fasterIsEq _ _).
+Proof.
+  apply (fasterIsEq _ _).
+Qed.
 
 End Faster.
 
@@ -521,12 +532,9 @@ Lemma Cjoin_fun_prf (x:Complete (Complete X)) : is_RegularFunction (Cjoin_raw x)
 Proof.
  intros d1 d2.
  rewrite <- ball_Cunit.
- assert (QposEq (d1 + d2)
-                ((1#2)*d1
-         + (exist (Qlt 0) (1#2) eq_refl*d1+exist (Qlt 0) (1#2) eq_refl*d2)
-         + exist (Qlt 0) (1#2) eq_refl*d2)).
- { unfold QposEq; simpl; ring. }
- rewrite H. clear H.
+ setoid_replace (proj1_sig d1 + proj1_sig d2)
+   with (proj1_sig ((1#2)*d1 + ((1#2)*d1+(1#2)*d2) + (1#2)*d2)%Qpos)
+   by (simpl; ring).
  apply ball_triangle with (approximate x (Qpos_mult (exist (Qlt 0) (1#2) eq_refl) d2)).
   apply ball_triangle with (approximate x (Qpos_mult (exist (Qlt 0) (1#2) eq_refl) d1)).
    apply ball_approx_l.
@@ -541,11 +549,10 @@ Lemma Cjoin_prf : is_UniformlyContinuousFunction Cjoin_fun Qpos2QposInf.
 Proof.
  intros e x y Hab d1 d2.
  do 2 rewrite <- ball_Cunit.
- assert (QposEq (d1 + e + d2)
-                ((exist (Qlt 0) (1#2) eq_refl*d1 + exist (Qlt 0) (1#2) eq_refl*d1)
-         + e + ((exist (Qlt 0) (1#2) eq_refl*d2) + exist (Qlt 0) (1#2) eq_refl*d2))).
- { unfold QposEq; simpl; ring. }
- rewrite H. clear H.
+ setoid_replace (proj1_sig d1 + proj1_sig e + proj1_sig d2)
+   with (proj1_sig (((1#2)*d1 + (1#2)*d1)
+                    + e + (((1#2)*d2) + (1#2)*d2)))%Qpos
+   by (simpl; ring).
  apply ball_triangle with y.
   apply ball_triangle with x.
    apply ball_triangle with (Cunit (approximate x ((1#2) * d1)%Qpos)).
@@ -608,7 +615,7 @@ Qed.
 
 Lemma Cmap_slow_raw_strong : forall (x:Complete X) (d:QposInf) (e:Qpos),
     QposInf_le d (QposInf_mult (Qpos2QposInf (exist (Qlt 0) (1#2) eq_refl)) (mu f e)) ->
-ball e (f (approximate x d)) (Cmap_slow_raw x e).
+ball (proj1_sig e) (f (approximate x d)) (Cmap_slow_raw x e).
 Proof.
  intros.
  apply (Cmap_slow_raw_strongInf x d e).
@@ -619,9 +626,9 @@ Lemma Cmap_slow_fun_prf (x:Complete X) : is_RegularFunction (Cmap_slow_raw x).
 Proof.
  intros e1 e2.
  unfold Cmap_slow_raw.
- cut (forall (e1 e2:Qpos), (QposInf_le (mu f e2) (mu f e1)) -> ball (m:=Y) (e1 + e2)
-   (f (approximate x (QposInf_mult (Qpos2QposInf (exist (Qlt 0) (1#2) eq_refl)) (QposInf_bind (mu f) e1))))
-     (f (approximate x (QposInf_mult (Qpos2QposInf (exist (Qlt 0) (1#2) eq_refl)) (QposInf_bind (mu f) e2))))).
+ cut (forall (e1 e2:Qpos), (QposInf_le (mu f e2) (mu f e1)) -> ball (m:=Y) (proj1_sig e1 + proj1_sig e2)
+   (f (approximate x (QposInf_mult (Qpos2QposInf (1#2)) (QposInf_bind (mu f) e1))))
+     (f (approximate x (QposInf_mult (Qpos2QposInf (1#2)) (QposInf_bind (mu f) e2))))).
   intros H.
   (* move this out *)
   assert (forall a b, {QposInf_le a b}+{QposInf_le b a}).
@@ -630,13 +637,11 @@ Proof.
   destruct (H0 (mu f e2) (mu f e1)).
    auto.
   apply ball_sym.
-  assert (QposEq (e1+e2) (e2+e1)).
- { unfold QposEq; simpl; ring. }
- rewrite H1. clear H1.
+  rewrite Qplus_comm.
    auto.
  clear e1 e2.
  intros e1 e2 H.
- apply ball_weak.
+ apply ball_weak. apply Qpos_nonneg.
  apply ball_sym.
  simpl.
  apply Cmap_slow_raw_strong.
@@ -679,13 +684,12 @@ Proof.
   destruct (mu f e0); try constructor.
   cut (forall z0 z1:Qpos, (proj1_sig z0 <= proj1_sig ((1#4)*q)%Qpos)
                      -> (proj1_sig z1 <= proj1_sig ((1#4)*q)%Qpos)
-                     -> ball q (approximate x z0) (approximate y z1)).
+                     -> ball (proj1_sig q) (approximate x z0) (approximate y z1)).
    intros H.
    destruct d1; destruct d2; simpl; apply H; autorewrite with  QposElim; auto with *.
   intros z0 z1 Hz0 Hz1.
   eapply ball_weak_le.
    2:apply Hxy.
-  autorewrite with QposElim.
   rewrite -> Qle_minus_iff in *.
   simpl. simpl in Hz0, Hz1.
   apply (Qplus_le_compat _ _ _ _ Hz0) in Hz1.
@@ -747,9 +751,9 @@ Proof.
  simpl.
  destruct (mu f e2) as [q|]; try constructor.
  simpl.
- apply ball_weak_le with ((1#2)*q)%Qpos.
+ apply ball_weak_le with (proj1_sig ((1#2)*q)%Qpos).
  simpl. 
- rewrite <- (Qmult_1_l (proj1_sig q)), Qmult_assoc.
+ rewrite <- (Qmult_1_l (proj1_sig q)) at 2.
  apply Qmult_le_r. apply Qpos_ispos. discriminate. 
  apply (Cmap_slow_raw_strong g x d0).
  apply QposInf_min_lb_r.
@@ -789,9 +793,9 @@ Proof.
   apply ball_triangle with x.
    apply ball_triangle with (Cunit (approximate x (half * (half * q))%Qpos)).
     rewrite -> ball_Cunit.
-    rewrite halfhalf.
+    unfold QposEq in halfhalf. rewrite halfhalf.
     apply ball_approx_l.
-   rewrite halfhalf.
+   unfold QposEq in halfhalf. rewrite halfhalf.
    apply ball_approx_l.
   apply ball_triangle with (Cunit (approximate x d0)).
    change (ball_ex (quarter * q)%Qpos x (Cunit (approximate x d0))).
@@ -806,7 +810,7 @@ Proof.
   destruct d0 as [d0|]; try constructor.
   apply ball_approx_r.
  apply ball_sym.
- apply ball_weak_le with (half*e2)%Qpos.
+ apply ball_weak_le with (proj1_sig (half*e2)%Qpos).
  simpl.
  rewrite <- (Qmult_1_l (proj1_sig e2)), Qmult_assoc.
  apply Qmult_le_r. apply Qpos_ispos. discriminate.
@@ -823,7 +827,7 @@ Proof.
  apply ball_triangle with x.
  apply ball_triangle with (Cunit (approximate x (half * (half * q))%Qpos)).
  - rewrite -> ball_Cunit. apply ball_approx_l.
- - rewrite halfhalf. apply ball_approx_l.
+ - unfold QposEq in halfhalf. rewrite halfhalf. apply ball_approx_l.
  - apply ball_triangle with (Cunit (approximate x d0)).
   change (ball_ex (eightth * q)%Qpos x (Cunit (approximate x d0))).
   apply ball_ex_weak_le with (d0)%QposInf.
@@ -842,11 +846,10 @@ Lemma MonadLaw5 : forall a, (Cjoin_fun (X:=X) (Cunit_fun _ a)) =m a.
 Proof.
  intros x e1 e2.
  simpl.
- pose (exist (Qlt 0) (1#2) eq_refl) as half. 
- assert (QposEq (e1+e2) (half*e1 + e2 + half*e1)).
- { unfold QposEq; simpl; ring. }
- rewrite H. clear H.
- apply ball_weak.
+ setoid_replace (proj1_sig e1+proj1_sig e2)
+   with (proj1_sig ((1#2)*e1 + e2 + (1#2)*e1)%Qpos)
+   by (simpl; ring).
+ apply ball_weak. apply Qpos_nonneg.
  apply regFun_prf.
 Qed.
 
@@ -854,26 +857,22 @@ Lemma MonadLaw6 : forall a, Cjoin_fun ((Cmap_slow_fun (X:=X) Cunit) a) =m a.
 Proof.
  intros a e1 e2.
  simpl.
- pose (exist (Qlt 0) (1#2) eq_refl) as half. 
- assert (QposEq (e1+e2)
-                (half*(half*e1) + e2 + exist (Qlt 0) (3#4) eq_refl*e1)).
- { unfold QposEq; simpl; ring. }
- rewrite H. clear H.
- apply ball_weak.
+ setoid_replace (proj1_sig e1 + proj1_sig e2)
+   with (proj1_sig ((1#2)*((1#2)*e1) + e2 + (3#4)*e1)%Qpos)
+   by (simpl; ring).
+ apply ball_weak. apply Qpos_nonneg.
  apply regFun_prf.
 Qed.
 
 Lemma MonadLaw7 : forall a, Cjoin_fun ((Cmap_slow_fun (X:=Complete (Complete X)) Cjoin) a) =m Cjoin_fun (Cjoin_fun a).
 Proof.
  intros x e1 e2.
- pose (exist (Qlt 0) (1#2) eq_refl) as halff. 
- pose (half := fun e:Qpos => (halff*e)%Qpos).
- apply ball_weak_le with  ((half (half e1)) + ((half (half e1)) + (half (half e1) + (half (half e2))) + (half (half e2))) + (half e2))%Qpos.
+ pose (half := fun e:Qpos => ((1#2)*e)%Qpos).
+ apply ball_weak_le with (proj1_sig ((half (half e1)) + ((half (half e1)) + (half (half e1) + (half (half e2))) + (half (half e2))) + (half e2))%Qpos).
   unfold half.
-  autorewrite with QposElim.
   simpl. ring_simplify.
   apply Qplus_le_l.
-  rewrite <- (Qmult_1_l (proj1_sig e1)), Qmult_assoc.
+  rewrite <- (Qmult_1_l (proj1_sig e1)) at 2.
   apply Qmult_le_r. apply Qpos_ispos. discriminate.
  apply (regFun_prf x).
 Qed.
@@ -883,12 +882,10 @@ between a twice completed metric space and a one completed metric space. *)
 Lemma CunitCjoin : forall a, (Cunit_fun _ (Cjoin_fun (X:=X) a)) =m a.
 Proof.
  intros x e1 e2 d1 d2.
- pose (exist (Qlt 0) (1#2) eq_refl) as half. 
- change (ball (d1 + (e1 + e2) + d2)
-   (approximate (approximate x (half * d1)%Qpos) (half * d1)%Qpos)
-     (approximate (approximate x e2) d2)).
- apply ball_weak_le with ((half * d1 + (half * d1 + e2) + d2))%Qpos.
-  autorewrite with QposElim.
+ change (ball (proj1_sig d1 + (proj1_sig e1 + proj1_sig e2) + proj1_sig d2)
+   (approximate (approximate x ((1#2) * d1)%Qpos) ((1#2) * d1)%Qpos)
+     (approximate (approximate x e2) (Qpos2QposInf d2))).
+ apply ball_weak_le with (proj1_sig (((1#2) * d1 + ((1#2) * d1 + e2) + d2))%Qpos).
   rewrite -> Qle_minus_iff. simpl.
   ring_simplify.
   auto with *.
@@ -936,16 +933,15 @@ Let CX_CY := UniformlyContinuousSpace (Complete X) (Complete Y).
 
 Lemma Cmap_strong_slow_prf : is_UniformlyContinuousFunction ((Cmap_slow (Y:=Y)):(X_Y -> CX_CY)) Qpos2QposInf.
 Proof.
- intros e f g H x.
+  intros e f g H. split. apply Qpos_nonneg.
+  intro x.
  apply ball_closed.
- intros e0.
- pose (exist (Qlt 0) (1#2) eq_refl) as half. 
- set (he0 := (half*e0)%Qpos).
- set (d0 := QposInf_min (Qpos2QposInf half*(mu f he0)) (Qpos2QposInf half*(mu g he0))).
+ intros e0 epos.
+ set (he0 := ((1#2)*exist _ _ epos)%Qpos).
+ set (d0 := QposInf_min (Qpos2QposInf (1#2)*(mu f he0)) (Qpos2QposInf (1#2)*(mu g he0))).
  set (a0 := approximate x d0).
- assert (QposEq (e+e0) (he0 + e + he0)).
- { unfold QposEq; simpl; ring. }
- rewrite H0. clear H0.
+ setoid_replace (proj1_sig e+e0) with (proj1_sig (he0 + e + he0)%Qpos)
+   by (simpl; ring).
  apply ball_triangle with (Cunit (g a0)).
   apply ball_triangle with (Cunit (f a0)).
   assert (QposEq he0 he0) by reflexivity.
@@ -997,9 +993,9 @@ Proof.
  change (Cmap_slow (Y:=Y) f2) with (Cmap_strong_slow f2).
  set (y1 :=(Cmap_strong_slow f1 x)).
  set (y2 :=(Cmap_strong_slow f2 x)).
- assert (QposEq (e1 + e2) (he1 + (he1 + he2) + he2)).
- { unfold QposEq; simpl; ring. }
- rewrite H. clear H.
+ setoid_replace (proj1_sig e1 + proj1_sig e2)
+   with (proj1_sig (he1 + (he1 + he2) + he2)%Qpos)
+   by (simpl; ring).
  rewrite <- ball_Cunit.
  apply ball_triangle with y2;[|apply ball_approx_r].
  apply ball_triangle with y1;[apply ball_approx_l|].
@@ -1011,7 +1007,7 @@ Definition Cap_slow_fun (f:Complete (X --> Y)) (x:Complete X) : Complete Y :=
 Build_RegularFunction (Cap_slow_fun_prf f x).
 
 Lemma Cap_slow_help (f:Complete (X --> Y)) (x:Complete X) (e:Qpos) :
- ball e (Cap_slow_fun f x) (Cmap_slow (approximate f e) x).
+ ball (proj1_sig e) (Cap_slow_fun f x) (Cmap_slow (approximate f e) x).
 Proof.
  intros d1 d2.
  pose (exist (Qlt 0) (1#2) eq_refl) as half. 
@@ -1020,10 +1016,10 @@ Proof.
  set (f2 := (approximate f e)).
  set (y1 := (Cmap_slow f1 x)).
  set (y2 := (Cmap_slow f2 x)).
- change (ball (d1 + e + d2) (approximate y1 d1') (approximate y2 d2)).
- assert (QposEq (d1 + e + d2) (d1' + (d1' + e) + d2)).
- { unfold QposEq; simpl; ring. }
- rewrite H. clear H.
+ change (ball (proj1_sig d1 + proj1_sig e + proj1_sig d2) (approximate y1 d1') (approximate y2 (Qpos2QposInf d2))).
+ setoid_replace (proj1_sig d1 + proj1_sig e + proj1_sig d2)
+   with (proj1_sig (d1' + (d1' + e) + d2)%Qpos)
+   by (simpl; ring).
  rewrite <- ball_Cunit.
  apply ball_triangle with y2;[|apply ball_approx_r].
  apply ball_triangle with y1;[apply ball_approx_l|].
@@ -1039,11 +1035,9 @@ Definition Cap_slow_modulus (f:Complete (X --> Y)) (e:Qpos) : QposInf
 Lemma Cap_weak_slow_prf (f:Complete (X --> Y)) : is_UniformlyContinuousFunction (Cap_slow_fun f) (Cap_slow_modulus f).
 Proof.
  intros e x y H.
- pose (exist (Qlt 0) (1#3) eq_refl) as third.
- set (e' := (third*e)%Qpos).
- assert (QposEq e (e'+e'+e')).
- { unfold QposEq; simpl; ring. }
- rewrite H0. clear H0.
+ set (e' := ((1#3)*e)%Qpos).
+ setoid_replace (proj1_sig e) with (proj1_sig (e'+e'+e')%Qpos)
+   by (simpl; ring).
  apply ball_triangle with (Cmap_slow (approximate f e') y).
   apply ball_triangle with (Cmap_slow (approximate f e') x).
    apply Cap_slow_help.
@@ -1058,16 +1052,17 @@ Build_UniformlyContinuousFunction (Cap_weak_slow_prf f).
 
 Lemma Cap_slow_prf : is_UniformlyContinuousFunction Cap_weak_slow Qpos2QposInf.
 Proof.
- intros e f1 f2 H x.
+  intros e f1 f2 H. split. apply Qpos_nonneg.
+  intro x.
  apply ball_closed.
- intros d.
- pose (exist (Qlt 0) (1#4) eq_refl) as quarter.
- assert (QposEq (e+d)
-                (quarter*d + (quarter*d + e + quarter*d) + quarter*d)).
- { unfold QposEq; simpl; ring. }
- rewrite H0. clear H0.
- apply ball_triangle with (Cmap_strong_slow (approximate f2 (quarter*d)%Qpos) x).
-  apply ball_triangle with (Cmap_strong_slow (approximate f1 (quarter*d)%Qpos) x).
+ intros d dpos.
+ setoid_replace (proj1_sig e + d)
+   with (proj1_sig ((1#4)*exist _ _ dpos
+                    + ((1#4)*exist _ _ dpos + e + (1#4)*exist _ _ dpos)
+                    + (1#4)*exist _ _ dpos)%Qpos)
+   by (simpl; ring).
+ apply ball_triangle with (Cmap_strong_slow (approximate f2 ((1#4)*exist _ _ dpos)%Qpos) x).
+  apply ball_triangle with (Cmap_strong_slow (approximate f1 ((1#4)*exist _ _ dpos)%Qpos) x).
    apply Cap_slow_help.
   apply (uc_prf Cmap_strong_slow).
   apply H.
@@ -1078,17 +1073,15 @@ Qed.
 Definition Cap_slow : Complete (X --> Y) --> Complete X --> Complete Y :=
 Build_UniformlyContinuousFunction Cap_slow_prf.
 
-Lemma StrongMonadLaw1 : forall a b, st_eq (Cap_slow_fun (Cunit_fun _ a) b) (Cmap_strong_slow a b).
+Lemma StrongMonadLaw1 : forall a b,
+    st_eq (Cap_slow_fun (Cunit_fun _ a) b) (Cmap_strong_slow a b).
 Proof.
  intros f x.
  apply regFunEq_e.
  intros e.
- pose (exist (Qlt 0) (1#2) eq_refl) as half.
- apply ball_weak_le with (half*e+e)%Qpos.
+ apply ball_weak_le with (proj1_sig ((1#2)*e+e)%Qpos).
  simpl. rewrite -> Qle_minus_iff; ring_simplify.
- apply (Qle_trans _ ((1#2)*0)). rewrite Qmult_0_r.
- apply Qle_refl. apply Qmult_le_l. reflexivity.
- destruct e. apply Qlt_le_weak, q.
+ apply Qmult_le_0_compat. discriminate. apply Qpos_nonneg.
  refine (regFun_prf _ _ _).
 Qed.
 
@@ -1134,7 +1127,7 @@ it does not preserve the decidability.
 Lemma Complete_stable : forall X, stableMetric X -> stableMetric (Complete X).
 Proof.
  intros X HX e x y Hb e1 e2.
- apply HX.
+ apply (HX (proj1_sig e1+e+proj1_sig e2)%Q).
  intros H.
  apply Hb.
  intros H0.
@@ -1145,24 +1138,22 @@ Qed.
 Lemma Complete_located : forall X, locatedMetric X -> locatedMetric (Complete X).
 Proof.
  intros X Hx e d x y Hed.
- assert (0 < proj1_sig d - proj1_sig e).
- { apply (Qplus_lt_l _ _ (proj1_sig e)). ring_simplify. exact Hed. } 
- assert ({c:Qpos | QposEq d (Qpos_plus e c)}) as H0.
+ assert (0 < d - e).
+ { apply (Qplus_lt_l _ _ e). ring_simplify. exact Hed. } 
+ assert ({c:Qpos | d == e + proj1_sig c}) as H0.
  { exists (exist _ _ H).
    unfold Qpos_plus, QposEq; destruct d,e; simpl.
    ring_simplify. reflexivity. }
  destruct H0 as [c Hc]. 
- pose (exist (Qlt 0) (1#5) eq_refl) as fifth. 
- pose (exist (Qlt 0) (3#1) eq_refl) as three. 
- set (c':=(fifth*c)%Qpos). clear H. 
- assert (proj1_sig (c'+e+c')%Qpos < proj1_sig (e+three*c')%Qpos) as H.
+ set (c':=((1#5)*c)%Qpos). clear H. 
+ assert (proj1_sig c'+e+ proj1_sig c' < e+(3#1)*proj1_sig c') as H.
  { rewrite -> Qlt_minus_iff. simpl. ring_simplify. auto with *. }
  destruct (Hx _ _ (approximate x c') (approximate y c') H) as [H0 | H0].
- - left.
+ - left. 
   rewrite -> Hc. rewrite <- ball_Cunit in H0.
-  assert (QposEq (e+c) (c' + (e + three * c') + c')).
- { unfold QposEq; simpl; ring. }
- rewrite H1. clear H1.
+  setoid_replace (e+proj1_sig c)
+    with (proj1_sig c' + (e + (3#1) * proj1_sig c') + proj1_sig c')%Q
+    by (simpl; ring).
   eapply ball_triangle;[eapply ball_triangle;[|apply H0]|];
     [apply ball_approx_r|apply ball_approx_l].
  - right.

--- a/metric2/CompleteProduct.v
+++ b/metric2/CompleteProduct.v
@@ -107,6 +107,7 @@ Proof.
  intros y e a b H.
  split; auto.
  apply ball_refl.
+ apply QposMinMax.Qpos_nonneg.
 Qed.
 
 Lemma pair_uc_r : forall x:X, @is_UniformlyContinuousFunction Y XY (fun y => (x,y)) Qpos2QposInf.
@@ -114,6 +115,7 @@ Proof.
  intros x e a b H.
  split; auto.
  apply ball_refl.
+ apply QposMinMax.Qpos_nonneg.
 Qed.
 
 (** C(X*Y) is isomorphic to (C X)*(C Y) *)

--- a/metric2/Graph.v
+++ b/metric2/Graph.v
@@ -121,11 +121,11 @@ Proof.
  simpl.
  unfold Cfst_raw.
  apply almostIn_closed.
- intros d.
- set (d':=((1#2)*d)%Qpos).
- assert (QposEq (e1 + e2 + d) ((e1 + d') + (d'+ e2)))
-   by (unfold QposEq; simpl; ring).
- rewrite H0. clear H0.
+ intros d dpos.
+ set (d':=((1#2)*exist _ _ dpos)%Qpos).
+ setoid_replace (proj1_sig e1 + proj1_sig e2 + d)
+   with (proj1_sig ((e1 + d') + (d'+ e2))%Qpos)
+   by (simpl; ring).
  assert (H':=H e1 d').
  clear H.
  unfold XY in *.
@@ -160,13 +160,13 @@ st_eq (Cmap plX f (Cfst p)) (Csnd p).
 Proof.
  intros plX plFEX p s H.
  apply ball_eq.
- intros e1.
+ intros e1 epos.
  apply regFunBall_e.
  intros e2.
- set (e':=((1#6)*e1)%Qpos).
- assert (QposEq (e2 + e1 + e2) ((e2 + e') + ((e' + e') + (e' + e')) + (e2 + e')))
-   by (unfold e'; unfold QposEq; simpl; ring).
- rewrite H0. clear H0. 
+ set (e':=((1#6)*exist _ _ epos)%Qpos).
+ setoid_replace (proj1_sig e2 + e1 + proj1_sig e2)
+   with (proj1_sig ((e2 + e') + ((e' + e') + (e' + e')) + (e2 + e'))%Qpos)
+   by (unfold e'; simpl; ring).
  set (d' := graphPoint_modulus e').
  assert (Hd'1 : proj1_sig d' <= proj1_sig e').
   unfold d', graphPoint_modulus.
@@ -195,7 +195,7 @@ Proof.
    assert (Z:=regFun_prf_ex p (mu f e2) d').
    destruct (mu f e2); try constructor.
    destruct Z; auto.
-  assert (L:existsC X (fun x => ball (d' + d') (approximate p d') (x, (f x)))).
+  assert (L:existsC X (fun x => ball (proj1_sig d' + proj1_sig d') (approximate p d') (x, (f x)))).
    clear -H'.
    simpl in H'.
    unfold FinEnum_map_modulus, graphPoint_modulus in H'.
@@ -310,7 +310,7 @@ Lemma graphPoint_b_uc : is_UniformlyContinuousFunction (graphPoint_b_raw f) (gra
 Proof.
  intros e a b H d1 d2.
  split.
-  change (ball_ex (d1 + e + d2) a b).
+  change (ball_ex (Qpos2QposInf d1 + e + Qpos2QposInf d2) a b).
   eapply ball_ex_weak_le;[|apply H].
   unfold graphPoint_modulus.
   destruct (mu f e) as [d|].
@@ -324,7 +324,7 @@ Proof.
   Qauto_le.
  simpl.
  revert d1 d2.
- change (ball e (f a) (f b)).
+ change (ball (proj1_sig e) (f a) (f b)).
  apply: uc_prf.
  eapply ball_ex_weak_le;[|apply H].
  unfold graphPoint_modulus.
@@ -355,7 +355,7 @@ Proof.
   auto using CompactImage_b_correct1.
  intros e1 e2.
  split. 
- apply ball_weak_le with (e:= (e1 + (graphPoint_modulus f ((1 # 2) * e2)))%Qpos)
+ apply ball_weak_le with (proj1_sig (e1 + (graphPoint_modulus f ((1 # 2) * e2)))%Qpos)
  ;[|apply regFun_prf].
   unfold graphPoint_modulus.
   destruct (mu f ((1#2)*e2)). simpl. 
@@ -370,9 +370,9 @@ Proof.
    simpl. Qauto_le. 
  simpl. unfold Cjoin_raw. 
  rewrite <- ball_Cunit.
- assert (QposEq (e1 + e2) ((1#2)*e1 + ((1#2)*e1 + (1#2)*e2) + (1#2)*e2))
-   by (unfold QposEq; simpl; ring).
- rewrite H. clear H.
+ setoid_replace (proj1_sig e1 + proj1_sig e2)
+   with (proj1_sig ((1#2)*e1 + ((1#2)*e1 + (1#2)*e2) + (1#2)*e2)%Qpos)
+   by (simpl; ring).
  eapply ball_triangle;[|apply ball_approx_r].
  eapply ball_triangle.
  apply (ball_approx_l (approximate (Cmap_fun plX f x) (Qpos2QposInf ((1 # 2)%Qpos * e1)))
@@ -403,11 +403,11 @@ Proof.
  simpl.
  unfold Cfst_raw.
  apply almostIn_closed.
- intros d.
- set (d':=((1#2)*d)%Qpos).
- assert (QposEq (e1 + e2 + d) ((e1 + d') + (d'+ e2)))
-   by (unfold QposEq; simpl; ring).
- rewrite H0. clear H0.
+ intros d dpos.
+ set (d':=((1#2)*exist _ _ dpos)%Qpos).
+ setoid_replace (proj1_sig e1 + proj1_sig e2 + d)
+   with (proj1_sig ((e1 + d') + (d'+ e2))%Qpos)
+   by (simpl; ring).
  assert (H':=H e1 d').
  clear H.
  unfold XY in *.
@@ -460,14 +460,13 @@ st_eq (Cbind plX f (Cfst p)) (Csnd p).
 Proof.
  intros plX plFEX p s H.
  apply ball_eq.
- intros e1.
+ intros e1 epos.
  apply regFunBall_e.
  intros e2.
- set (e':=((1#6)*e1)%Qpos).
- assert (QposEq (e2 + e1 + e2)
-                ((e2 + e') + ((e' + e') + (e' + e')) + (e2 + e')))
-   by (unfold e', QposEq; simpl; ring).
- rewrite H0. clear H0. 
+ set (e':=((1#6)*exist _ _ epos)%Qpos).
+ setoid_replace (proj1_sig e2 + e1 + proj1_sig e2)
+   with (proj1_sig ((e2 + e') + ((e' + e') + (e' + e')) + (e2 + e'))%Qpos)
+   by (unfold e'; simpl; ring).
  set (d' := graphPoint_modulus f ((1#2)*e')).
  assert (Hd'1 : proj1_sig d' <= proj1_sig e').
   unfold d', graphPoint_modulus.
@@ -492,14 +491,14 @@ Proof.
                       (Qpos2QposInf (1#2)*d'))%Qpos.
    unfold Cjoin_raw.
    simpl.
-   apply ball_weak_le with ((1#2)*e2 + ((1#2)*e2 + (1#2)*e') + (1#2)*d')%Qpos.
+   apply ball_weak_le with (proj1_sig ((1#2)*e2 + ((1#2)*e2 + (1#2)*e') + (1#2)*d')%Qpos).
    simpl.
     clear - Hd'1.
     rewrite -> Qle_minus_iff in *.
     replace RHS with ((1 # 2) * (proj1_sig e' + - proj1_sig d'))
       by simpl; ring.
     Qauto_nonneg.
-   cut (ball ((1 # 2) * e2 + (1 # 2) * e') (f (Cfst_raw p (mu f ((1 # 2) * e2))))
+   cut (ball ((1 # 2) * proj1_sig e2 + (1 # 2) * proj1_sig e') (f (Cfst_raw p (mu f ((1 # 2) * e2))))
      (f (Cfst_raw p ((1 # 2) * d')%Qpos))).
     intros L.
     apply L.
@@ -528,7 +527,7 @@ Proof.
    assert (Z:=regFun_prf_ex p (mu f ((1#2)*e2)) (Qpos2QposInf (1#2)%Qpos*d')).
    destruct (mu f ((1#2)*e2)); try constructor.
    destruct Z; auto.
-   assert (L:existsC X (fun x => ball (((1#2)*d') + d')
+   assert (L:existsC X (fun x => ball (proj1_sig (((1#2)*d') + d')%Qpos)
                                    (approximate p (Qpos2QposInf (1#2)%Qpos*d')) (Couple_raw ((Cunit x), (f x)) (Qpos2QposInf ((1#2)*d')%Qpos)))).
    clear -H'.
    simpl in H'.
@@ -554,7 +553,7 @@ Proof.
     apply stableXY.
    auto.
   apply ball_triangle with (approximate (f a) (Qpos2QposInf ((1#2)%Qpos*d'))).
-   apply ball_weak_le with ((1#2)*d' + ((1#2)*e' + (1#2)*e') + (1#2)*d')%Qpos.
+   apply ball_weak_le with (proj1_sig ((1#2)*d' + ((1#2)*e' + (1#2)*e') + (1#2)*d')%Qpos).
     clear - Hd'1.
     simpl.
     rewrite -> Qle_minus_iff in *.
@@ -562,8 +561,8 @@ Proof.
     exact Hd'1.
    simpl.
    rewrite <- ball_Cunit.
-   eapply ball_triangle;[|apply ball_approx_r].
-   eapply ball_triangle;[apply ball_approx_l|].
+   eapply ball_triangle;[|apply (ball_approx_r _ ((1#2)*d')%Qpos)].
+   eapply ball_triangle;[apply (ball_approx_l _ ((1#2)*d'))|].
    apply (mu_sum plX ((1#2)*e') (((1#2)*e')::nil) f)%Qpos.
    simpl.
    unfold graphPoint_modulus in d'.

--- a/metric2/ProductMetric.v
+++ b/metric2/ProductMetric.v
@@ -58,10 +58,10 @@ Variable X Y : MetricSpace.
 Definition prod_ball e (a b:X*Y) :=
 ball e (fst a) (fst b) /\ ball e (snd a) (snd b).
 
-Lemma prod_ball_refl : forall e a, prod_ball e a a.
+Lemma prod_ball_refl : forall (e:Q) a,
+    0 <= e -> prod_ball e a a.
 Proof.
- intros e a.
- split; auto with *.
+ intros e a. split; apply ball_refl; exact H.
 Qed.
 
 Lemma prod_ball_sym : forall e a b, prod_ball e a b -> prod_ball e b a.
@@ -76,14 +76,15 @@ Proof.
  split; eauto with metric.
 Qed.
 
-Lemma prod_ball_closed : forall e a b, (forall d, prod_ball (e + d) a b) -> prod_ball e a b.
+Lemma prod_ball_closed : forall e a b,
+    (forall d, 0 < d -> prod_ball (e + d) a b) -> prod_ball e a b.
 Proof.
  intros e a b H.
  unfold prod_ball in *.
  split; apply ball_closed; firstorder.
 Qed.
 
-Lemma prod_ball_eq : forall a b, (forall e, prod_ball e a b) -> prod_st_eq _ _ a b.
+Lemma prod_ball_eq : forall a b, (forall e, 0 < e -> prod_ball e a b) -> prod_st_eq _ _ a b.
 Proof.
  intros a b H.
  unfold prod_ball in *.
@@ -93,11 +94,12 @@ Qed.
 Lemma prod_is_MetricSpace : is_MetricSpace (prodS X Y) prod_ball.
 Proof.
  split.
-     exact prod_ball_refl.
-    exact prod_ball_sym.
-   exact prod_ball_triangle.
-  exact prod_ball_closed.
- exact prod_ball_eq.
+ - intros. intros a. apply prod_ball_refl, H.
+ - exact prod_ball_sym.
+ - exact prod_ball_triangle.
+ - exact prod_ball_closed.
+ - exact prod_ball_eq.
+ - intros. destruct H. apply (msp_nonneg (msp X)) in H. exact H.
 Qed.
 
 Definition ProductMS : MetricSpace.
@@ -143,7 +145,8 @@ Proof.
    tauto.
   intros H.
   split; auto.
-  apply ball_refl.
+  apply ball_refl. 
+  apply (msp_nonneg (msp X) e x y H).
  destruct (H0 _ _ _ Z).
  assumption.
 Qed.
@@ -157,8 +160,9 @@ Proof.
   cut (ball (m:=Y) e x y -> ball (m:=ProductMS) e (a,x) (a, y)).
    tauto.
   intros H.
-  split; auto.
-  apply ball_refl.
+  split; auto. 
+  apply ball_refl. 
+  apply (msp_nonneg (msp Y) e x y H).
  destruct (H0 _ _ _ Z).
  assumption.
 Qed.
@@ -237,17 +241,19 @@ Section uc_curry.
    apply uc_prf.
    destruct (mu e)...
    split... apply ball_refl.
+   apply Qpos_nonneg.
   Qed.
 
   Definition uc_curry_help (a: A): B --> C := Build_UniformlyContinuousFunction (uc_curry_help_prf a).
 
   Definition uc_curry_prf: is_UniformlyContinuousFunction uc_curry_help (mu f).
   Proof with auto.
-   repeat intro. simpl.
+   repeat intro. split. apply Qpos_nonneg. intro. simpl.
    destruct f. clear f. simpl in *.
    apply uc_prf.
    destruct (mu e)...
    split... apply ball_refl.
+   apply Qpos_nonneg.
   Qed.
 
   Definition uc_curry: A --> B --> C := Build_UniformlyContinuousFunction uc_curry_prf.
@@ -301,6 +307,8 @@ Section completion_distributes.
    intros. unfold distrib_Complete, undistrib_Complete. simpl.
    unfold prod_st_eq. simpl.
    split; apply regFunEq_e; simpl; intros; apply ball_refl.
+   apply (Qpos_nonneg (e+e)).
+   apply (Qpos_nonneg (e+e)).
   Qed.
 
   Lemma undistrib_after_distrib_Complete xy: st_eq (undistrib_Complete (distrib_Complete xy)) xy.
@@ -308,6 +316,8 @@ Section completion_distributes.
    intros. unfold undistrib_Complete. simpl.
    apply regFunEq_e.
    split; simpl; apply ball_refl.
+   apply (Qpos_nonneg (e+e)).
+   apply (Qpos_nonneg (e+e)).
   Qed.
 
 End completion_distributes.

--- a/model/metric2/LinfDistMonad.v
+++ b/model/metric2/LinfDistMonad.v
@@ -117,10 +117,10 @@ Proof.
  simpl.
  unfold dist_raw.
  simpl.
- fold (glue o (Map (fun z : RegularFunction X => approximate z d1) s)
-   (Map (fun z : RegularFunction X => approximate z d1) s0)).
- fold (glue o (Map (fun z : RegularFunction X => approximate z d2) t)
-   (Map (fun z : RegularFunction X => approximate z d2) t0)).
+ fold (glue o (Map (fun z : RegularFunction X => approximate z (Qpos2QposInf d1)) s)
+   (Map (fun z : RegularFunction X => approximate z (Qpos2QposInf d1)) s0)).
+ fold (glue o (Map (fun z : RegularFunction X => approximate z (Qpos2QposInf d2)) t)
+   (Map (fun z : RegularFunction X => approximate z (Qpos2QposInf d2)) t0)).
  simpl in *.
  rewrite -> StepFSupBallGlueGlue in H |- *.
  split; revert d1 d2; tauto.
@@ -164,7 +164,7 @@ Proof.
  fold (glue o (Map (fun z : RegularFunction X => approximate z e) x)
    (Map (fun z : RegularFunction X => approximate z e) y)).
  rewrite -> StepFSupBallGlueGlue.
- assert (forall w:StepF (Complete X), StepFSupBall (X:=X) (e + e1)
+ assert (forall w:StepF (Complete X), StepFSupBall (X:=X) (proj1_sig e + proj1_sig e1)
    (Map (fun z : RegularFunction X => approximate z e) w) (Map (fun z : RegularFunction X =>
      approximate z (half * (half * e1))%Qpos) w)).
   induction w using StepF_ind.
@@ -172,14 +172,14 @@ Proof.
    rewrite <- ball_Cunit.
    apply ball_triangle with x0.
     apply ball_approx_l.
-   apply ball_weak_le  with  (half * (half * e1))%Qpos.
+   apply ball_weak_le  with (proj1_sig (half * (half * e1))%Qpos).
     rewrite -> Qle_minus_iff.
     simpl.
      replace RHS with ((3#4)*proj1_sig e1); [| simpl; ring].
      Qauto_nonneg.
    apply ball_approx_r.
   simpl.
-  change (StepFSupBall (X:=X) (e + e1) (glue o0 (Map (fun z : RegularFunction X => approximate z e) w1)
+  change (StepFSupBall (X:=X) (proj1_sig e + proj1_sig e1) (glue o0 (Map (fun z : RegularFunction X => approximate z e) w1)
     (Map (fun z : RegularFunction X => approximate z e) w2)) (glue o0 (Map
       (fun z : RegularFunction X => approximate z (half * (half * e1))%Qpos) w1) (Map
         (fun z : RegularFunction X => approximate z (half * (half * e1))%Qpos) w2))).
@@ -221,25 +221,25 @@ Proof.
  induction x using StepF_ind.
   intros e e1. simpl.
   unfold dist_raw. simpl.
-  change (ballS Y (e + e1) (Cmap_slow_raw f x e) (f (approximate x
+  change (ballS Y (proj1_sig e + proj1_sig e1) (Cmap_slow_raw f x e) (f (approximate x
     (QposInf_bind (fun y' : Qpos => (half * y')%Qpos) (mu f e1))))).
   unfold Cmap_slow_raw. simpl.
   set (ee:=(QposInf_bind (fun y' : Qpos => (half * y')%Qpos) (mu f e))).
   set (ee1:=(QposInf_bind (fun y' : Qpos => (half * y')%Qpos) (mu f e1))).
   rewrite <-  ball_Cunit.
-  assert (H:ball (m:=(Complete Y)) (e + e1)
+  assert (H:ball (m:=(Complete Y)) (proj1_sig e + proj1_sig e1)
     ((Cmap_slow f) (Cunit (approximate x ee))) ((Cmap_slow f) (Cunit (approximate x ee1)))).
    apply ball_triangle with (Cmap_slow f x);apply: (uc_prf (Cmap_slow f));[apply: ball_ex_approx_l|apply: ball_ex_approx_r].
   apply H.
  intros e1 e2. simpl. unfold dist_raw. simpl.
  (* Why do we need to fold glue??*)
- change (StepFSupBall (X:=Y) (e1 + e2) (glue o (Map (fun z : RegularFunction Y => approximate z e1)
+ change (StepFSupBall (X:=Y) (proj1_sig e1 + proj1_sig e2) (glue o (Map (fun z : RegularFunction Y => approximate z e1)
    (Map (Cmap_slow_fun f) x1)) (Map (fun z : RegularFunction Y => approximate z e1)
      (Map (Cmap_slow_fun f) x2))) (glue o (Map f (Map (fun z : RegularFunction X => approximate z
        (QposInf_bind (fun y' : Qpos => (half * y')%Qpos) (mu f e2))) x1)) (Map f (Map
          (fun z : RegularFunction X => approximate z
            (QposInf_bind (fun y' : Qpos => (half * y')%Qpos) (mu f e2))) x2)))).
- rewrite -> (@StepFSupBallGlueGlue Y (e1+e2) o).
+ rewrite -> (@StepFSupBallGlueGlue Y (proj1_sig e1+proj1_sig e2) o).
  split; [apply IHx1|apply IHx2].
 Qed.
 
@@ -255,9 +255,9 @@ Proof.
  intros e e1. simpl. unfold dist_raw. simpl.
  unfold StepFSupBall.
  (* From here onwards the proof is too difficult *)
- change (ballS X (e + e1) (approximate x e) (approximate x (half * e1)%Qpos)).
+ change (ballS X (proj1_sig e + proj1_sig e1) (approximate x e) (approximate x (half * e1)%Qpos)).
  simpl.
- apply ball_weak_le with (Qpos_plus e (half * e1)%Qpos).
+ apply ball_weak_le with (proj1_sig (Qpos_plus e (half * e1)%Qpos)).
   2: apply (regFun_prf_ex x e (half * e1)%Qpos).
  rewrite -> Qle_minus_iff. simpl.
   replace RHS with ((1#2)* proj1_sig e1); [| simpl; ring].
@@ -277,7 +277,7 @@ Proof.
    with (Map (fun z  => (approximate ((Cunit_fun X) z) e1)) x).
   simpl.
   setoid_replace (Map (fun z : X => z) x) with x.
-   set (b:=(@ballS X (e1+e2))).
+   set (b:=(@ballS X (proj1_sig e1+proj1_sig e2))).
    set (f:=(@join _ _) ^@> (constStepF b)).
    cut (StepFfoldProp (f <@> x )).
     unfold f;  evalStepF; tauto.

--- a/model/metric2/LinfMetric.v
+++ b/model/metric2/LinfMetric.v
@@ -180,7 +180,7 @@ Proof.
    rewrite <- Hs , <- Ht.
    assumption.
   intros x y Hxy.
-  change (Qball e x y) in Hxy.
+  change (Qball (proj1_sig e) x y) in Hxy.
   rewrite ->  Qball_Qabs in Hxy.
   apply Hxy.
  intros o s s0 t t0 Hst Hst0 H.

--- a/model/reals/CRreal.v
+++ b/model/reals/CRreal.v
@@ -38,8 +38,8 @@ Local Open Scope uc_scope.
 ** Example of a real number structure: $\langle$#&lang;#[CR]$\rangle$#&rang;#
 *)
 
-Lemma CRAbsSmall_ball : forall (x y:CR) (e:Qpos),
-    AbsSmall (R:=CRasCOrdField) (inject_Q_CR (proj1_sig e)) ((x:CRasCOrdField)[-]y) <->
+Lemma CRAbsSmall_ball : forall (x y:CR) (e:Q),
+    AbsSmall (R:=CRasCOrdField) (inject_Q_CR e) ((x:CRasCOrdField)[-]y) <->
  ball e x y.
 Proof.
  intros x y e.
@@ -57,10 +57,10 @@ Proof.
   simpl.
   set (x':=approximate x ((1#2)*((1#2)*d))%Qpos).
   set (y':=approximate y ((1#2)*((1#2)*d))%Qpos).
-  change (-proj1_sig d <= x' - y' + - - proj1_sig e) in H1'.
-  change (-proj1_sig d <= proj1_sig e + - (x' - y')) in H2'.
+  change (-proj1_sig d <= x' - y' + - - e) in H1'.
+  change (-proj1_sig d <= e + - (x' - y')) in H2'.
   rewrite -> Qle_minus_iff in *.
-  apply: ball_weak.
+  apply: ball_weak. apply Qpos_nonneg.
   split; simpl; rewrite -> Qle_minus_iff.
   rewrite Qopp_involutive. do 2 rewrite Qopp_involutive in H1'.
   rewrite (Qplus_comm (proj1_sig d)).
@@ -74,18 +74,18 @@ Proof.
    set (x':=(approximate (doubleSpeed x) ((1 # 2) * d)%Qpos)) in *;
      set (y':=(approximate (doubleSpeed y) ((1 # 2) * d)%Qpos)) in *.
   autorewrite with QposElim in H1.
-  change (- ((1 # 2) * proj1_sig d + proj1_sig e + (1 # 2) * proj1_sig d)<=x' - y') in H1.
-  change (-proj1_sig d <= x' - y' + - - proj1_sig e).
+  change (- ((1 # 2) * proj1_sig d + e + (1 # 2) * proj1_sig d)<=x' - y') in H1.
+  change (-proj1_sig d <= x' - y' + - - e).
   rewrite -> Qle_minus_iff.
   rewrite -> Qle_minus_iff in H1.
-  replace RHS with (x' - y' + - - ((1 # 2) * proj1_sig d + proj1_sig e + (1 # 2) * proj1_sig d)) by ring.
+  replace RHS with (x' - y' + - - ((1 # 2) * proj1_sig d + e + (1 # 2) * proj1_sig d)) by ring.
   assumption.
  autorewrite with QposElim in H2.
- change (x' - y'<=((1 # 2) * proj1_sig d + proj1_sig e + (1 # 2) * proj1_sig d)) in H2.
- change (-proj1_sig d <= proj1_sig e + - (x' - y')).
+ change (x' - y'<=((1 # 2) * proj1_sig d + e + (1 # 2) * proj1_sig d)) in H2.
+ change (-proj1_sig d <= e + - (x' - y')).
  rewrite -> Qle_minus_iff.
  rewrite -> Qle_minus_iff in H2.
- replace RHS with ((1 # 2) * proj1_sig d + proj1_sig e + (1 # 2) * proj1_sig d + - (x' - y'))
+ replace RHS with ((1 # 2) * proj1_sig d + e + (1 # 2) * proj1_sig d + - (x' - y'))
    by ring.
  assumption.
 Qed.
@@ -127,16 +127,16 @@ Proof.
     [rstepr (e[-][0]);assumption|].
   rewrite -> CRAbsSmall_ball.
   change (nat -> Complete Q_as_MetricSpace) in f.
-  change (ball d (f m) (CRlim (Build_CauchySeq CRasCOrdField f Hf))).
+  change (ball (proj1_sig d) (f m) (CRlim (Build_CauchySeq CRasCOrdField f Hf))).
   rewrite <- (MonadLaw5 (f m)).
-  change (ball d (Cjoin (Cunit (f m))) (CRlim (Build_CauchySeq CRasCOrdField f Hf))).
+  change (ball (proj1_sig d) (Cjoin (Cunit (f m))) (CRlim (Build_CauchySeq CRasCOrdField f Hf))).
   unfold CRlim.
   apply uc_prf.
-  change (ball d (Cunit (f m)) (Build_RegularFunction (Rlim_subproof0 f Hf))).
+  change (ball (proj1_sig d) (Cunit (f m)) (Build_RegularFunction (Rlim_subproof0 f Hf))).
   intros e1 e2.
   simpl.
   destruct (Hf (' proj1_sig e2)%CR (CRlt_Qlt _ _ (Qpos_ispos e2))) as [a Ha].
-  change (ball (e1+d+e2) (f m) (f a)).
+  change (ball (proj1_sig (e1+d+e2)%Qpos) (f m) (f a)).
   destruct (le_ge_dec a m).
    rewrite <- CRAbsSmall_ball.
    eapply AbsSmall_leEq_trans;[|apply Ha;assumption].
@@ -147,7 +147,7 @@ Proof.
    ring_simplify.
    change (0<= proj1_sig (e1+d+x)%Qpos).
    apply Qpos_nonneg.
-  apply ball_weak_le with ((1#2)*d+(1#2)*d)%Qpos.
+  apply ball_weak_le with (proj1_sig ((1#2)*d+(1#2)*d)%Qpos).
    rewrite -> Qle_minus_iff.
    simpl. ring_simplify.
    change (0<= proj1_sig (e1+e2)%Qpos).

--- a/ode/AbstractIntegration.v
+++ b/ode/AbstractIntegration.v
@@ -148,8 +148,9 @@ Lemma CRΣ_gball (f g: nat -> CR) (e : Q) (n : nat):
    (forall m, (m < n)%nat -> gball e (f m) (g m)) ->
    (gball (n * e) (cmΣ n f) (cmΣ n g)).
 Proof.
- induction n; [reflexivity |].
- intros.
+  induction n.
+  - intros. apply ball_refl. rewrite Qmult_0_l. apply Qle_refl.
+  - intros.
  rewrite Q.S_Qplus.
  setoid_replace ((n + 1) * e)%Q with (e + n * e)%Q by ring.
  unfold cmΣ. simpl @cm_Sum.
@@ -207,8 +208,8 @@ Section integral_approximation.
     boundedness property. We start by generalizing mid to CR: *)
 
     Lemma bounded_with_real_mid (from: Q) (width: Qpos) (mid: CR) (r: Qpos):
-      (forall x, from <= x <= from+proj1_sig width -> ball r (f x) mid) ->
-      ball (width * r) (∫ f from (from_Qpos width)) (scale (proj1_sig width) mid).
+      (forall x, from <= x <= from+proj1_sig width -> ball (proj1_sig r) (f x) mid) ->
+      ball (proj1_sig (width * r)%Qpos) (∫ f from (from_Qpos width)) (scale (proj1_sig width) mid).
     Proof with auto.
      intros H d1 d2.
      simpl approximate.
@@ -217,7 +218,7 @@ Section integral_approximation.
      set (v := (exist (Qlt 0) (/ (proj1_sig width) * proj1_sig d2)%Q P)).
      assert (QposEq (d1 + width * r + d2)%Qpos (d1 + width * (r + v))%Qpos).
      { unfold QposEq; simpl; field. apply Qpos_nonzero. }
-     rewrite H0. clear H0.
+     unfold QposEq in H0. rewrite H0. clear H0.
      apply regFunBall_Cunit.
      apply integral_bounded_prim.
      intros.
@@ -233,22 +234,22 @@ Section integral_approximation.
     Proof with auto.
      pattern r.
      apply QnonNeg.Qpos_ind.
-       intros ?? E.
+     - intros ?? E.
        split. intros H ?. rewrite <- E. apply H. intros. rewrite E...
        intros H ?. rewrite E. apply H. intros. rewrite <- E...
-      rewrite Qmult_0_r, gball_0.
+     - rewrite Qmult_0_r, gball_0.
       intros.
-      apply ball_eq. intro .
-      assert (QposEq e (width * (e * Qpos_inv width))%Qpos).
-      { unfold QposEq; simpl; field. apply Qpos_nonzero. }
-      rewrite H0. clear H0.
+      apply ball_eq. intros e epos.
+      setoid_replace e with (proj1_sig (width * (exist _ _ epos * Qpos_inv width))%Qpos)
+        by (simpl; field; apply Qpos_nonzero).
       apply bounded_with_real_mid.
       intros q ?.
       setoid_replace (f q) with mid...
+      apply ball_refl. apply Qpos_nonneg.
       apply -> (@gball_0 CR)...
-     intros.
-     apply (ball_gball (width * q)%Qpos), bounded_with_real_mid.
-     intros. apply ball_gball...
+     - intros.
+       apply (ball_gball (proj1_sig (width * q)%Qpos)), bounded_with_real_mid.
+       intros. apply H, H0.
     Qed.
 
     (** Next, we generalize r to a full CR: *)
@@ -280,7 +281,7 @@ Section integral_approximation.
       apply CRle_trans with r...
       apply -> CRnonNeg_le_0...
      apply (bounded_with_nonneg_radius from width mid (exist _ _ E)).
-     intros. simpl. apply gball_sym...
+     intros. apply gball_sym...
     Qed.
 
     (** Finally, we generalize to nonnegative width: *)
@@ -625,7 +626,9 @@ Proof with auto.
   intros.
   apply integral_bounded_prim...
   intros.
-  rewrite (H x x (refl_equal _))...
+  assert (st_eq (f x) (g x)).
+  { apply (@gball_0 CR). apply H. reflexivity. }
+  rewrite H3...
  replace (@integrate g) with (@integrate f) by reflexivity.
  apply integral_wd...
 Qed.
@@ -660,27 +663,43 @@ Proof. reflexivity. Qed.
 Lemma cmΣ_plus (n : nat) (f g : nat -> CR) : cmΣ n (f + g) = cmΣ n f + cmΣ n g.
 Proof.
 induction n as [| n IH].
-+ symmetry; apply cm_rht_unit.
-+ rewrite !cmΣ_succ. rewrite IH.
-  change (f n + g n + (cmΣ n f + cmΣ n g) = f n + cmΣ n f + (g n + cmΣ n g)).
-  change (CRasCMonoid : Type) with (CR : Type). ring.
++ symmetry. apply gball_0. 
+  apply (@cm_rht_unit CRasCMonoid (cmΣ 0 (f + g))).
++ apply gball_0. rewrite !cmΣ_succ.
+  apply gball_0 in IH. rewrite IH. clear IH.
+  change (f n + g n + (cmΣ n f + cmΣ n g) [=] f n + cmΣ n f + (g n + cmΣ n g))%CR.
+  do 2 rewrite <- CRplus_assoc.
+  apply CRplus_eq_r.
+  rewrite CRplus_comm, <- CRplus_assoc.
+  apply CRplus_eq_r. apply CRplus_comm.
 Qed.
 
 Lemma cmΣ_negate (n : nat) (f : nat -> CR) : cmΣ n (- f) = - cmΣ n f.
 Proof.
 induction n as [| n IH].
-+ change ((0 : CR) = - 0). (* [change (0 = - 0)] loops *) ring.
-+ rewrite !cmΣ_succ. rewrite IH.
-  change (- f n - cmΣ n f = - (f n + cmΣ n f)).
-  change (CRasCMonoid : Type) with (CR : Type). (* Why the last command? *) ring.
++ apply gball_0. change ((0 : CR) [=] - 0)%CR.
+  apply CRopp_0. 
++ apply gball_0. rewrite !cmΣ_succ.
+  apply gball_0 in IH. rewrite IH. clear IH.
+  change (- f n - cmΣ n f [=] - (f n + cmΣ n f))%CR.
+  apply (CRplus_eq_r (f n + cmΣ n f)%CR).
+  rewrite CRplus_opp.
+  rewrite (CRplus_comm (f n)), <- CRplus_assoc.
+  rewrite (CRplus_assoc (f n)).
+  rewrite CRplus_opp, CRplus_0_l. apply CRplus_opp.
 Qed.
 
 Lemma cmΣ_const (n : nat) (m : CR) : cmΣ n (λ _, m) = m * '(n : Q).
 Proof.
 induction n as [| n IH].
-+ rewrite cmΣ_empty. change (0 = m * 0). symmetry; apply rings.mult_0_r.
-+ rewrite cmΣ_succ, IH, S_Qplus, <- CRplus_Qplus.
-  change (m + m * '(n : Q) = m * ('(n : Q) + 1)). ring.
++ apply gball_0. rewrite cmΣ_empty.
+  change (0 [=] m * 0). symmetry; apply rings.mult_0_r.
++ apply gball_0. rewrite cmΣ_succ.
+  apply gball_0 in IH. rewrite IH, S_Qplus, <- CRplus_Qplus.
+  change (m + m * '(n : Q) [=] m * ('(n : Q) + 1)).
+  rewrite rings.plus_mult_distr_l.
+  rewrite rings.mult_1_r.
+  rewrite rings.plus_comm. reflexivity.
 Qed.
 
 Lemma riemann_sum_const (a : Q) (w : Q) (m : CR) (n : positive) :
@@ -688,15 +707,17 @@ Lemma riemann_sum_const (a : Q) (w : Q) (m : CR) (n : positive) :
 Proof.
 unfold riemann_sum. rewrite cmΣ_const, positive_nat_Z.
 change ('step w n * m * '(n : Q) = 'w * m).
+apply gball_0.
 rewrite (mult_comm _ ('(inject_Z n : Q))), mult_assoc, CRmult_Qmult, step_mult; reflexivity.
 Qed.
 
 Lemma riemann_sum_plus (f g : Q -> CR) (a w : Q) (n : positive) :
   riemann_sum (f + g) a w n = riemann_sum f a w n + riemann_sum g a w n.
 Proof.
-unfold riemann_sum. rewrite <- cmΣ_plus. apply cm_Sum_eq. intro k.
+  unfold riemann_sum. rewrite <- cmΣ_plus.
+  apply gball_0. apply cm_Sum_eq. intro k.
 change (
-  cast Q CR (step w n) * (f (a + (k : Q) * step w n) + g (a + (k : Q) * step w n)) =
+  cast Q CR (step w n) * (f (a + (k : Q) * step w n) + g (a + (k : Q) * step w n)) [=]
   cast Q CR (step w n) * f (a + (k : Q) * step w n) + cast Q CR (step w n) * g (a + (k : Q) * step w n)).
 apply rings.plus_mult_distr_l. (* Without [change] unification fails, [apply:] loops *)
 Qed.
@@ -704,9 +725,10 @@ Qed.
 Lemma riemann_sum_negate (f : Q -> CR) (a w : Q) (n : positive) :
   riemann_sum (- f) a w n = - riemann_sum f a w n.
 Proof.
-unfold riemann_sum. rewrite <- cmΣ_negate. apply cm_Sum_eq. intro k.
-change ('step w n * (- f (a + (k : Q) * step w n)) = -('step w n * f (a + (k : Q) * step w n))).
-ring.
+  unfold riemann_sum. rewrite <- cmΣ_negate.
+  apply gball_0. apply cm_Sum_eq. intro k.
+change ('step w n * (- f (a + (k : Q) * step w n)) [=] -('step w n * f (a + (k : Q) * step w n))).
+  rewrite rings.negate_mult_distr_r. reflexivity.
 Qed.
 
 Section RiemannSumBounds.
@@ -736,7 +758,10 @@ Lemma riemann_sum_bounds (a w : Q) (m : CR) (e : Q) (n : positive) :
   0 ≤ w -> (forall (x : Q), (a ≤ x ≤ a + w) -> gball e (f x) m) ->
   gball (w * e) (riemann_sum f a w n) ('w * m).
 Proof.
-intros w_nn A. rewrite <- (riemann_sum_const a w m n). unfold riemann_sum.
+  intros w_nn A.
+  pose proof (riemann_sum_const a w m n).
+  apply gball_0 in H. rewrite <- H. clear H.
+  unfold riemann_sum.
 rewrite <- (step_mult w n), <- (Qmult_assoc (inject_Z n) _ e), <- (positive_nat_Z n).
 apply CRΣ_gball. intros k A1. apply CRball.gball_CRmult_Q_nonneg; [now apply step_nonneg |].
 apply A. split; [apply index_inside_l | apply index_inside_r]; trivial.
@@ -748,8 +773,12 @@ Section IntegralBound.
 
 Context (f : Q -> CR) `{Integrable f}.
 
-Lemma scale_0_r (x : Q) : scale x 0 = 0.
-Proof. rewrite <- CRmult_scale; change (cast Q CR x * 0 = 0); ring. Qed.
+Lemma scale_0_r (x : Q) : scale x 0 [=] 0.
+Proof.
+  rewrite <- CRmult_scale.
+  change (cast Q CR x * 0 [=] 0).
+  apply rings.mult_0_r.
+Qed.
 
 Require Import MathClasses.misc.propholds.
 
@@ -944,7 +973,7 @@ Qed.
 Lemma CRabs_negate (x : CR) : abs (-x) = abs x.
 Proof.
 change (abs (-x)) with (CRabs (-x)).
-rewrite CRabs_opp; reflexivity.
+apply gball_0. rewrite CRabs_opp; reflexivity.
 Qed.
 
 Lemma mspc_ball_Qle (r a x : Q)
@@ -988,36 +1017,82 @@ Proof.
   intros A1 A2.
   Print QnonNeg.eq.
   assert (QnonNeg.eq (u+v)%Qnn w) as H0. { apply A2. }
-  assert (Qeq (a+`u) b). { apply A1. }
-  rewrite <- H1. rewrite <- H0.
+  assert (Qeq (a+`u) b) as H1. { apply A1. }
+  apply gball_0. rewrite <- A1. rewrite <- H0.
   apply integral_additive.
 Qed.
 
 Lemma int_add (a b c : Q) : int a b + int b c = int a c.
-Proof with apply integral_additive'; simpl; ring.
+Proof.
 unfold int.
 destruct (decide (a ≤ b)) as [AB | AB];
 destruct (decide (b ≤ c)) as [BC | BC];
 destruct (decide (a ≤ c)) as [AC | AC].
-+ idtac...
++ apply integral_additive'; simpl; ring.
 + assert (A : a ≤ c) by (now transitivity b); elim (AC A).
-+ apply minus_eq_plus; symmetry...
-+ rewrite minus_eq_plus, (rings.plus_comm (-integrate _ _ _)), <- plus_eq_minus, (rings.plus_comm (integrate _ _ _))...
-+ rewrite (rings.plus_comm (-integrate _ _ _)), minus_eq_plus, (rings.plus_comm (integrate _ _ _)); symmetry...
-+ rewrite (rings.plus_comm (-integrate _ _ _)), minus_eq_plus, (rings.plus_comm (-integrate _ _ _)), <- plus_eq_minus...
++ apply gball_0. apply minus_eq_plus. symmetry.
+  pose proof (integral_additive' a c ((c - a) ↾ int_obligation_1 a c AC)
+                                 ((b - c) ↾ int_obligation_2 b c BC)
+                                 ((b - a) ↾ int_obligation_1 a b AB) ).
+  apply gball_0 in H0. apply H0. clear H0.
+  simpl. ring. simpl. ring.
++ apply gball_0. apply minus_eq_plus.
+  rewrite (rings.plus_comm (-integrate _ _ _)), <- plus_eq_minus, (rings.plus_comm (integrate _ _ _)).
+  pose proof (integral_additive' c a ((a - c) ↾ int_obligation_2 a c AC)
+                                 ((b - a) ↾ int_obligation_1 a b AB)
+                                 ((b - c) ↾ int_obligation_2 b c BC) ).
+  apply gball_0 in H0. apply H0. clear H0.
+  simpl. ring. simpl. ring. 
++ apply gball_0.
+  rewrite (rings.plus_comm (-integrate _ _ _)).
+  apply minus_eq_plus. rewrite (rings.plus_comm (integrate _ _ _)).
+  symmetry.
+  pose proof (integral_additive' b a ((a - b) ↾ int_obligation_2 a b AB)
+                                 ((c - a) ↾ int_obligation_1 a c AC)
+                                 ((c - b) ↾ int_obligation_1 b c BC) ).
+  apply gball_0 in H0. apply H0. clear H0.
+  simpl. ring. simpl. ring. 
++ apply gball_0. rewrite (rings.plus_comm (-integrate _ _ _)).
+  apply minus_eq_plus. rewrite (rings.plus_comm (-integrate _ _ _)), <- plus_eq_minus.
+  pose proof (integral_additive' b c ((c - b) ↾ int_obligation_1 b c BC)
+                                 ((a - c) ↾ int_obligation_2 a c AC)
+                                 ((a - b) ↾ int_obligation_2 a b AB) ).
+  apply gball_0 in H0. apply H0. clear H0.
+  simpl. ring. simpl. ring. 
 + assert (b ≤ a) by (now apply orders.le_flip); assert (B : b ≤ c) by (now transitivity a); elim (BC B).
-+ rewrite <- rings.negate_plus_distr, negate_inj, (rings.plus_comm (integrate _ _ _))...
++ apply gball_0.
+  rewrite <- rings.negate_plus_distr. apply negate_inj.
+  rewrite (rings.plus_comm (integrate _ _ _)).
+  pose proof (integral_additive' c b ((b - c) ↾ int_obligation_2 b c BC)
+                                 ((a - b) ↾ int_obligation_2 a b AB)
+                                 ((a - c) ↾ int_obligation_2 a c AC) ).
+  apply gball_0 in H0. apply H0. clear H0.
+  simpl. ring. simpl. ring. 
 Qed.
 
 Lemma int_diff (a b c : Q) : int a b - int a c = int c b.
-Proof. apply minus_eq_plus. rewrite rings.plus_comm. symmetry; apply int_add. Qed.
+Proof.
+  apply gball_0. apply minus_eq_plus. symmetry.
+  rewrite (rings.plus_comm (int c b) (int a c)).
+  pose proof (int_add a c b). apply gball_0 in H0.
+  apply H0.
+Qed.
 
 Lemma int_zero_width (a : Q) : int a a = 0.
-Proof. apply (plus_right_cancel (int a a)); rewrite rings.plus_0_l; apply int_add. Qed.
+Proof.
+  apply gball_0.
+  apply (plus_right_cancel (int a a)).
+  rewrite rings.plus_0_l.
+  pose proof (int_add a a a). apply gball_0 in H0. exact H0.
+Qed.
 
 Lemma int_opposite (a b : Q) : int a b = - int b a.
 Proof.
-apply rings.equal_by_zero_sum. rewrite rings.negate_involutive, int_add. apply int_zero_width.
+  apply gball_0.
+  apply (CRplus_eq_r (int b a)). rewrite CRplus_opp.
+  pose proof (int_add b a b). apply gball_0 in H0. rewrite H0.
+  pose proof (int_zero_width b).
+  apply gball_0 in H1. exact H1.
 Qed.
 
 Lemma int_abs_bound (a b M : Q) :
@@ -1143,13 +1218,22 @@ Lemma int_plus (f g : Q -> CR)
        a b
   = int f a b + int g a b.
 Proof.
-unfold int; destruct (decide (a ≤ b)); rewrite integrate_plus; ring.
+  unfold int; destruct (decide (a ≤ b)).
+  rewrite integrate_plus. reflexivity.
+  apply gball_0.
+  pose proof (integrate_plus f g b ((a - b) ↾ int_obligation_2 a b n)).
+  apply gball_0 in H1. rewrite H1. clear H1.
+  apply rings.negate_plus_distr.
 Qed.
 
 Lemma int_negate (f : Q -> CR) `{!IsUniformlyContinuous f f_mu} (a b : Q) :
   int (- f) a b = - int f a b.
 Proof.
-unfold int; destruct (decide (a ≤ b)); rewrite integrate_negate; reflexivity.
+  unfold int; destruct (decide (a ≤ b)).
+  rewrite integrate_negate. reflexivity.
+  apply gball_0.
+  pose proof (integrate_negate f b ((a - b) ↾ int_obligation_2 a b n)).
+  apply gball_0 in H. rewrite H. reflexivity.
 Qed.
 
 Lemma int_minus (f g : Q -> CR)
@@ -1171,7 +1255,35 @@ Lemma int_minus (f g : Q -> CR)
                                             f (-g) _ _ _ _)))
        a b
   = int f a b - int g a b.
-Proof. rewrite int_plus, int_negate; reflexivity. Qed.
+Proof.
+  rewrite int_plus.
+  pose proof (int_negate g a b).
+  apply gball_0. apply gball_0 in H1. rewrite H1. reflexivity.
+Qed.
+
+Lemma abs_int_minus (f g : Q -> CR)
+      `{@IsUniformlyContinuous
+           Q (msp_mspc_ball Q_as_MetricSpace) 
+           CR (msp_mspc_ball CR) 
+          f f_mu,
+        @IsUniformlyContinuous
+           Q (msp_mspc_ball Q_as_MetricSpace) 
+           CR (msp_mspc_ball CR) 
+          g g_mu} 
+      (a b : Q) :
+  abs (@int (f - g)
+       (@Integral_instance_0
+                        (f-g) _ (@uc_ulc _ _ _ _ _ _
+                                         (@sum_uc
+                                            Q (msp_mspc_ball Q_as_MetricSpace)
+                                            (msp_mspc_ball_ext Q_as_MetricSpace) 
+                                            f (-g) _ _ _ _)))
+       a b)
+  [=] abs (int f a b - int g a b).
+Proof.
+  rewrite <- gball_0. apply CRabs_proper.
+  apply int_minus.
+Qed.
 
 Import interfaces.orders orders.semirings.
 
@@ -1218,7 +1330,8 @@ Lemma int_lip (e M : Q) :
 Proof.
 intros A1 A2. apply CRball.gball_CRabs. subst F; cbv beta.
 change (int f x0 x1 - int f x0 x2)%CR with (int f x0 x1 - int f x0 x2).
-rewrite int_diff; [| trivial]. (* Why does it leave the second subgoal [Integrable f]? *)
+pose proof (int_diff f x0 x1 x2). apply gball_0 in H1.
+rewrite H1.
 change (abs (int f x2 x1) ≤ '(M * e)).
 transitivity ('(M * abs (x1 - x2))).
 + rewrite mult_comm. apply int_abs_bound; trivial. intros x A3; apply A1, (mspc_ball_convex x2 x1); easy.
@@ -1238,13 +1351,21 @@ Lemma lipschitz_bounded (a r M x : Q) :
   -> @ball Q (msp_mspc_ball Q_as_MetricSpace) r a x
   -> abs (f x) ≤ '(M + L a r * r).
 Proof.
-intros A1 A2. mc_setoid_replace (f x) with (f x - 0) by ring.
-apply mspc_ball_CRabs, mspc_symm.
-(* [apply mspc_triangle with (c := f a)] does not work *)
-apply (mspc_triangle _ _ _ (f a)).
-+ apply mspc_ball_CRabs. mc_setoid_replace (0 - f a) with (- f a) by ring.
-  now rewrite CRabs_negate.
-+ apply (@llip _ _ _ _
+  intros A1 A2.
+  assert (f x = f x - 0) as H1.
+  { apply gball_0. rewrite rings.minus_0_r. reflexivity. }
+  pose proof (CRabs_proper _ _ H1).
+  apply gball_0 in H2. rewrite H2. clear H2 H1.
+  apply mspc_ball_CRabs, mspc_symm.
+  apply (mspc_triangle _ _ _ (f a)).
+  - apply mspc_ball_CRabs.
+    assert (0 - f a = - f a) as H1.
+    { apply gball_0. rewrite rings.plus_0_l. reflexivity. }
+    pose proof (CRabs_proper _ _ H1).
+    apply gball_0 in H2. rewrite H2. clear H2 H1.
+    pose proof (CRabs_negate (f a)).
+    apply gball_0 in H1. now rewrite H1.
+  - apply (@llip _ _ _ _
               (msp_mspc_ball_ext Q_as_MetricSpace) f _ H).
   2: exact A2. 2: exact A2.
   apply mspc_refl.

--- a/reals/fast/CRArith.v
+++ b/reals/fast/CRArith.v
@@ -80,6 +80,7 @@ Qed.
 Lemma CRplus_Qplus : forall (x y:Q), inject_Q_CR x + inject_Q_CR y == inject_Q_CR (x + y)%Q.
 Proof.
  intros x y e1 e2; apply ball_refl.
+ apply (Qpos_nonneg (e1+e2)).
 Qed.
 
 Hint Rewrite <- CRplus_Qplus : toCRring.
@@ -87,6 +88,7 @@ Hint Rewrite <- CRplus_Qplus : toCRring.
 Lemma CRopp_Qopp : forall (x:Q), - inject_Q_CR x == inject_Q_CR (- x)%Q.
 Proof.
  intros x e1 e2; apply ball_refl.
+ apply (Qpos_nonneg (e1+e2)). 
 Qed.
 (* begin hide *)
 Hint Rewrite CRopp_Qopp : CRfast_compute.
@@ -95,6 +97,7 @@ Hint Rewrite <- CRopp_Qopp : toCRring.
 Lemma CRminus_Qminus : forall (x y:Q), inject_Q_CR x - inject_Q_CR y == inject_Q_CR (x - y)%Q.
 Proof.
  intros x y e1 e2; apply ball_refl.
+ apply (Qpos_nonneg (e1+e2)). 
 Qed.
 (* begin hide *)
 Hint Rewrite <- CRminus_Qminus : toCRring.
@@ -104,6 +107,7 @@ Proof.
  intros x y.
  rewrite -> CRmult_scale.
  intros e1 e2; apply ball_refl.
+ apply (Qpos_nonneg (e1+e2)). 
 Qed.
 (* begin hide *)
 Hint Rewrite <- CRmult_Qmult : toCRring.
@@ -374,45 +378,30 @@ Proof with auto.
  apply Qlt_le_trans with x0...
 Qed.
 
-Lemma in_CRball (r: Qpos) (x y : CR)
-  : x - ' proj1_sig r <= y /\ y <= x + ' proj1_sig r <-> ball r x y.
+Lemma in_CRball (r: Q) (x y : CR)
+  : x - ' r <= y /\ y <= x + ' r <-> ball r x y.
   (* A characterization of ball in terms of <=, similar to CRAbsSmall. *)
 Proof with intuition.
  intros.
- cut (AbsSmall (' proj1_sig r) (x - y) <-> (x - ' proj1_sig r <= y /\ y <= x + ' proj1_sig r)).
-  pose proof (CRAbsSmall_ball x y r)...
- unfold AbsSmall.
+ cut (AbsSmall (' r) (x - y) <-> (x - ' r <= y /\ y <= x + ' r)).
+ - pose proof (CRAbsSmall_ball x y r)...
+ - unfold AbsSmall.
  simpl.
- setoid_replace (x - y <= ' proj1_sig r) with (x - ' proj1_sig r <= y).
-  setoid_replace (- ' proj1_sig r <= x - y) with (y <= x + ' proj1_sig r).
+ setoid_replace (x - y <= ' r) with (x - ' r <= y).
+  setoid_replace (- ' r <= x - y) with (y <= x + ' r).
    intuition.
-  rewrite (CRplus_le_r (- ' proj1_sig r) (x - y) ('proj1_sig r + y)).
-  assert (- ' proj1_sig r + (' proj1_sig r + y) == y) as E by ring. rewrite E.
-  assert (x - y + (' proj1_sig r + y) == x + ' proj1_sig r)%CR as F by ring. rewrite F...
- rewrite (CRplus_le_r (x - y) (' proj1_sig r) (y - 'proj1_sig r)).
- assert (x - y + (y - ' proj1_sig r) == x - ' proj1_sig r) as E by ring. rewrite E.
- assert (' proj1_sig r + (y - ' proj1_sig r) == y) as F by ring. rewrite F...
+  rewrite (CRplus_le_r (- ' r) (x - y) ('r + y)).
+  assert (- ' r + (' r + y) == y) as E by ring. rewrite E.
+  assert (x - y + (' r + y) == x + ' r)%CR as F by ring. rewrite F...
+ rewrite (CRplus_le_r (x - y) (' r) (y - 'r)).
+ assert (x - y + (y - ' r) == x - ' r) as E by ring. rewrite E.
+ assert (' r + (y - ' r) == y) as F by ring. rewrite F...
 Qed.
 
   (* And the same for gball: *)
 Lemma in_CRgball (r: Q) (x y: CR): x - ' r <= y /\ y <= x + ' r <-> gball r x y.
 Proof with intuition.
- unfold gball.
- destruct Q_dec as [[?|?]|?].
-   intuition.
-   generalize (CRle_trans H0 H1).
-   rewrite <- CRplus_le_l.
-   rewrite CRopp_Qopp.
-   rewrite CRle_Qle.
-   clear H0 H1.
-   intros.
-   apply Qlt_irrefl with 0%Q.
-   apply Qlt_le_trans with (-r)%Q.
-    change (- 0 < - r)%Q.
-    apply Qopp_lt_compat...
-   apply Qle_trans with r...
-  rewrite <- in_CRball...
- rewrite q, CRopp_Qopp, ?CRplus_0_r, CRle_def... 
+  unfold gball. apply in_CRball.
 Qed.  
 
 Lemma CRgball_plus (x x' y y': CR) e1 e2:
@@ -485,7 +474,7 @@ Proof.
  intros. rewrite <- CRplus_Qplus.
  apply CRplus_le_r with (-'proj1_sig e)%CR.
  assert (' approximate x e + 'proj1_sig e - 'proj1_sig e == ' approximate x e)%CR as E by ring. rewrite E.
- apply (in_CRball e x ('approximate x e)), ball_approx_r.
+ apply (in_CRball (proj1_sig e) x ('approximate x e)), ball_approx_r.
 Qed.
 
 Hint Immediate lower_CRapproximation upper_CRapproximation.

--- a/reals/fast/CRFieldOps.v
+++ b/reals/fast/CRFieldOps.v
@@ -361,7 +361,7 @@ Definition Qmult_modulus (c:Qpos)(e:Qpos) : QposInf
 
 Lemma Qmult_uc_prf (c:Qpos) : is_UniformlyContinuousFunction (fun a => uc_compose (Qscale_uc a) (QboundAbs c)) (Qmult_modulus c).
 Proof with simpl in *; auto with *.
- intros e a0 a1 H b.
+ intros e a0 a1 H. split. apply Qpos_nonneg. intro b.
  simpl in *.
  set (b' := Qmax (- proj1_sig c) (Qmin (proj1_sig c) b)).
  repeat rewrite -> (fun x => Qmult_comm x b').
@@ -406,8 +406,9 @@ Cmap2 QPrelengthSpace QPrelengthSpace (Qmult_uc c).
 Instance: Proper (QposEq ==> @st_eq _) Qmult_uc.
 Proof.
  intros e1 e2 E x1 x2.
- apply ball_eq_iff. intro e.
- simpl. unfold QposEq in E. rewrite E. reflexivity.
+ apply ball_eq_iff. intros e epos.
+ simpl. unfold QposEq in E. rewrite E.
+ apply Qball_Reflexive. apply Qlt_le_weak, epos.
 Qed.
 
 Instance: Proper (QposEq ==> @st_eq _) CRmult_bounded.
@@ -538,6 +539,7 @@ Proof.
    apply (Qlt_not_le _ _ q). rewrite abs. apply Qle_refl. }
  simpl. simpl in H0. rewrite H0. 
  do 2 rewrite QposInf_bind_id. apply ball_refl.
+ apply (Qpos_nonneg (e+e)).
 Qed.
 
 Lemma CRmult_bounded_mult : forall (c:Qpos) (x y:CR),
@@ -654,7 +656,8 @@ Proof.
   rewrite -> Qmult_comm.
   apply mult_resp_leEq_lft;[|apply Qpos_nonneg].
   apply mult_resp_leEq_both; (apply Qpos_nonneg || apply Qmax_ub_l).
- change (@ball Q_as_MetricSpace (c*c*e) (Qmax (proj1_sig c) a1) (Qmax (proj1_sig c) a0)).
+  change (@ball Q_as_MetricSpace (proj1_sig (c*c*e)%Qpos)
+                (Qmax (proj1_sig c) a1) (Qmax (proj1_sig c) a0)).
  apply ball_sym.
  apply QboundBelow_uc_prf.
  apply Ha.
@@ -712,6 +715,7 @@ Proof.
   rewrite -> Z;[|apply Qmax_ub_l].
   unfold Qinv_modulus.
   replace (Qpos_red (c1 * c1 * e)) with (Qpos_red (f (c2 * c2 * e)%Qpos)); [apply: ball_refl|].
+  apply (Qpos_nonneg (e+e)).
   apply Qpos_red_eq.
   unfold f.
   unfold QposEq.
@@ -745,6 +749,7 @@ Proof.
  simpl.
  setoid_replace (Qmax (proj1_sig c) x) with x.
   apply: ball_refl.
+  apply (Qpos_nonneg (e+e)).
  rewrite <- Qle_max_r.
  assumption.
 Qed.
@@ -818,7 +823,7 @@ Proof.
   simpl.
   unfold Cap_raw; simpl.
   ring_simplify.
-  apply: ball_refl.
+  apply: ball_refl. apply (Qpos_nonneg (e+e)).
  assert (Y:forall x, (x + - 0 == x)%CR).
   intros x.
   transitivity (doubleSpeed x);[|apply: doubleSpeed_Eq].
@@ -827,7 +832,7 @@ Proof.
   simpl.
   unfold Cap_raw; simpl.
   ring_simplify.
-  apply: ball_refl.
+  apply: ball_refl. apply (Qpos_nonneg (e+e)).
  intros x y [[c x_]|[c x_]] [[d y_]|[d y_]] H.
     change (-(CRinv_pos c (-x))== (-(CRinv_pos d (-y))))%CR.
     rewrite -> H in *.

--- a/reals/fast/CRGeometricSum.v
+++ b/reals/fast/CRGeometricSum.v
@@ -482,23 +482,23 @@ Proof.
  revert e0 e1.
  cut (forall (e0 e1:Qpos), (proj1_sig e1 <= proj1_sig e0) -> forall (p p0 : positive),
    err_prop (proj1_sig e0) (Str_nth_tl (nat_of_P p) series) -> err_prop (proj1_sig e1) (Str_nth_tl (nat_of_P p0) series) ->
-     Qball (e0) (InfiniteSum_raw_N p (fun (_ : Stream Q -> bool) (_ : Stream Q) => 0)
+     Qball (proj1_sig e0) (InfiniteSum_raw_N p (fun (_ : Stream Q -> bool) (_ : Stream Q) => 0)
        (err_prop (proj1_sig e0)) series) (InfiniteSum_raw_N p0 (fun (_ : Stream Q -> bool) (_ : Stream Q) => 0)
          (err_prop (proj1_sig e1)) series)).
   intros X e0 e1 p0 p1.
   destruct (Qle_total (proj1_sig e1) (proj1_sig e0)).
    intros H0 H1.
-   apply: ball_weak;simpl;auto.
+   apply: ball_weak;simpl;auto. apply Qpos_nonneg.
   intros H0 H1.
   assert (QposEq (e0 + e1) (e1+e0)) by (unfold QposEq; simpl; ring).
   apply (ball_wd _ H2 _ _ (reflexivity _) _ _ (reflexivity _)). clear H2.
-  apply: ball_weak.
+  apply: ball_weak. apply Qpos_nonneg.
   apply ball_sym.
   apply X; auto with *.
  intros e0 e1 He p0 p1 H0.
  revert H.
  set (P0:=fun s q => GeometricSeries s ->
-   err_prop (proj1_sig e1) (Str_nth_tl (nat_of_P p1) s) -> Qball e0 q (InfiniteSum_raw_N p1 (fun (_ : Stream Q -> bool) (_ : Stream Q) => 0)
+   err_prop (proj1_sig e1) (Str_nth_tl (nat_of_P p1) s) -> Qball (proj1_sig e0) q (InfiniteSum_raw_N p1 (fun (_ : Stream Q -> bool) (_ : Stream Q) => 0)
      (err_prop (proj1_sig e1)) s)).
  change (P0 series (InfiniteSum_raw_N p0 (fun (_ : Stream Q -> bool) (_ : Stream Q) => 0)
    (err_prop (proj1_sig e0)) series)).
@@ -599,7 +599,7 @@ Proof.
  rewrite -> Qplus'_correct.
  rewrite (@InfiniteSum_raw_N_extend' (InfiniteGeometricSum_maxIter (tl series) e)
    (InfiniteGeometricSum_maxIter series e)).
-   apply: ball_refl.
+   apply: ball_refl. apply (Qpos_nonneg (e+e)).
   apply InfiniteGeometricSum_maxIter_correct.
   destruct Gs; assumption.
  apply (@InfiniteGeometricSum_maxIter_monotone series e).
@@ -629,8 +629,8 @@ Proof.
   setoid_replace (InfiniteSum_raw_N (InfiniteGeometricSum_maxIter series e)
                                     (fun (_ : Stream Q -> bool) (_ : Stream Q) => 0) (err_prop (proj1_sig e)) series - 0)
     with 0.
-   apply zero_AbsSmall.
-   apply Qpos_nonneg.
+   apply zero_AbsSmall. 
+   apply (Qpos_nonneg (e+e)).
   simpl.
   ring_simplify.
   assert (X:err_prop (proj1_sig e) series).
@@ -660,7 +660,6 @@ Proof.
  cut (AbsSmall (R:=CRasCOrdField) (' proj1_sig e)%CR (InfiniteGeometricSum Gs)).
   intros [H0 H1].
   unfold e in *.
-  autorewrite with QposElim in *.
   split; assumption.
  stepr (InfiniteGeometricSum Gs[-]0)%CR; [| now (unfold cg_minus; simpl; ring)].
  rewrite -> CRAbsSmall_ball.
@@ -674,7 +673,7 @@ Proof.
  setoid_replace (InfiniteSum_raw_N p (fun (_ : Stream Q -> bool) (_ : Stream Q) => 0) e'
    series - 0) with (InfiniteSum_raw_N p (fun (_ : Stream Q -> bool) (_ : Stream Q) => 0) e'
      series) by (simpl; ring).
- apply err_prop_correct; try assumption.
+ apply (err_prop_correct (d+e+d)%Qpos); try assumption.
   apply err_prop_monotone with (proj1_sig e).
   simpl.
    Qauto_le.

--- a/reals/fast/CRGroupOps.v
+++ b/reals/fast/CRGroupOps.v
@@ -84,7 +84,7 @@ Qed.
 (** Lifting translate yields binary addition over CR. *)
 Lemma Qplus_uc_prf :  is_UniformlyContinuousFunction Qtranslate_uc Qpos2QposInf.
 Proof.
- intros e a0 a1 H b.
+ intros e a0 a1 H. split. apply Qpos_nonneg. intro b.
  simpl in *.
  repeat rewrite -> (fun x => Qplus_comm x b).
  apply Qtranslate_uc_prf.
@@ -343,7 +343,7 @@ Proof.
  rewrite <- (doubleSpeed_Eq y).
  apply: regFunEq_e.
  intros e.
- apply ball_weak.
+ apply ball_weak. apply Qpos_nonneg.
  split;[apply H2|].
  apply: inv_cancel_leEq;simpl.
  stepr (approximate y ((1 # 2) * e)%Qpos - approximate x ((1 # 2) * e)%Qpos); [| simpl; ring].
@@ -381,7 +381,8 @@ Lemma QboundBelow_uc_prf (a:Q)
 Proof.
  intros e b0 b1 H.
  simpl in *.
- assert (X:forall a b0 b1, Qball e b0 b1 -> b0 <= a <= b1 -> Qball e a b1).
+ assert (X:forall a b0 b1, Qball (proj1_sig e) b0 b1
+                      -> b0 <= a <= b1 -> Qball (proj1_sig e) a b1).
   clear a b0 b1 H.
   intros a b0 b1 H [H1 H2].
   unfold Qball in *.
@@ -398,7 +399,7 @@ Proof.
    simpl; ring.
    apply Qlt_le_weak. destruct e. exact q.
  do 2 apply Qmax_case; intros H1 H2.
-    apply: ball_refl.
+    apply: ball_refl. apply Qpos_nonneg.
    eapply X.
     apply H.
    tauto.
@@ -418,7 +419,7 @@ Definition boundBelow (a:Q) : CR --> CR := Cmap QPrelengthSpace (QboundBelow_uc 
 (** CRmax is the lifting of [QboundBelow]. *)
 Lemma Qmax_uc_prf :  is_UniformlyContinuousFunction QboundBelow_uc Qpos2QposInf.
 Proof.
- intros e a0 a1 H b.
+ intros e a0 a1 H. split. apply Qpos_nonneg. intro b.
  simpl in *.
  repeat rewrite -> (fun x => Qmax_comm x b).
  apply QboundBelow_uc_prf.
@@ -442,22 +443,22 @@ Proof.
  split.
  - apply Qmax_case. intros. apply Qmax_case. intros.
    unfold Qminus. rewrite Qplus_opp_r. apply (Qopp_le_compat 0).
-   apply Qpos_nonneg. intros.
+   apply (Qpos_nonneg (e1+e2)). intros.
    apply (Qle_trans _ (approximate ((1 # 2)%Q ↾ eq_refl * e1)%Qpos - approximate e2)).
    destruct regFun_prf as [H1 _].
    refine (Qle_trans _ _ _ _ H1). simpl. ring_simplify.
    apply Qplus_le_l. apply Qmult_le_r. apply Qpos_ispos. discriminate.
    apply Qplus_le_l. exact H. intros. apply Qmax_case.
-   intros. apply (Qle_trans _ 0). apply (Qopp_le_compat 0), Qpos_nonneg.
+   intros. apply (Qle_trans _ 0). apply (Qopp_le_compat 0), (Qpos_nonneg (e1+e2)).
    unfold Qminus. rewrite <- Qle_minus_iff. exact H. intros.
    destruct regFun_prf as [H1 _].
    refine (Qle_trans _ _ _ _ H1). simpl. ring_simplify.
    apply Qplus_le_l. apply Qmult_le_r. apply Qpos_ispos. discriminate.
  - apply Qmax_case. apply Qmax_case. intros.
-   unfold Qminus. rewrite Qplus_opp_r. apply Qpos_nonneg.
+   unfold Qminus. rewrite Qplus_opp_r. apply (Qpos_nonneg (e1+e2)).
    intros. apply (Qle_trans _ 0).
    apply (Qplus_le_l _ _ (approximate e2)). ring_simplify. exact H.
-   apply Qpos_nonneg. intros.
+   apply (Qpos_nonneg (e1+e2)). intros.
    apply Qmax_case. intros. apply Qopp_le_compat in H0.
    apply (Qle_trans _ (approximate ((1 # 2) * e1)%Qpos - approximate e2)).
    apply Qplus_le_r, H0. destruct regFun_prf as [_ H1].
@@ -483,7 +484,7 @@ Proof.
  eapply Qle_trans;[|apply Qmax_ub_l].
  cut (AbsSmall (proj1_sig e) (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos +
    - approximate x ((1 # 2) * e)%Qpos));[unfold AbsSmall;tauto|].
- change (ball e (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos) (approximate x ((1 # 2) * e)%Qpos)).
+ change (ball (proj1_sig e) (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos) (approximate x ((1 # 2) * e)%Qpos)).
  eapply ball_weak_le;[|apply regFun_prf].
  simpl.
  rewrite -> Qle_minus_iff.
@@ -505,7 +506,7 @@ Proof.
  eapply Qle_trans;[|apply Qmax_ub_r].
  cut (AbsSmall (proj1_sig e) (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos +
    - approximate x ((1 # 2) * e)%Qpos));[unfold AbsSmall;tauto|].
- change (ball e (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos) (approximate x ((1 # 2) * e)%Qpos)).
+ change (ball (proj1_sig e) (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos) (approximate x ((1 # 2) * e)%Qpos)).
  eapply ball_weak_le;[|apply regFun_prf].
  simpl.
  rewrite -> Qle_minus_iff.
@@ -537,7 +538,7 @@ Proof.
  apply Qplus_le_compat.
  - apply (Qle_trans _ (- ((1 # 2) * ` e))).
    destruct e; simpl; ring_simplify; apply Qle_refl.
-   cut (ball ((1#2)*e)%Qpos (approximate z ((1#2)*((1 # 2) * e))%Qpos)
+   cut (ball ((1#2)*proj1_sig e) (approximate z ((1#2)*((1 # 2) * e))%Qpos)
              (approximate z ((1#2)*((1 # 2) * ((1 # 2) * e)))%Qpos)).
    intros [A B]. assumption.
  apply: ball_weak_le. 2:apply regFun_prf.
@@ -583,7 +584,7 @@ Definition boundAbove (a:Q) : CR --> CR := Cmap QPrelengthSpace (QboundAbove_uc 
 (** CRmin is the lifting of [QboundAbove]. *)
 Lemma Qmin_uc_prf :  is_UniformlyContinuousFunction QboundAbove_uc Qpos2QposInf.
 Proof.
- intros e a0 a1 H b.
+ intros e a0 a1 H. split. apply Qpos_nonneg. intro b.
  simpl in *.
  repeat rewrite -> (fun x => Qmin_comm x b).
  apply QboundAbove_uc_prf.
@@ -624,7 +625,7 @@ Proof.
  eapply Qle_trans;[|apply Qmax_ub_l].
  cut (AbsSmall (proj1_sig e) (approximate x ((1 # 2) * e)%Qpos +
    - approximate x ((1 # 2) * ((1 # 2) * e))%Qpos));[unfold AbsSmall;tauto|].
- change (ball e (approximate x ((1 # 2) * e)%Qpos) (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos)).
+ change (ball (proj1_sig e) (approximate x ((1 # 2) * e)%Qpos) (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos)).
  eapply ball_weak_le;[|apply regFun_prf].
  simpl.
  rewrite -> Qle_minus_iff.
@@ -647,7 +648,7 @@ Proof.
  eapply Qle_trans;[|apply Qmax_ub_r].
  cut (AbsSmall (proj1_sig e) (approximate x ((1 # 2) * e)%Qpos +
    - approximate x ((1 # 2) * ((1 # 2) * e))%Qpos));[unfold AbsSmall;tauto|].
- change (ball e (approximate x ((1 # 2) * e)%Qpos) (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos)).
+ change (ball (proj1_sig e) (approximate x ((1 # 2) * e)%Qpos) (approximate x ((1 # 2) * ((1 # 2) * e))%Qpos)).
  eapply ball_weak_le;[|apply regFun_prf].
  simpl.
  rewrite -> Qle_minus_iff.
@@ -678,7 +679,7 @@ Proof.
  apply Qplus_le_compat.
  - apply (Qle_trans _ (- ((1 # 2) * ` e))).
    destruct e; simpl; ring_simplify; apply Qle_refl.
-   cut (ball ((1#2)*e)%Qpos (approximate z ((1#2)*((1 # 2) * ((1 # 2) * e)))%Qpos)
+   cut (ball ((1#2)*proj1_sig e) (approximate z ((1#2)*((1 # 2) * ((1 # 2) * e)))%Qpos)
              (approximate z ((1#2)*((1 # 2) * e))%Qpos)) ;[intros [A B]; assumption|].
  apply: ball_weak_le. 2:apply regFun_prf.
  rewrite -> Qle_minus_iff.

--- a/reals/fast/CRabs.v
+++ b/reals/fast/CRabs.v
@@ -94,7 +94,7 @@ Proof.
    simpl.
    rewrite -> Qabs_neg; auto with *.
    rewrite -> Qopp_involutive.
-   apply: ball_refl.
+   apply: ball_refl. apply (Qpos_nonneg (e+e)).
   cut (CRabs m== - - CRabs m)%CR.
    intros. assumption.
   ring.
@@ -112,7 +112,9 @@ Proof.
  apply: regFunEq_e.
  intros e.
  simpl.
- rewrite -> Qabs_pos; auto with *.
+ rewrite -> Qabs_pos. apply ball_refl.
+ apply (Qpos_nonneg (e+e)).
+ auto with *.
 Qed.
 
 Lemma approximate_CRabs (x: CR) (e: Qpos):
@@ -208,8 +210,9 @@ Qed.
 Lemma CRabs_scale (a : Q) (x : CR) : CRabs (scale a x) == scale (Qabs a) (CRabs x).
 Proof.
 apply lift_eq_complete with (f := uc_compose CRabs (scale a)) (g := uc_compose (scale (Qabs a)) CRabs).
-intros q e1 e2. change (@ball Q_as_MetricSpace (e1 + e2) (Qabs (a * q)) (Qabs a * Qabs q)%Q).
+intros q e1 e2. change (@ball Q_as_MetricSpace (proj1_sig e1 + proj1_sig e2) (Qabs (a * q)) (Qabs a * Qabs q)%Q).
 apply <- ball_eq_iff. apply Qabs_Qmult.
+apply (Qpos_ispos (e1+e2)).
 Qed.
 
 (* begin hide *)

--- a/reals/fast/CRpower.v
+++ b/reals/fast/CRpower.v
@@ -87,7 +87,7 @@ Lemma Qpower_N_uc_prf (c:Qpos) :
 Proof.
  unfold Qpower_N_modulus.
  destruct n as [|p].
-  simpl. intros e x y E. now apply ball_refl.
+  simpl. intros e x y E. apply ball_refl, Qpos_nonneg. 
  destruct (p_is_some_anti_convert p) as [m Hm].
  assert (X:=(fun I pI => Derivative_nth I pI _ _ (Derivative_id I pI) m)).
  assert (- proj1_sig c < proj1_sig c)%Q.
@@ -283,8 +283,9 @@ Hint Rewrite CRpower_N_correct' : IRtoCR.
 Instance: Proper (eq ==> QposEq ==> @st_eq _) Qpower_N_uc.
 Proof.
  intros p1 p2 Ep e1 e2 Ee x.
- apply ball_eq_iff. intro e.
- simpl. unfold QposEq in Ee. rewrite Ep, Ee. reflexivity.
+ apply ball_eq_iff. intros e epos.
+ simpl. unfold QposEq in Ee. rewrite Ep, Ee.
+ apply ball_refl. apply Qlt_le_weak, epos.
 Qed.
 
 Instance: Proper (eq ==> QposEq ==> @st_eq _) CRpower_N_bounded. 

--- a/reals/fast/CRroot.v
+++ b/reals/fast/CRroot.v
@@ -102,7 +102,8 @@ Proof.
 Qed.
 
 Lemma root_has_error_ball : forall (e1 e2:Qpos) (b1 b2:Q), 
-  (proj1_sig e1 + proj1_sig e2<=1) ->  (1 <= b1) -> (1 <= b2) -> root_has_error e1 b1 -> Qball e2 b1 b2 -> root_has_error (e1+e2) b2.
+    (proj1_sig e1 + proj1_sig e2<=1) ->  (1 <= b1) -> (1 <= b2) -> root_has_error e1 b1
+    -> Qball (proj1_sig e2) b1 b2 -> root_has_error (e1+e2) b2.
 Proof.
  intros e1 e2 b1 b2 He Hb1 Hb2 [H0 H1] [H2 H3].
  simpl in H2, H3.
@@ -118,7 +119,8 @@ Proof.
 Qed.
 
 Lemma ball_root_has_error : forall (e1 e2:Qpos) (b1 b2:Q), 
-  ((proj1_sig e1 + proj1_sig e2)<=1) -> (1<=b1) -> (1<=b2) -> root_has_error e1 b1 -> root_has_error e2 b2 -> Qball (e1+e2) b1 b2.
+    ((proj1_sig e1 + proj1_sig e2)<=1) -> (1<=b1) -> (1<=b2) -> root_has_error e1 b1
+    -> root_has_error e2 b2 -> Qball (proj1_sig e1+proj1_sig e2) b1 b2.
 Proof.
  intros e1 e2 b1 b2 He Hb1 Hb2 [H0 H1] [H2 H3].
  clear Ha.
@@ -358,7 +360,7 @@ end.
 Lemma sqrt_regular : @is_RegularFunction Q_as_MetricSpace sqrt_raw.
 Proof.
  intros e1 e2.
- apply ball_weak_le with (Qpos_min (1#2) e1 + Qpos_min (1#2) e2)%Qpos.
+ apply ball_weak_le with (proj1_sig (Qpos_min (1#2) e1 + Qpos_min (1#2) e2)%Qpos).
  - simpl. do 2 rewrite Q_Qpos_min.
   apply: plus_resp_leEq_both; simpl; auto with *.
  - apply ball_root_has_error.
@@ -472,7 +474,7 @@ Proof.
  intro He.
  set (d:= (e * Qpos_inv (6#1))%Qpos).
  simpl (approximate (' a)%CR (Qpos2QposInf ((en # ed) ↾ epos))).
- change (Qball (e + e)
+ change (Qball (proj1_sig e + proj1_sig e)
                (approximate ((CRpower_N_bounded 2 (3 # 1)) rational_sqrt_mid)
                             (Qpos2QposInf e)) a).
  assert (
@@ -797,8 +799,8 @@ Lemma sqrt_uc_prf : @is_UniformlyContinuousFunction
                       Q_as_MetricSpace CR rational_sqrt sqrt_modulus.
 Proof.
  intros e a.
- cut (forall a b, (0 <= a) -> (0 <= b) -> ball_ex (X:=Q_as_MetricSpace) (sqrt_modulus e) a b ->
-   ball (m:=CR) e (rational_sqrt a) (rational_sqrt b)).
+ cut (forall a b, (0 <= a) -> (0 <= b) -> ball_ex (X:=Q_as_MetricSpace) (sqrt_modulus e) a b
+             -> ball (m:=CR) (proj1_sig e) (rational_sqrt a) (rational_sqrt b)).
   intros X b Hab.
   destruct (Qle_total 0 a) as [Ha|Ha].
    destruct (Qle_total 0 b) as [Hb|Hb].
@@ -836,7 +838,7 @@ Proof.
   destruct (Qlt_le_dec_fast 0 b) as [Z0|_].
    elim (Qle_not_lt _ _ Hb Z0).
   change 0%CR with (rational_sqrt 0).
-  apply ball_refl.
+  apply ball_refl. apply Qpos_nonneg.
  clear a.
  intros a b Ha Hb Hab.
  assert (Z:[0][<=]inj_Q IR a).

--- a/reals/fast/CRsum.v
+++ b/reals/fast/CRsum.v
@@ -44,7 +44,7 @@ end
 Lemma CRsum_list_prf : forall l, is_RegularFunction (CRsum_list_raw l).
 Proof.
  intros [|a t] e1 e2.
-  apply ball_refl.
+  apply ball_refl. apply (Qpos_nonneg (e1 + e2)).
  unfold CRsum_list_raw.
  simpl.
  set (p:=P_of_succ_nat (@length (RegularFunction Q_as_MetricSpace) t)).
@@ -52,7 +52,7 @@ Proof.
  set (e2':=((1 # p) * e2)%Qpos).
  simpl in e1'. fold e1'.
  simpl in e2'. fold e2'.
- assert (Qball (e1' + e2') (0 + approximate a e1') (0 + approximate a e2')).
+ assert (Qball (proj1_sig e1' + proj1_sig e2') (0 + approximate a e1') (0 + approximate a e2')).
  { ring_simplify. apply (regFun_prf a). }
   assert (X:forall e:Qpos, proj1_sig ((1 # p) * e)%Qpos*(length t)
                       + proj1_sig ((1 # p) * e)%Qpos <= proj1_sig e).
@@ -90,8 +90,7 @@ Proof.
   simpl in *.
   ring_simplify in H1.
   ring_simplify in H2.
-  apply (@ball_weak_le Q_as_MetricSpace (e1' + e2')); auto.
-  autorewrite with QposElim.
+  apply (@ball_weak_le Q_as_MetricSpace (proj1_sig e1' + proj1_sig e2')); auto.
   apply Qplus_le_compat; auto.
  simpl in *.
  change (Zpos (P_of_succ_nat (length t))) with (Z_of_nat (1+(length t))) in H1.
@@ -125,7 +124,7 @@ Lemma CRsum_correct : forall l, (CRsum_list l == fold_right (fun x y => x + y) 0
 Proof.
  induction l.
   apply: regFunEq_e; intros e.
-  apply ball_refl.
+  apply ball_refl. apply (Qpos_nonneg (e+e)).
  simpl (fold_right (fun x y : CR => (x + y)%CR) 0%CR (a :: l)).
  rewrite <- IHl.
  clear -l.
@@ -137,24 +136,25 @@ Proof.
  simpl.
  destruct l; simpl.
   ring_simplify.
-  assert (QposEq (e+e) ((1 # 1) *e + (1 # 2) * e + (1 # 2) * e))
-    by (unfold QposEq; simpl; ring).
- apply (ball_wd _ H _ _ (reflexivity _) _ _ (reflexivity _)). clear H.
-  apply: ball_weak.
+  setoid_replace (proj1_sig e+proj1_sig e)
+    with (proj1_sig ((1 # 1) *e + (1 # 2) * e + (1 # 2) * e))%Qpos
+         by (simpl; ring).
+  apply: ball_weak. apply Qpos_nonneg.
   apply regFun_prf.
  set (n:=  (@length (RegularFunction Q_as_MetricSpace) l)).
  cut (forall (z1:Q) (e3 e5 e1 e2 e4 e6:Qpos) (z2 z3:Q),
-         ball e5 z1 z2 ->
+         ball (proj1_sig e5) z1 z2 ->
          (z3 == approximate a e3 + z1)
          -> (proj1_sig e1*n + proj1_sig e2*n +proj1_sig e3 + proj1_sig e4 + proj1_sig e5  <= proj1_sig e6)
-         -> Qball e6 (fold_left Qplus
+         -> Qball (proj1_sig e6) (fold_left Qplus
      (map (fun x : RegularFunction Q_as_MetricSpace => approximate x e1) l) z3) (approximate a e4 +
        fold_left Qplus (map (fun x : RegularFunction Q_as_MetricSpace => approximate x e2) l) z2)).
  { intros H.
   apply (H (approximate s ((1 # Pos.succ (P_of_succ_nat n)) * e)%Qpos)
-    ((1 # Pos.succ (P_of_succ_nat n)) * e)%Qpos ((1 # Pos.succ (P_of_succ_nat n)) * e +
-      (1 # P_of_succ_nat n) * ((1 # 2) * e))%Qpos).
-    simpl.
+           ((1 # Pos.succ (P_of_succ_nat n)) * e)%Qpos
+           ((1 # Pos.succ (P_of_succ_nat n)) * e +
+            (1 # P_of_succ_nat n) * ((1 # 2) * e))%Qpos
+           _ _ _ (e+e)%Qpos).
     rewrite -> Qplus_0_l.
     apply: regFun_prf.
     rewrite Qplus_0_l. reflexivity.

--- a/reals/fast/Compress.v
+++ b/reals/fast/Compress.v
@@ -49,7 +49,7 @@ Definition approximateQ (x:Q) (p:positive) :=
 let (n,d) := x in (Z.div (n*p) d#p).
 
 Lemma approximateQ_correct : forall x p,
-    ball (exist (Qlt 0) (1#p) eq_refl) x (approximateQ x p).
+    ball (1#p) x (approximateQ x p).
 Proof.
  intros [n d] p.
  split; simpl; unfold Qle; simpl.
@@ -110,14 +110,20 @@ match e with
  end
 end.
 
-Lemma compress_raw_prop : forall x e, ball e x (Cunit (compress_raw x e)).
+Lemma compress_raw_prop : forall x (e:Qpos),
+    ball (proj1_sig e) x (Cunit (compress_raw x e)).
 Proof.
  intros x. intros [[n d] dpos].
  destruct n as [|n|n]. inversion dpos. 2: inversion dpos.
  simpl.
- case_eq (Z.succ (xO d / n));try (intros; apply: ball_approx_r).
- intros p Hp.
- apply ball_weak_le with (exist (Qlt 0) (2#p) eq_refl).
+ assert (0 < Z.succ ((d~0)%positive / n))%Z as zpos.
+ { unfold Z.succ. 
+   apply (Z.lt_le_trans _ (0+1)). reflexivity.
+   apply Z.add_le_mono_r. apply Z_div_pos.
+   reflexivity. discriminate. }
+ destruct (Z.succ (xO d / n)) eqn:Hp.
+ - exfalso. discriminate.
+ - apply ball_weak_le with (2#p).
   unfold Qle.
   simpl.
   rewrite Zpos_mult_morphism.
@@ -149,6 +155,7 @@ Proof.
                (Cunit (approximateQ (approximate x (Qpos2QposInf (1 # p))) p))).
   rewrite -> ball_Cunit.
   apply approximateQ_correct.
+ - exfalso. discriminate.
 Qed.
 
 Lemma compress_raw_prf : forall x, is_RegularFunction (compress_raw x).

--- a/reals/fast/ContinuousCorrect.v
+++ b/reals/fast/ContinuousCorrect.v
@@ -100,7 +100,7 @@ Proof.
  intros x Hx H.
  set (J:=compact_in_interval I HI x H).
  apply ball_eq.
- intros e.
+ intros e epos.
  assert (HJ:compact_ J) by apply compact_compact_in_interval.
  destruct Hf as [Hf1 Hf0].
  clear Hf.
@@ -110,13 +110,13 @@ Proof.
   unfold J;  apply iprop_compact_in_interval_inc1.
  clear Hf0.
  destruct X as [_ X].
- assert (He : [0][<](inj_Q IR (proj1_sig ((1#2)*e)%Qpos))).
+ assert (He : [0][<](inj_Q IR (proj1_sig ((1#2)*exist _ _ epos)%Qpos))).
   stepl (inj_Q IR (nring 0)); [| now apply (inj_Q_nring IR 0)].
   apply inj_Q_less.
   apply Qpos_ispos.
  destruct (X _ He) as [d0 Hd0 Hf].
  clear X.
- set (d1:=mu g ((1#2)*e)).
+ set (d1:=mu g ((1#2)*exist _ _ epos)).
  set (Hab := (Lend_leEq_Rend J HJ)) in *.
  set (a:= (@Lend J HJ)) in *.
  set (b:= (@Rend J HJ)) in *.
@@ -139,8 +139,9 @@ Proof.
    apply Qpos_ispos.
   apply (inj_Q_nring IR 0).
  destruct (Q_dense_in_compact Hab0 HJx _ H0d) as [q Hq0 Hq1].
- assert (QposEq e ((1#2)*e+(1#2)*e)) by (unfold QposEq; simpl; ring).
- apply (ball_wd _ H0 _ _ (reflexivity _) _ _ (reflexivity _)). clear H0.
+ setoid_replace e
+   with (proj1_sig ((1#2)*exist _ _ epos+(1#2)*exist _ _ epos))%Qpos
+   by (simpl; ring).
  assert (Hfq : Dom f (inj_Q IR q)).
   apply Hf1.
   apply HJ'.
@@ -148,7 +149,7 @@ Proof.
  apply ball_triangle with (IRasCR (f (inj_Q IR q) Hfq)).
   rewrite <- CRAbsSmall_ball.
   stepr (IRasCR (f x Hx[-]f (inj_Q IR q) Hfq)); [| now (simpl; apply IR_minus_as_CR)].
-  stepl (IRasCR (inj_Q IR (proj1_sig ((1 # 2) * e)%Qpos))); [| now (simpl; apply IR_inj_Q_as_CR)].
+  stepl (IRasCR (inj_Q IR (proj1_sig ((1 # 2) * exist _ _ epos)%Qpos))); [| now (simpl; apply IR_inj_Q_as_CR)].
   rewrite <- IR_AbsSmall_as_CR.
   apply AbsIR_imp_AbsSmall.
   apply Hf; try assumption.

--- a/reals/fast/Interval.v
+++ b/reals/fast/Interval.v
@@ -268,11 +268,11 @@ end.
 
 Lemma CompactIntervalQ_prf : is_RegularFunction CompactIntervalQ_raw.
 Proof.
- cut (forall e1 e2, hemiMetric Q_as_MetricSpace (e1 + e2) (fun a : Q_as_MetricSpace =>
+ cut (forall (e1 e2:Qpos), hemiMetric Q_as_MetricSpace (proj1_sig e1 + proj1_sig e2) (fun a : Q_as_MetricSpace =>
    InFinEnumC a (CompactIntervalQ_raw e1)) (fun a : Q_as_MetricSpace =>
      InFinEnumC a (CompactIntervalQ_raw e2))).
   intros Z e1 e2.
-  split.
+  split. apply (Qpos_nonneg (e1+e2)). split.
    apply Z.
   eapply hemiMetric_wd1;[|apply Z].
   unfold QposEq; simpl; ring.
@@ -406,7 +406,7 @@ Proof.
  intros x [Hlx Hxr] e1 e2.
  simpl.
  set (y:= (Qmax (Qmin (approximate x e1) r) l)).
- apply (@almostIn_triangle_l _ stableQ e1 e2 (approximate x e1) y).
+ apply (@almostIn_triangle_l _ stableQ (proj1_sig e1) (proj1_sig e2) (approximate x e1) y).
   unfold y.
   apply Qmin_case.
    apply Qmax_case.

--- a/reals/fast/ModulusDerivative.v
+++ b/reals/fast/ModulusDerivative.v
@@ -73,8 +73,9 @@ match l,r with
  | Some l', Some r' => (uc_compose (QboundBelow_uc l') (QboundAbove_uc r') q)
 end.
 
-Lemma ball_clamp : forall e (a b : Q),
-    @ball Q_as_MetricSpace e a b -> ball e (clamp a) (clamp b).
+Lemma ball_clamp : forall (e:Qpos) (a b : Q),
+    @ball Q_as_MetricSpace (proj1_sig e) a b
+    -> ball (proj1_sig e) (clamp a) (clamp b).
 Proof.
  destruct l; destruct r; unfold clamp; intros e a b Hab; try apply uc_prf; apply Hab.
 Qed.
@@ -140,7 +141,7 @@ Proof.
   apply AbsSmall_imp_AbsIR.
   stepr (inj_Q IR (clamp a - clamp b)%Q); [| now apply inj_Q_minus].
   apply inj_Q_AbsSmall.
-  change (ball y (clamp a) (clamp b)).
+  change (ball (proj1_sig y) (clamp a) (clamp b)).
   apply ball_clamp.
   auto.
  assert (Z:[0][<]inj_Q IR (proj1_sig y)).

--- a/reals/fast/Plot.v
+++ b/reals/fast/Plot.v
@@ -104,8 +104,8 @@ Local Open Scope raster.
 
 (** The resulting plot is close to the graph of [f] *)
 Theorem Plot_correct :
-ball (err + Qpos_max ((1 # 2 * P_of_succ_nat (pred n)) * w)
-        ((1 # 2 * P_of_succ_nat (pred m)) * h))
+ball (proj1_sig (err + Qpos_max ((1 # 2 * P_of_succ_nat (pred n)) * w)
+        ((1 # 2 * P_of_succ_nat (pred m)) * h))%Qpos)
  (graphQ (uc_compose clip f))
  (Cunit (InterpRaster PlotQ (l,t) (r,b))).
 Proof.
@@ -131,10 +131,11 @@ Proof.
  setoid_replace Z1 with (l+proj1_sig w,b).
   unfold Z, PlotQ.
   (* TODO: figure out why rewrite Hw, Hh hangs *)
-  replace (RasterizeQ2 (approximate (graphQ (uc_compose clip f)) err) n m t l b r) with
-   (RasterizeQ2 (approximate (graphQ (uc_compose clip f)) err) n m (b + proj1_sig h) l b (l + proj1_sig w)) by now rewrite Hw, Hh.
+  replace (RasterizeQ2 (approximate (graphQ (uc_compose clip f)) err) n m t l b r)
+    with (RasterizeQ2 (approximate (graphQ (uc_compose clip f)) err) n m (b + proj1_sig h) l b (l + proj1_sig w)) by now rewrite Hw, Hh.
   destruct n; try discriminate.
   destruct m; try discriminate.
+  split. apply Qpos_nonneg.
   apply (RasterizeQ2_correct).
   intros.
   rewrite <- Hw.

--- a/reals/fast/RasterizeQ.v
+++ b/reals/fast/RasterizeQ.v
@@ -116,7 +116,7 @@ Let C := fun l r (n:nat) (i:Z) => l + (r - l) * (2 * i + 1 # 1) / (2 * n # 1).
 
 Lemma rasterization_error : forall l (w:Qpos) n x,
 (l <= x <= l + proj1_sig w) ->
-ball (m:=Q_as_MetricSpace) ((1 #2*P_of_succ_nat n) * w) (C l (l + proj1_sig w) (S n) (min n
+ball (m:=Q_as_MetricSpace) ((1 #2*P_of_succ_nat n) * proj1_sig w) (C l (l + proj1_sig w) (S n) (min n
              (Z_to_nat
                 (Z.le_max_l 0 (rasterize1 l (l+proj1_sig w) (S n) x))))) x.
 Proof.
@@ -248,7 +248,7 @@ Lemma RasterizeQ2_correct1 : forall x y,
  InFinEnumC ((x,y):ProductMS _ _) f ->
  existsC (ProductMS _ _)
   (fun p => InFinEnumC p (InterpRaster (RasterizeQ2 f (S n) (S m) t l b r) (l,t) (r,b))
-            /\ ball err p (x,y)).
+            /\ ball (proj1_sig err) p (x,y)).
 Proof.
  intros x y.
  unfold RasterizeQ2.
@@ -282,7 +282,7 @@ Proof.
    apply InterpRaster_correct1.
    rewrite setRaster_correct1; unfold i, j; auto with *.
   split.
-   change (ball err (C l r (S n) i) x).
+   change (ball (proj1_sig err) (C l r (S n) i) x).
    change (st_eq x (fst a)) in Hl.
    rewrite -> Hl.
    eapply ball_weak_le.
@@ -292,7 +292,7 @@ Proof.
    simpl in Hl.
    rewrite ->  Hl in Hfl.
    auto.
-  change (ball err (C t b (S m) (m-j)%nat) y).
+  change (ball (proj1_sig err) (C t b (S m) (m-j)%nat) y).
   change (st_eq y (snd a)) in Hr.
   rewrite -> Hr.
   eapply ball_weak_le.
@@ -327,7 +327,7 @@ Qed.
 Lemma RasterizeQ2_correct2 : forall x y,
  InFinEnumC ((x,y):ProductMS _ _) (InterpRaster (RasterizeQ2 f (S n) (S m) t l b r) (l,t) (r,b))
  -> (existsC (ProductMS _ _)
-  (fun p => InFinEnumC p f/\ ball err p (x,y))).
+  (fun p => InFinEnumC p f/\ ball (proj1_sig err) p (x,y))).
 Proof.
  intros x y H.
  destruct (InStrengthen _ _ H) as [[x' y'] [H' Hxy]].
@@ -346,7 +346,7 @@ Proof.
  cut (existsC (ProductMS Q_as_MetricSpace Q_as_MetricSpace)
    (fun p : ProductMS Q_as_MetricSpace Q_as_MetricSpace =>
      InFinEnumC (X:=ProductMS Q_as_MetricSpace Q_as_MetricSpace) p (rev f) /\
-       ball (m:=ProductMS Q_as_MetricSpace Q_as_MetricSpace) err p (x, y))).
+       ball (m:=ProductMS Q_as_MetricSpace Q_as_MetricSpace) (proj1_sig err) p (x, y))).
   intros L.
   clear -L.
   destruct L as [G | z [Hz0 Hz]] using existsC_ind.
@@ -412,7 +412,7 @@ Proof.
   auto.
  assert (L0:existsC (Q * Q) (fun p : Q * Q =>
    InFinEnumC (X:=ProductMS Q_as_MetricSpace Q_as_MetricSpace) p l0 /\
-     ball (m:=ProductMS Q_as_MetricSpace Q_as_MetricSpace) err p (x, y))).
+     ball (m:=ProductMS Q_as_MetricSpace Q_as_MetricSpace) (proj1_sig err) p (x, y))).
   apply IHl0.
    simpl in Hij.
    rewrite setRaster_correct2 in Hij; auto.
@@ -429,10 +429,11 @@ Proof.
 Qed.
 
 Lemma RasterizeQ2_correct :
- ball err
+ ball (proj1_sig err)
   (InterpRaster (RasterizeQ2 f (S n) (S m) t l b r) (l,t) (r,b))
   f.
 Proof.
+  split. apply Qpos_nonneg.
  split; intros [x y] Hx.
   destruct (RasterizeQ2_correct2 Hx) as [ G | z [Hz0 Hz1]] using existsC_ind.
    auto using existsC_stable.

--- a/reals/fast/uneven_CRplus.v
+++ b/reals/fast/uneven_CRplus.v
@@ -61,13 +61,12 @@ Section uneven_CRplus.
    apply regFunEq_e. intro e.
    rewrite approximate_CRplus...
    unfold uneven_CRplus_approx.
-   assert (QposEq (e + e) ((e * ll + (1#2) * e) + (e * rr + (1#2) * e))).
-   { unfold QposEq. unfold QposEq in llrr.
+   setoid_replace (proj1_sig e + proj1_sig e)
+     with (proj1_sig ((e * ll + (1#2) * e) + (e * rr + (1#2) * e)))%Qpos.
+    apply Qball_plus; apply regFun_prf.
      simpl in llrr.
    transitivity (proj1_sig e + proj1_sig e * proj1_sig (ll + rr)%Qpos)...
-   rewrite llrr. ring. }
-   rewrite H. clear H.
-    apply Qball_plus; apply regFun_prf.
+   unfold QposEq in llrr. simpl in llrr. rewrite llrr. ring.
   Qed.
 
 End uneven_CRplus.

--- a/reals/faster/AQmetric.v
+++ b/reals/faster/AQmetric.v
@@ -32,14 +32,15 @@ Global Instance: Proper ((=) ==> (=)) inject_AQ_AR := uc_wd (@Cunit AQ_as_Metric
 Lemma AQball_fold ε (x y : AQ_as_MetricSpace) : ball ε x y → Qball ε ('x) ('y).
 Proof. easy. Qed.
 
-Lemma AQball_abs (ε : Qpos) (x y : AQ_as_MetricSpace) : 
-  ball ε x y ↔ 'abs (x - y) ≤ ('ε : Q).
+Lemma AQball_abs (ε : Q) (x y : AQ_as_MetricSpace) : 
+  ball ε x y ↔ 'abs (x - y) ≤ ε.
 Proof.
   simpl. rewrite Qball_Qabs.
   now rewrite abs.preserves_abs, rings.preserves_minus.
 Qed.
 
-Definition AQball_bool (k : Z) (x y : AQ) := bool_decide_rel (≤) (abs (x - y)) (1 ≪ k).
+Definition AQball_bool (k : Z) (x y : AQ) : bool
+  := bool_decide_rel (≤) (abs (x - y)) (1 ≪ k).
 
 Lemma AQball_bool_true (k : Z) (x y : AQ_as_MetricSpace) : 
   AQball_bool k x y ≡ true ↔ ball (2 ^ k) x y.
@@ -63,7 +64,8 @@ Proof.
 Qed.
 
 Lemma AQball_bool_true_eps (ε : Qpos) (x y : AQ_as_MetricSpace) : 
-  AQball_bool (Qdlog2 (proj1_sig ε)) x y ≡ true → ball ε x y.
+  AQball_bool (Qdlog2 (proj1_sig ε)) x y ≡ true
+  → ball (proj1_sig ε) x y.
 Proof.
   intros E.
   apply AQball_abs.
@@ -74,7 +76,8 @@ Proof.
 Qed.
 
 Lemma AQball_plus (ε1 ε2 : Qpos) (x1 x2 y1 y2 : AQ_as_MetricSpace) : 
-  ball ε1 x1 y1 → ball ε2 x2 y2 → ball (ε1 + ε2) (x1 + x2) (y1 + y2).
+  ball (proj1_sig ε1) x1 y1
+  → ball (proj1_sig ε2) x2 y2 → ball (proj1_sig ε1 + proj1_sig ε2) (x1 + x2) (y1 + y2).
 Proof.
   intros.
   apply ball_triangle with (x2 + y1); apply AQball_abs.
@@ -85,7 +88,7 @@ Proof.
 Qed.
 
 Lemma AQball_plus_l (ε : Qpos) (x y z : AQ_as_MetricSpace) :
-  ball ε x y → ball ε (z + x) (z + y).
+  ball (proj1_sig ε) x y → ball (proj1_sig ε) (z + x) (z + y).
 Proof.
   intros E.
   apply AQball_abs.
@@ -94,7 +97,7 @@ Proof.
 Qed.
 
 Lemma AQball_plus_r (ε : Qpos) (x y z : AQ_as_MetricSpace) :
-  ball ε x y → ball ε (x + z) (y + z).
+  ball (proj1_sig ε) x y → ball (proj1_sig ε) (x + z) (y + z).
 Proof.
   intros E.
   apply AQball_abs.
@@ -103,7 +106,7 @@ Proof.
 Qed.
 
 Lemma AQball_opp (ε : Qpos) (x y : AQ_as_MetricSpace) :
-  ball ε x y → ball ε (-x) (-y).
+  ball (proj1_sig ε) x y → ball (proj1_sig ε) (-x) (-y).
 Proof.
   intros.
   apply AQball_abs.

--- a/reals/faster/ARArith.v
+++ b/reals/faster/ARArith.v
@@ -75,7 +75,10 @@ Global Instance inject_PosAQ_AR: Cast (AQ₊) AR := (cast AQ AR ∘ cast (AQ₊)
 Global Instance inject_Z_AR: Cast Z AR := (cast AQ AR ∘ cast Z AQ)%prg.
 
 Lemma ARtoCR_inject (x : AQ) : cast AR CR (cast AQ AR x) = cast Q CR (cast AQ Q x).
-Proof. apply: regFunEq_e. intros ε. apply ball_refl. Qed.
+Proof.
+  apply: regFunEq_e. intros ε. apply ball_refl.
+  apply (Qpos_nonneg (ε + ε)). 
+Qed.
 
 Global Instance AR0: Zero AR := cast AQ AR 0.
 Lemma ARtoCR_preserves_0 : cast AR CR 0 = 0.
@@ -237,8 +240,11 @@ Proof. change (SemiRing_Morphism (inverse (cast AR CR))). split; apply _. Qed.
 Instance: SemiRing_Morphism (cast AQ AR).
 Proof.
   repeat (split; try apply _); intros; try reflexivity.
-   apply: regFunEq_e. intros ε. now apply ball_refl. 
-  rewrite ARmult_scale. apply: regFunEq_e. intros ε. now apply ball_refl.
+   apply: regFunEq_e. intros ε. apply ball_refl. 
+   apply (Qpos_nonneg (ε + ε)).
+   rewrite ARmult_scale. apply: regFunEq_e. intros ε.
+   apply ball_refl.
+   apply (Qpos_nonneg (ε + ε)).
 Qed.
 
 Add Ring CR : (rings.stdlib_ring_theory CR).
@@ -585,9 +591,9 @@ Proof.
    2: now eapply ball_sym, aq_div_dlog2.
   eapply ball_triangle.
    now eapply aq_div_dlog2.
-  simpl. aq_preservation. apply Qinv_pos_uc_prf in E.
+   simpl. aq_preservation.
   rewrite 2!left_identity.
-  apply E.
+   exact (Qinv_pos_uc_prf (' c) ε (' x) (' y) E).
 Qed.
 
 Definition AQinv_pos_uc (c : AQ₊) := Build_UniformlyContinuousFunction (AQinv_pos_uc_prf c).
@@ -598,21 +604,21 @@ Lemma ARtoCR_preserves_inv_pos_aux c (x : AR) : is_RegularFunction_noInf _
    (λ γ, / Qmax (''c) ('approximate x (Qinv_modulus ('c) γ)) : Q_as_MetricSpace).
 Proof.
   intros ε1 ε2.
-  apply_simplified (Qinv_pos_uc_prf ('c)).
+  apply_simplified (Qinv_pos_uc_prf ('c) (ε1 + ε2)%Qpos).
   apply AQball_fold. 
-  assert (QposEq (Qinv_modulus ('c) (ε1 + ε2))
-                 (Qinv_modulus ('c) ε1 + Qinv_modulus ('c) ε2))
-    by (unfold QposEq; simpl; ring).
-  rewrite H5. now apply regFun_prf.
+  setoid_replace (' c * ' c * (` ε1 + ` ε2))%Q
+    with (proj1_sig (Qinv_modulus ('c) ε1 + Qinv_modulus ('c) ε2)%Qpos)
+    by (simpl; ring).
+  apply regFun_prf.
 Qed.
 
 Lemma ARtoCR_preserves_inv_pos x c : 'ARinv_pos c x = CRinv_pos ('c) ('x).
 Proof.
   apply: regFunEq_e. intros ε. 
   simpl. unfold Cjoin_raw. simpl.
-  assert (QposEq (ε + ε) ((1#2) * ε + ((1#2) * ε + ε)))
-    by (unfold QposEq; simpl; ring).
-  rewrite H5. clear H5.
+  setoid_replace (proj1_sig ε + proj1_sig ε)%Q
+    with (proj1_sig ((1#2) * ε + ((1#2) * ε + ε)))%Qpos
+    by (simpl; ring).
   eapply ball_triangle.
    now apply aq_div_dlog2.
   rewrite aq_preserves_max. 

--- a/reals/faster/ARQ.v
+++ b/reals/faster/ARQ.v
@@ -15,9 +15,11 @@ Instance Q_approx: AppApprox Q := λ x k,
 
 Lemma Q_approx_correct (x : Q) (k : Z) : Qball (2 ^ k) (app_approx x k) x.
 Proof.
-  destruct k as [|p|]; try reflexivity.
-  unfold app_approx, Q_approx.
-  setoid_replace (2 ^ Zneg p)%Qpos with (1 # (2 ^ p))%Qpos.
+  destruct k as [|p|].
+  - apply ball_refl. discriminate.
+  - apply ball_refl. apply Qpower.Qpower_pos_positive. discriminate.
+  - unfold app_approx, Q_approx.
+  setoid_replace (2 ^ Zneg p)%Q with (1 # (2 ^ p))%Q.
    now apply ball_sym, approximateQ_correct.
   change (/ Qpower (inject_Z 2%Z) (Zpos p) == 1 # 2 ^ p).
   rewrite <-Qpower.Zpower_Qpower; auto with zarith.

--- a/reals/faster/ARbigD.v
+++ b/reals/faster/ARbigD.v
@@ -190,7 +190,7 @@ Proof.
   split; try apply _.
   intros [n d] ε.
   unfold app_inverse, inverse_Q_bigD.
-  apply ball_weak_le with (Qpos_power 2 (Qdlog2 (proj1_sig ε))).
+  apply ball_weak_le with (proj1_sig (Qpos_power 2 (Qdlog2 (proj1_sig ε)))).
    now apply (Qpos_dlog2_spec ε).
    simpl.
    rewrite (Qmake_Qdiv n d).

--- a/reals/faster/ARbigQ.v
+++ b/reals/faster/ARbigQ.v
@@ -74,7 +74,8 @@ Instance: DenseEmbedding (cast bigQ Q_as_MetricSpace).
 Proof.
   split; try apply _.
   intros. unfold app_inverse, inverse_Q_bigQ.
-  now rewrite (rationals.morphisms_involutive _ _).
+  rewrite (rationals.morphisms_involutive _ _).
+  apply ball_refl. apply QposMinMax.Qpos_nonneg.
 Qed.
 
 Instance: AppRationals bigQ.

--- a/reals/faster/ARroot.v
+++ b/reals/faster/ARroot.v
@@ -257,7 +257,7 @@ Proof.
    apply AQsqrt_mid_bounded_regular_aux2.
    now apply: (order_preserving (+ (3:N))).
   assert (∀ ε1 ε2 : Qpos, N_of_Z (-Qdlog2 (proj1_sig ε2)) ≤ N_of_Z (-Qdlog2 (proj1_sig ε1)) → 
-     ball (ε1 + ε2) (AQsqrt_mid_raw ε1 : AQ_as_MetricSpace) (AQsqrt_mid_raw ε2)).
+     ball (proj1_sig ε1 + proj1_sig ε2) (AQsqrt_mid_raw ε1 : AQ_as_MetricSpace) (AQsqrt_mid_raw ε2)).
   { intros ε1 ε2 E.
    unfold AQsqrt_mid_raw.
    eapply ball_weak_le; auto.
@@ -284,9 +284,7 @@ Proof.
   destruct (total (≤) (N_of_Z (-Qdlog2 (proj1_sig ε1)))
                   (N_of_Z (-Qdlog2 (proj1_sig ε2)))); auto.
   apply ball_sym. 
-  assert (QposEq (ε1 + ε2) (ε2 + ε1))
-    by (unfold QposEq; simpl; apply commutativity).
-  rewrite H8. auto.
+  rewrite Qplus_comm. auto.
 Qed.
 
 Definition AQsqrt_mid : AR := mkRegularFunction (0 : AQ_as_MetricSpace) AQsqrt_mid_bounded_prf.
@@ -315,7 +313,7 @@ Qed.
 
 Lemma AQsqrt_mid_spec : AQsqrt_mid ^ (2:N)= 'a.
 Proof.
-  assert (∀ ε, Qball ε ('(AQsqrt_mid_raw ε ^ (2:N))) ('a)) as P.
+  assert (∀ ε, Qball (proj1_sig ε) ('(AQsqrt_mid_raw ε ^ (2:N))) ('a)) as P.
   { intros ε. apply Qball_Qabs. rewrite Qabs.Qabs_neg.
     eapply Qle_trans.
      2: now apply Qpos_dlog2_spec.
@@ -352,7 +350,8 @@ Proof.
   rewrite <-(ARpower_N_bounded_N_power _ _ 4). 
   - intros ε1 ε2. simpl.
    rewrite lattices.meet_r, lattices.join_r.
-    + apply ball_weak. apply ball_weak_le with (ε1 * Qpos_inv (8 # 1))%Qpos.
+    + apply ball_weak. apply Qpos_nonneg.
+      apply ball_weak_le with (proj1_sig (ε1 * Qpos_inv (8 # 1))%Qpos).
       change ('ε1 / (8#1) ≤ 'ε1). 
       rewrite <-(rings.mult_1_r ('ε1)) at 2.
       apply Qmult_le_l. apply Qpos_ispos. discriminate.

--- a/reals/faster/ApproximateRationals.v
+++ b/reals/faster/ApproximateRationals.v
@@ -94,7 +94,7 @@ Section approximate_rationals_more.
   Proof. now rewrite aq_shift_correct. Qed.
 
   Lemma aq_div_dlog2 (x y : AQ) (ε : Q₊) : 
-    ball ε ('app_div x y (Qdlog2 ('ε))) ('x / 'y).
+    ball (proj1_sig ε) ('app_div x y (Qdlog2 ('ε))) ('x / 'y).
   Proof.
     eapply ball_weak_le.
      now apply Qpos_dlog2_spec.
@@ -102,7 +102,7 @@ Section approximate_rationals_more.
   Qed.
 
   Lemma aq_approx_dlog2 (x : AQ) (ε : Q₊) : 
-    ball ε ('app_approx x (Qdlog2 ('ε))) ('x).
+    ball (proj1_sig ε) ('app_approx x (Qdlog2 ('ε))) ('x).
   Proof.
     eapply ball_weak_le.
      now apply Qpos_dlog2_spec.
@@ -155,13 +155,13 @@ Section approximate_rationals_more.
       { rewrite Eγ. simpl. ring. }
       rewrite H5. clear H5.
      simpl.
-      apply (in_Qball ((1#3)*γ)), ball_sym, dense_inverse.
+      apply (in_Qball (proj1_sig ((1#3)*γ)%Qpos)), ball_sym, dense_inverse.
     apply Qle_lt_trans with (y - (1#6) * proj1_sig γ)%Q.
     assert (Qeq (y - (1 # 6) * ` γ)
                 ((1 # 2) * (x + y) + proj1_sig ((1 # 3) * γ)%Qpos)).
     { rewrite Eγ. simpl. ring. }
     rewrite H5. clear H5. simpl.
-      apply (in_Qball ((1#3)*γ)), ball_sym, dense_inverse.
+      apply (in_Qball (proj1_sig ((1#3)*γ)%Qpos)), ball_sym, dense_inverse.
       apply (Qlt_le_trans _ (y-0)).
     apply Qplus_lt_r.
     apply Qopp_Qlt_0_r...

--- a/util/Qsums.v
+++ b/util/Qsums.v
@@ -120,16 +120,17 @@ Proof.
  ring.
 Qed.
 
-Lemma Σ_Qball (f g: nat -> Q) (e: Qpos) (n: nat):
-  (forall i: nat, (i < n)%nat -> Qabs (f i - g i) <= proj1_sig e / inject_Z (Z.of_nat n)) ->
+Lemma Σ_Qball (f g: nat -> Q) (e: Q) (n: nat):
+  0 <= e ->
+  (forall i: nat, (i < n)%nat -> Qabs (f i - g i) <= e / inject_Z (Z.of_nat n)) ->
   Qball e (Σ n f) (Σ n g).
 Proof with auto.
- intro H.
+ intros epos H.
  apply Qball_Qabs.
- destruct n. simpl. apply Qpos_nonneg.
+ destruct n. simpl. exact epos.
  rewrite Σ_sub.
- setoid_replace (proj1_sig e)
-   with (inject_Z (Z.of_nat (S n)) * (/ inject_Z (Z.of_nat (S n)) * proj1_sig e)).
+ setoid_replace e
+   with (inject_Z (Z.of_nat (S n)) * (/ inject_Z (Z.of_nat (S n)) * e)).
   apply Σ_abs_le.
   intros ? E.
   specialize (H x E).
@@ -139,13 +140,19 @@ Proof with auto.
  field. discriminate.
 Qed.
 
-Lemma Σ_Qball_pos_bounds (f g: nat -> Q) (e: Qpos) (n: positive):
+Lemma Σ_Qball_pos_bounds (f g: nat -> Q) (e: Q) (n: positive):
   (forall i: nat, (i < Pos.to_nat n)%nat -> Qball (e * (1#n)) (f i) (g i)) ->
   Qball e (Σ (Pos.to_nat n) f) (Σ (Pos.to_nat n) g).
 Proof with intuition.
- intros. apply Σ_Qball. intros.
- setoid_replace (proj1_sig e / inject_Z (Z.of_nat (nat_of_P n)))
-   with (proj1_sig (e * (1#n))%Qpos).
+  intros.
+  assert (0 <= e).
+  { specialize (H O (Pos2Nat.is_pos n)).
+    apply (msp_nonneg (msp (Q_as_MetricSpace))) in H.
+    rewrite <- (Qmult_0_l (1#n)) in H.
+    apply Qmult_le_r in H. exact H. reflexivity. }
+  apply Σ_Qball. exact H0. intros.
+ setoid_replace (e / inject_Z (Z.of_nat (nat_of_P n)))
+   with (e * (1#n)).
   apply Qball_Qabs...
   unfold canonical_names.equiv, stdlib_rationals.Q_eq.
  rewrite <- Zpos_eq_Z_of_nat_o_nat_of_P...
@@ -177,7 +184,7 @@ Proof.
  field. discriminate.
 Qed.
 
-Lemma Qball_hetero_Σ (n m: positive) f g e:
+Lemma Qball_hetero_Σ (n m: positive) f g (e:Q):
  (forall i: nat, (i < Pos.to_nat (n * m)%positive)%nat ->
    Qball (e * (1# (n * m)%positive))
      (/ inject_Z (Zpos m) * f (i / Pos.to_nat m)%nat)


### PR DESCRIPTION
Remove `Qpos` and `gball` from the definition of metric spaces.