### PR TITLE
Stop using deprecated firstorder using syntax.

### DIFF
--- a/model/structures/Qsec.v
+++ b/model/structures/Qsec.v
@@ -323,7 +323,7 @@ Proof.
 Qed.
 
 Lemma Qle_is_not_lt : forall x y : Q, x <= y <-> ~ y < x.
-Proof. firstorder using Qle_not_lt Qnot_lt_le. Qed.
+Proof. firstorder using Qle_not_lt, Qnot_lt_le. Qed.
 
 Lemma Qge_is_not_gt : forall x y : Q, x >= y <-> y <= x.
 Proof. firstorder. Qed.

--- a/model/totalorder/QMinMax.v
+++ b/model/totalorder/QMinMax.v
@@ -205,7 +205,7 @@ Lemma Qminus_antitone : forall a : Q, Qantitone (fun x => a - x).
 Proof.
  change (forall a x y : Q, x <= y -> a + - y <= a + - x).
  intros.
- apply Qplus_le_compat; firstorder using Qle_refl Qopp_le_compat.
+ apply Qplus_le_compat; firstorder using Qle_refl, Qopp_le_compat.
 Qed.
 
 Definition Qminus_min_max_antidistr_r : forall x y z : Q, x - Qmin y z == Qmax (x-y) (x-z) :=

--- a/model/totalorder/ZMinMax.v
+++ b/model/totalorder/ZMinMax.v
@@ -207,7 +207,7 @@ Lemma Zminus_antitone : forall a : Z, Zantitone (fun x => a - x).
 Proof.
  change (forall a x y : Z, x <= y -> a + - y <= a + - x).
  intros.
- apply Zplus_le_compat; firstorder using Z.le_refl Zopp_le_compat.
+ apply Zplus_le_compat; firstorder using Z.le_refl, Zopp_le_compat.
 Qed.
 
 Definition Zminus_min_max_antidistr_r : forall x y z : Z, x - Z.min y z = Z.max (x-y) (x-z) :=

--- a/order/SemiLattice.v
+++ b/order/SemiLattice.v
@@ -94,7 +94,7 @@ Lemma meet_assoc : forall x y z:X, meet x (meet y z) == meet (meet x y) z.
 Proof.
  assert (forall x y z : X, meet x (meet y z) <= meet (meet x y) z).
   intros.
-  apply meet_glb; [apply meet_glb|]; firstorder using meet_lb_l meet_lb_r le_trans.
+  apply meet_glb; [apply meet_glb|]; firstorder using meet_lb_l, meet_lb_r, le_trans.
  intros.
  apply le_antisym.
   apply H.
@@ -109,7 +109,7 @@ Qed.
 Lemma meet_idem : forall x:X, meet x x == x.
 Proof.
  intros.
- apply le_antisym; firstorder using meet_lb_l meet_glb le_refl.
+ apply le_antisym; firstorder using meet_lb_l, meet_glb, le_refl.
 Qed.
 
 Lemma le_meet_l : forall x y : X, x <= y <-> meet x y == x.
@@ -156,8 +156,8 @@ Lemma meet_le_compat : forall w x y z : X, w<=y -> x<=z -> meet w x <= meet y z.
 Proof.
  intros.
  apply le_trans with (y:=meet y x).
-  firstorder using meet_monotone_l monotone_def.
- firstorder using meet_monotone_r monotone_def.
+  firstorder using meet_monotone_l, monotone_def.
+ firstorder using meet_monotone_r, monotone_def.
 Qed.
 
 End Meet.


### PR DESCRIPTION
The old and deprecated syntax (without the commas) is getting removed in coq/coq#13315.