### PR TITLE
Don't rely on setoid rewrite forgetting arrow binder names (coq/coq#13882)

### DIFF
--- a/liouville/nat_Q_lists.v
+++ b/liouville/nat_Q_lists.v
@@ -89,6 +89,7 @@ Proof.
   rewrite <- nat_of_P_o_P_of_succ_nat_eq_succ in H.
   apply nat_of_P_inj; symmetry; assumption.
  unfold list_Q.
+ intro H.
  rewrite -> in_flat_map.
  exists (Z.abs_nat c, Z.abs_nat d).
  split.

--- a/order/TotalOrder.v
+++ b/order/TotalOrder.v
@@ -54,9 +54,9 @@ Hypothesis Hf : monotone X f.
 
 Add Morphism f with signature (@st_eq X) ==> (@st_eq X)  as monotone_compat.
 Proof.
- revert Hf;rewrite -> monotone_def;intros.
- revert H0; do 2 rewrite -> equiv_le_def.
- firstorder.
+  revert Hf;rewrite -> monotone_def;intros Hf ??.
+  do 2 rewrite -> equiv_le_def.
+  firstorder.
 Qed.
 
 (** meet distributes over any monotone function. *)


### PR DESCRIPTION
This should be backwards compatible and so may be merged now.