### PR TITLE
Update meta.yml and CI to test Coq 8.13.

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -1,4 +1,6 @@
-name: CI
+# This file was generated from `meta.yml`, please do not edit manually.
+# Follow the instructions on https://github.com/coq-community/templates to regenerate.
+name: Docker CI
 
 on:
   push:
@@ -16,6 +18,7 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.13'
           - 'coqorg/coq:8.12'
           - 'coqorg/coq:8.11'
           - 'coqorg/coq:8.10'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
+<!---
+This file was generated from `meta.yml`, please do not edit manually.
+Follow the instructions on https://github.com/coq-community/templates to regenerate.
+--->
 # C-CoRN
 
-[![CI][action-shield]][action-link]
+[![Docker CI][docker-action-shield]][docker-action-link]
 [![Contributing][contributing-shield]][contributing-link]
 [![Code of Conduct][conduct-shield]][conduct-link]
 [![Zulip][zulip-shield]][zulip-link]
 
-[action-shield]: https://github.com/coq-community/corn/workflows/CI/badge.svg?branch=master
-[action-link]: https://github.com/coq-community/corn/actions?query=workflow%3ACI
+[docker-action-shield]: https://github.com/coq-community/corn/workflows/Docker%20CI/badge.svg?branch=master
+[docker-action-link]: https://github.com/coq-community/corn/actions?query=workflow:"Docker%20CI"
 
 [contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
 [contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md

--- a/coq-corn.opam
+++ b/coq-corn.opam
@@ -46,7 +46,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.7" & < "8.13~") | (= "dev")}
+  "coq" {(>= "8.7" & < "8.14~") | (= "dev")}
   "coq-math-classes" {(>= "8.8.1") | (= "dev")}
   "coq-bignums" 
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -80,10 +80,11 @@ license:
 
 supported_coq_versions:
   text: Coq 8.7 or greater
-  opam: '{(>= "8.7" & < "8.13~") | (= "dev")}'
+  opam: '{(>= "8.7" & < "8.14~") | (= "dev")}'
 
 tested_coq_opam_versions:
 - version: dev
+- version: "8.13"
 - version: "8.12"
 - version: "8.11"
 - version: "8.10"


### PR DESCRIPTION
The goal here is to make a new release, which will be officially compatible with Coq 8.7-8.13 (although it will very likely be compatible as well with the unreleased Coq 8.14).