### PR TITLE
Remove support for untested versions of Coq.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ CoRN includes the following parts:
   - Bas Spitters ([**@spitters**](https://github.com/spitters))
   - Vincent Semeria ([**@vincentse**](https://github.com/vincentse))
 - License: [GNU General Public License v2](LICENSE)
-- Compatible Coq versions: Coq 8.11 or greater
+- Compatible Coq versions: Coq 8.14 or greater
 - Additional dependencies:
   - [Math-Classes](https://github.com/coq-community/math-classes) 8.8.1 or
 greater, which is a library of abstract interfaces for mathematical

--- a/meta.yml
+++ b/meta.yml
@@ -79,17 +79,14 @@ license:
   identifier: GPL-2.0
 
 supported_coq_versions:
-  text: Coq 8.11 or greater
-  opam: '{(>= "8.11" & < "8.17~") | (= "dev")}'
+  text: Coq 8.14 or greater
+  opam: '{(>= "8.14" & < "8.17~") | (= "dev")}'
 
 tested_coq_opam_versions:
 - version: dev
 - version: "8.16"
 - version: "8.15"
 - version: "8.14"
-- version: "8.13"
-- version: "8.12"
-- version: "8.11"
 
 dependencies:
 - opam:


### PR DESCRIPTION
I am making this suggestion because e.g. when I tried to compile CoRN from source with Coq 8.12.x, I had many problems that had to be fixed by manually adjusting proofs. It looks to me as if the Docker CI that CoRN has configured is only valid for 8.14-8.17 and dev.

I'm an outsider to this project so it's possible this change doesn't make sense or ignores some considerations--if so I'd be interested to learn what these are.