### PR TITLE
Use `bc` for version comparison in configure.sh

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -9,7 +9,7 @@ COQ_VERSION=`echo $COQ_VERSION_LINE | sed 's/The Coq Proof Assistant, version 8\
 DIRECTORIES="algebra complex coq_reals fta ftc liouville logic metrics model raster reals tactics transc order metric2 stdlib_omissions util classes ode"
 
 # Include constructive measure theory on version 8.12 and after
-if [ $COQ_VERSION -gt 11 ] ;
+if (( $(echo "$COQ_VERSION > 11.0" |bc -l) ));
 then
     find $DIRECTORIES -name "*.v" >>Make
 else


### PR DESCRIPTION
Because versions have the form X.Y.Z (major/minor/patch), the regex used to grab the minor.patch version for comparison yields a float. The -gt flag does not process floats, but `bc`, which is broadly available on *nix systems, does.

Alternatively since support for versions less than 8.14 is dropped, we could just delete this conditional.