### PR TITLE
Source lt/le/lt_le/le_lt_trans from library.

### DIFF
--- a/algebra/COrdCauchy.v
+++ b/algebra/COrdCauchy.v
@@ -214,12 +214,12 @@ Proof.
  apply AbsSmall_wdl_unfolded with (Three[*]((eg[+]eg)[*]Mg)[+]Three[*]((ef[+]ef)[*]Mf)).
   2: unfold eg, ef in |- *; rational.
  apply AbsSmall_plus; apply AbsSmall_mult; try apply AbsSmall_plus; try apply inv_resp_AbsSmall.
-      apply HPf; apply le_trans with N; auto; unfold N in |- *; eauto with arith.
-     apply HPf; apply le_trans with N; auto; unfold N in |- *; eauto with arith.
-    apply HNg; auto; apply le_trans with N; auto; unfold N in |- *; eauto with arith.
-   apply HPg; apply le_trans with N; auto; unfold N in |- *; eauto with arith.
-  apply HPg; apply le_trans with N; auto; unfold N in |- *; eauto with arith.
- apply HNf; auto; apply le_trans with N; auto; unfold N in |- *; eauto with arith.
+      apply HPf; apply Nat.le_trans with N; auto; unfold N in |- *; eauto with arith.
+     apply HPf; apply Nat.le_trans with N; auto; unfold N in |- *; eauto with arith.
+    apply HNg; auto; apply Nat.le_trans with N; auto; unfold N in |- *; eauto with arith.
+   apply HPg; apply Nat.le_trans with N; auto; unfold N in |- *; eauto with arith.
+  apply HPg; apply Nat.le_trans with N; auto; unfold N in |- *; eauto with arith.
+ apply HNf; auto; apply Nat.le_trans with N; auto; unfold N in |- *; eauto with arith.
 Qed.
 
 (**

--- a/algebra/COrdFields2.v
+++ b/algebra/COrdFields2.v
@@ -600,7 +600,7 @@ Proof.
    auto with arith.
   change (nring n [<] nring (R:=R) 0) in |- *.
   apply nring_less.
-  apply lt_le_trans with (S n).
+  apply Nat.lt_le_trans with (S n).
    auto with arith.
   exfalso. revert H; rewrite -> leEq_def. intro H; destruct H.
   apply nring_less; auto with arith.

--- a/algebra/CPoly_Degree.v
+++ b/algebra/CPoly_Degree.v
@@ -189,7 +189,7 @@ Lemma degree_le_mon : forall (p : RX) m n,
  m <= n -> degree_le m p -> degree_le n p.
 Proof.
  unfold degree_le in |- *. intros. apply H0.
- apply le_lt_trans with n; auto with arith.
+ apply Nat.le_lt_trans with n; auto with arith.
 Qed.
 
 Lemma degree_le_inv : forall (p : RX) n, degree_le n p -> degree_le n [--]p.
@@ -271,7 +271,7 @@ Proof.
  astepl (nth_coeff m0 p[+]nth_coeff m0 q).
  cut (m < m0). intro.
   Step_final ([0][+] ([0]:R)).
- apply lt_trans with n; auto.
+ apply Nat.lt_trans with n; auto.
 Qed.
 
 Lemma degree_minus_lft : forall (p q : RX) m n,
@@ -297,7 +297,7 @@ Proof.
  astepl (nth_coeff m0 p[+]nth_coeff m0 q).
  cut (m < m0). intro.
   Step_final ([0][+] ([0]:R)).
- apply lt_trans with n; auto.
+ apply Nat.lt_trans with n; auto.
 Qed.
 
 Lemma monic_minus : forall (p q : RX) m n,

--- a/algebra/Cauchy_COF.v
+++ b/algebra/Cauchy_COF.v
@@ -112,8 +112,8 @@ Proof.
        unfold z0 in |- *; elim (HNz NN); auto; unfold NN in |- *; eauto with arith.
       apply shift_minus_leEq; apply shift_leEq_plus'.
       unfold cg_minus in |- *; apply shift_plus_leEq'.
-      elim (HNz n); auto; apply le_trans with NN; auto; unfold NN in |- *; eauto with arith.
-     elim (HNx n); auto; apply le_trans with NN; auto; unfold NN in |- *; eauto with arith.
+      elim (HNz n); auto; apply Nat.le_trans with NN; auto; unfold NN in |- *; eauto with arith.
+     elim (HNx n); auto; apply Nat.le_trans with NN; auto; unfold NN in |- *; eauto with arith.
     apply shift_minus_leEq; apply shift_leEq_plus'.
     unfold cg_minus in |- *; apply shift_plus_leEq'.
     unfold x0 in |- *; elim (HNx NN); auto; unfold NN in |- *; eauto with arith.
@@ -133,10 +133,10 @@ Proof.
       apply shift_minus_leEq; apply shift_leEq_plus'.
       unfold cg_minus in |- *; apply shift_plus_leEq'.
       unfold z0 in |- *; elim (HNz NN); auto; unfold NN in |- *; eauto with arith.
-     elim (HNz n); auto; apply le_trans with NN; auto; unfold NN in |- *; eauto with arith.
+     elim (HNz n); auto; apply Nat.le_trans with NN; auto; unfold NN in |- *; eauto with arith.
     apply shift_minus_leEq; apply shift_leEq_plus'.
     unfold cg_minus in |- *; apply shift_plus_leEq'.
-    elim (HNy n); auto; apply le_trans with NN; auto; unfold NN in |- *; eauto with arith.
+    elim (HNy n); auto; apply Nat.le_trans with NN; auto; unfold NN in |- *; eauto with arith.
    unfold y0 in |- *; elim (HNy NN); auto; unfold NN in |- *; eauto with arith.
   apply shift_minus_leEq.
   rstepr (y0[-]z0).
@@ -378,8 +378,8 @@ Proof.
       unfold KK in |- *; apply div_resp_pos; auto.
       apply mult_resp_pos; auto; apply pos_three.
      intros; simpl in |- *; unfold KK in |- *.
-     cut (N <= n); [ intro Hn | apply le_trans with (max N Ny); auto with arith ].
-     cut (Ny <= n); [ intro Hn' | apply le_trans with (max N Ny); auto with arith ].
+     cut (N <= n); [ intro Hn | apply Nat.le_trans with (max N Ny); auto with arith ].
+     cut (Ny <= n); [ intro Hn' | apply Nat.le_trans with (max N Ny); auto with arith ].
      apply leEq_transitive with (e[/] _[//]pos_ap_zero _ _ (Hy' n Hn')).
       apply mult_cancel_leEq with ([1][/] _[//]pos_ap_zero _ _ He).
        apply recip_resp_pos; auto.
@@ -402,8 +402,8 @@ Proof.
      unfold KK in |- *; apply div_resp_pos; auto.
      apply mult_resp_pos; auto; apply pos_three.
     intros; simpl in |- *; unfold KK in |- *.
-    cut (N <= n); [ intro Hn | apply le_trans with (max N Ny); auto with arith ].
-    cut (Ny <= n); [ intro Hn' | apply le_trans with (max N Ny); auto with arith ].
+    cut (N <= n); [ intro Hn | apply Nat.le_trans with (max N Ny); auto with arith ].
+    cut (Ny <= n); [ intro Hn' | apply Nat.le_trans with (max N Ny); auto with arith ].
     apply leEq_transitive with (e[/] _[//]pos_ap_zero _ _ (Hy' n Hn')).
      apply mult_cancel_leEq with ([1][/] _[//]pos_ap_zero _ _ He).
       apply recip_resp_pos; auto.
@@ -885,19 +885,19 @@ Proof.
   rstepr (x_ m[-]x_ N1[+] (x_ N1[-]x_ m0)).
   apply AbsSmall_plus.
    apply px2.
-   apply le_trans with NN; assumption.
+   apply Nat.le_trans with NN; assumption.
   apply AbsSmall_minus.
   apply px2.
-  apply le_trans with NN; assumption.
+  apply Nat.le_trans with NN; assumption.
  unfold e8 in |- *.
  rstepl (e [/]SixteenNZ[+]e [/]SixteenNZ).
  rstepr (y_ m0[-]y_ N2[+] (y_ N2[-]y_ m)).
  apply AbsSmall_plus.
   apply py2.
-  apply le_trans with NN; assumption.
+  apply Nat.le_trans with NN; assumption.
  apply AbsSmall_minus.
  apply py2.
- apply le_trans with NN; assumption.
+ apply Nat.le_trans with NN; assumption.
 Qed.
 
 Lemma R_ap_alt_2 : forall x y : R_CSetoid, {e : F | [0] [<] e |
@@ -927,9 +927,9 @@ Proof.
  assert (N_NN : N <= NN).
   unfold NN in |- *; auto with arith.
  assert (N1_NN : N1 <= NN).
-  unfold NN in |- *; apply le_trans with (max N1 N2); auto with arith.
+  unfold NN in |- *; apply Nat.le_trans with (max N1 N2); auto with arith.
  assert (N2_NN : N2 <= NN).
-  unfold NN in |- *; apply le_trans with (max N1 N2); auto with arith.
+  unfold NN in |- *; apply Nat.le_trans with (max N1 N2); auto with arith.
  set (x0 := x_ NN) in *.
  set (y0 := y_ NN) in *.
  simpl in |- *.
@@ -961,7 +961,7 @@ Proof.
     rstepr (x_ m[-]x_ N1[+] (x_ N1[-]x0)).
     apply plus_resp_leEq_both.
      assert (H7 : AbsSmall e16 (x_ m[-]x_ N1)).
-      apply H31; apply le_trans with NN; auto.
+      apply H31; apply Nat.le_trans with NN; auto.
      elim H7; intros.
      rstepl ([--]e16).
      assumption.
@@ -986,7 +986,7 @@ Proof.
   assert (H7 : AbsSmall e16 (y_ N2[-]y_ m)).
    apply AbsSmall_minus.
    apply H41.
-   apply le_trans with NN; auto.
+   apply Nat.le_trans with NN; auto.
   elim H7; intros.
   rstepl ([--]e16).
   assumption.
@@ -1006,7 +1006,7 @@ Proof.
    apply plus_resp_leEq_both.
     assert (H8 : AbsSmall e16 (y_ m[-]y_ N2)).
      apply H41.
-     apply le_trans with NN; auto.
+     apply Nat.le_trans with NN; auto.
     elim H8; intros.
     rstepl ([--]e16).
     assumption.
@@ -1033,7 +1033,7 @@ Proof.
  assert (H8 : AbsSmall e16 (x_ N1[-]x_ m)).
   apply AbsSmall_minus.
   apply H31.
-  apply le_trans with NN; auto.
+  apply Nat.le_trans with NN; auto.
  elim H8; intros.
  rstepl ([--]e16).
  assumption.

--- a/fta/KeyLemma.v
+++ b/fta/KeyLemma.v
@@ -128,7 +128,7 @@ Proof.
   apply less_leEq; apply a_0_eps_fuzz.
  intros l H H0.
  cut (1 <= n - j). intro H1.
-  2: apply le_trans with (n - S j); [ auto | apply lem_1b ].
+  2: apply Nat.le_trans with (n - S j); [ auto | apply lem_1b ].
  cut (n - j <= n). intro H2.
   2: apply lem_1c.
  elim (Hrecj H1 H2). intros t' H4 H5.
@@ -184,7 +184,7 @@ Proof.
   auto.
  exists k'.
  split.
-  apply le_trans with (n - j).
+  apply Nat.le_trans with (n - j).
    unfold l in |- *; apply lem_1b.
   auto.
  split. auto.
@@ -502,7 +502,7 @@ Proof.
  exists (chfun k' k_SJ J).
  split. intro i.
   apply chfun_3. auto. auto.
-    apply le_trans with (k' J); auto.
+    apply Nat.le_trans with (k' J); auto.
   elim (H10 J). auto.
   split.
   intro i. apply chfun_4; auto.

--- a/fta/MainLemma.v
+++ b/fta/MainLemma.v
@@ -244,7 +244,7 @@ Proof.
   rstepl (a i[*] (r[^]i[*]Three[^]i) [-]eps).
   astepl (a i[*] (r[*]Three) [^]i[-]eps).
   apply H2; auto with arith.
-  apply le_trans with (S k); auto.
+  apply Nat.le_trans with (S k); auto.
  astepl (Sum (S k) n (fun i : nat => (a k[*] (r[*]Three) [^]k[+]eps) [*][1][/] Three[^]i[//]H3 i)).
  astepl (Sum (S k) n (fun i : nat => (a k[*] (r[*]Three) [^]k[+]eps) [*] ([1][/] Three[^]i[//]H3 i))).
  apply leEq_wdl with ((a k[*] (r[*]Three) [^]k[+]eps) [*]
@@ -463,7 +463,7 @@ Proof.
   intros i0 H17 H18.
   rewrite <- H12.
   apply H8; auto with arith.
-  apply le_trans with (S j); auto with arith.
+  apply Nat.le_trans with (S j); auto with arith.
  split.
   astepl ([1][*] (t[*]p3m (S j)) [^]n).
   astepl (a n[*] (t[*]p3m (S j)) [^]n).

--- a/ftc/COrdLemmas.v
+++ b/ftc/COrdLemmas.v
@@ -348,7 +348,7 @@ Proof.
      elim (le_lt_dec (f (S n)) i); intro; simpl in |- *.
       cut (f n < f (S n)); [ intro | apply f_mon; apply lt_n_Sn ].
       exfalso; apply (le_not_lt (f n) i); auto.
-      apply le_trans with (f (S n)); auto with arith.
+      apply Nat.le_trans with (f (S n)); auto with arith.
      intros; unfold part_tot_nat_fun in |- *;
        elim (le_lt_dec (f (S n)) i);elim (le_lt_dec (f n) i);simpl;intros; try reflexivity;try exfalso; try lia.
     rewrite <-H1; cut (0 < f (S n)); [ intro | rewrite <- f0; auto with arith ];
@@ -356,7 +356,7 @@ Proof.
         rewrite <- H3; apply lt_le_weak; auto with arith.
    intros; unfold part_tot_nat_fun in |- *;elim (le_lt_dec (f (S n)) i);
      [intro; simpl in |- *; exfalso; lia| reflexivity].
-  apply lt_trans with (f n); auto with arith.
+  apply Nat.lt_trans with (f n); auto with arith.
  red in |- *; intros; rewrite -> H1; reflexivity.
 Qed.
 

--- a/ftc/Composition.v
+++ b/ftc/Composition.v
@@ -479,9 +479,9 @@ Proof.
  exists (max N M).
  intros n Hn x Hx.
  assert (Hn0 : N <= n).
-  apply le_trans with (max N M); auto with *.
+  apply Nat.le_trans with (max N M); auto with *.
  assert (Hn1 : M <= n).
-  apply le_trans with (max N M); auto with *.
+  apply Nat.le_trans with (max N M); auto with *.
  apply AbsSmall_imp_AbsIR.
  assert (X:Continuous_I (a:=a) (b:=b) Hab (G[o]f n)).
   eapply Continuous_I_comp.

--- a/ftc/FunctSequence.v
+++ b/ftc/FunctSequence.v
@@ -816,8 +816,8 @@ Proof.
  eapply leEq_transitive.
   apply triangle_IR.
  apply plus_resp_leEq_both.
-  unfold incf in |- *; apply HNf; apply le_trans with (max Nf Ng); auto.
- unfold incg in |- *; apply HNg; apply le_trans with (max Nf Ng); auto.
+  unfold incf in |- *; apply HNf; apply Nat.le_trans with (max Nf Ng); auto.
+ unfold incg in |- *; apply HNg; apply Nat.le_trans with (max Nf Ng); auto.
 Qed.
 
 Lemma fun_Lim_seq_minus' : forall H H',
@@ -839,8 +839,8 @@ Proof.
  eapply leEq_transitive.
   apply triangle_IR_minus.
  apply plus_resp_leEq_both.
-  unfold incf in |- *; apply HNf; apply le_trans with (max Nf Ng); auto.
- unfold incg in |- *; apply HNg; apply le_trans with (max Nf Ng); auto.
+  unfold incf in |- *; apply HNf; apply Nat.le_trans with (max Nf Ng); auto.
+ unfold incg in |- *; apply HNg; apply Nat.le_trans with (max Nf Ng); auto.
 Qed.
 
 Lemma fun_Lim_seq_mult' : forall H H',
@@ -891,14 +891,14 @@ Proof.
        apply AbsIR_nonneg.
       eapply shift_mult_leEq'.
        apply pos_max_one.
-      unfold eg in HNG; unfold incg in |- *; apply HNG; apply le_trans with (max NF NG); auto.
+      unfold eg in HNG; unfold incg in |- *; apply HNG; apply Nat.le_trans with (max NF NG); auto.
      eapply leEq_wdl.
       2: apply eq_symmetric_unfolded; apply AbsIR_resp_mult.
      apply leEq_transitive with (ee [/]ThreeNZ[*]ee [/]ThreeNZ).
       2: astepr (ee [/]ThreeNZ[*][1]); apply mult_resp_leEq_lft.
        apply mult_resp_leEq_both; try apply AbsIR_nonneg.
         eapply leEq_transitive.
-         unfold incf in |- *; apply HNF; apply le_trans with (max NF NG); auto.
+         unfold incf in |- *; apply HNF; apply Nat.le_trans with (max NF NG); auto.
         unfold ef in |- *.
         apply shift_div_leEq.
          apply pos_max_one.
@@ -906,7 +906,7 @@ Proof.
          apply rht_leEq_Max.
         apply less_leEq; apply shift_less_div; astepl ZeroR; [ apply pos_three | assumption ].
        eapply leEq_transitive.
-        unfold incg in |- *; apply HNG; apply le_trans with (max NF NG); auto.
+        unfold incg in |- *; apply HNG; apply Nat.le_trans with (max NF NG); auto.
        unfold eg in |- *.
        apply shift_div_leEq.
         apply pos_max_one.
@@ -932,7 +932,7 @@ Proof.
      apply AbsIR_nonneg.
     eapply shift_mult_leEq'.
      apply pos_max_one.
-    unfold ef in HNF; unfold incf in |- *; apply HNF; apply le_trans with (max NF NG); auto.
+    unfold ef in HNF; unfold incf in |- *; apply HNF; apply Nat.le_trans with (max NF NG); auto.
    unfold ef in |- *.
    apply div_resp_pos.
     apply pos_max_one.

--- a/ftc/FunctSeries.v
+++ b/ftc/FunctSeries.v
@@ -608,7 +608,7 @@ Proof.
         Transparent Frestr.
         eapply leEq_wdr.
          apply triangle_SumIR.
-         rewrite <- (S_pred m k); auto; apply lt_le_trans with N; auto.
+         rewrite <- (S_pred m k); auto; apply Nat.lt_le_trans with N; auto.
         apply Sum_wd; intros.
         Opaque FAbs.
         simpl in |- *.
@@ -626,7 +626,7 @@ Proof.
         apply Feq_imp_eq with I.
          apply Feq_transitive with (FSum N (pred m) f).
           unfold I in |- *; apply fun_seq_part_sum_n; auto with arith.
-          apply le_lt_trans with k; [ idtac | apply lt_le_trans with N ]; auto with arith.
+          apply Nat.le_lt_trans with k; [ idtac | apply Nat.lt_le_trans with N ]; auto with arith.
          apply eq_imp_Feq.
            unfold I in |- *; apply contin_imp_inc; Contin.
           simpl in |- *.
@@ -641,7 +641,7 @@ Proof.
      cut (Dom (FSum N (pred m) g) x). intro H6.
       apply leEq_wdr with (Part _ _ H6).
        apply FSum_resp_leEq.
-        rewrite <- (S_pred m k); auto; apply lt_le_trans with N; auto.
+        rewrite <- (S_pred m k); auto; apply Nat.lt_le_trans with N; auto.
        intros.
        Opaque FAbs.
        simpl in |- *.
@@ -649,7 +649,7 @@ Proof.
         2: apply eq_symmetric_unfolded;
           apply FAbs_char with (Hx' := contin_imp_inc _ _ _ _ (contF i) x0 (HxF i)).
        apply Hk.
-        apply le_trans with N; auto with arith.
+        apply Nat.le_trans with N; auto with arith.
        simpl in HxF.
        apply (HxF 0).
       cut (Dom (fun_seq_part_sum g m{-}fun_seq_part_sum g N) x). intro H7.
@@ -658,7 +658,7 @@ Proof.
         simpl in |- *; rational.
        apply Feq_imp_eq with I.
         unfold I in |- *; apply fun_seq_part_sum_n; auto with arith.
-        apply le_lt_trans with k; [ idtac | apply lt_le_trans with N ]; auto with arith.
+        apply Nat.le_lt_trans with k; [ idtac | apply Nat.lt_le_trans with N ]; auto with arith.
        auto.
       split; simpl in |- *.
        apply (contin_imp_inc _ _ _ _ (fun_seq_part_sum_cont _ _ _ _ contG m)); auto.
@@ -680,7 +680,7 @@ Proof.
   auto with arith.
  intros m H5 x H6 Hx Hx'.
  apply AbsIR_imp_AbsSmall.
- cut (N <= m); [ intro | apply le_trans with (max N k); auto with arith ].
+ cut (N <= m); [ intro | apply Nat.le_trans with (max N k); auto with arith ].
  eapply leEq_wdl.
   Transparent fun_seq_part_sum.
   simpl in Hx'.

--- a/ftc/Integral.v
+++ b/ftc/Integral.v
@@ -840,7 +840,7 @@ Proof.
  intro.
  unfold partition_join_fun in |- *.
  elim le_lt_dec; intro; simpl in |- *.
-  exfalso; apply le_Sn_n with n; apply le_trans with (S (n + m)); auto with arith.
+  exfalso; apply le_Sn_n with n; apply Nat.le_trans with (S (n + m)); auto with arith.
  apply eq_transitive_unfolded with (Q _ (le_n _)).
   apply prf1; auto with arith.
  apply finish.
@@ -1023,7 +1023,7 @@ Proof.
    Opaque minus.
    unfold partition_join, partition_join_fun in |- *.
    elim le_lt_dec; simpl in |- *; intro.
-    exfalso; apply le_Sn_n with n; eapply le_trans.
+    exfalso; apply le_Sn_n with n; eapply Nat.le_trans.
      2: apply a0.
     auto with arith.
    Transparent minus.
@@ -1031,7 +1031,7 @@ Proof.
   Opaque minus.
   unfold partition_join, partition_join_fun in |- *.
   elim le_lt_dec; simpl in |- *; intro.
-   exfalso; apply le_Sn_n with n; eapply le_trans.
+   exfalso; apply le_Sn_n with n; eapply Nat.le_trans.
     2: apply a0.
    auto with arith.
   Transparent minus.
@@ -1146,7 +1146,7 @@ Proof.
        apply leEq_less_trans with (nring (R:=IR) n2).
         assumption.
        apply nring_less.
-       apply le_lt_trans with p.
+       apply Nat.le_lt_trans with p.
         unfold p in |- *; apply le_max_r.
        auto with arith.
       unfold EP2 in |- *; eapply less_wdl.
@@ -1157,7 +1157,7 @@ Proof.
       apply leEq_less_trans with (nring (R:=IR) n1).
        assumption.
       apply nring_less.
-      apply le_lt_trans with p.
+      apply Nat.le_lt_trans with p.
        unfold p in |- *; apply le_max_l.
       auto with arith.
      red in |- *; do 3 intro.
@@ -1191,7 +1191,7 @@ Proof.
       unfold partition_join_pts in |- *.
       elim le_lt_dec; intro; simpl in |- *.
        elim le_lt_eq_dec; intro; simpl in |- *.
-        exfalso; apply le_Sn_n with (S i); eapply le_trans.
+        exfalso; apply le_Sn_n with (S i); eapply Nat.le_trans.
          2: apply a0.
         auto with arith.
        exfalso; apply lt_irrefl with (S i); pattern (S i) at 2 in |- *;

--- a/ftc/MoreFunSeries.v
+++ b/ftc/MoreFunSeries.v
@@ -1079,8 +1079,8 @@ Proof.
  intros e H.
  elim (HCauchy e H); intros N HN.
  exists (S N); do 4 intro.
- cut (m = S (pred m)); [ intro | apply S_pred with 0; apply lt_le_trans with (S N); auto with arith ].
- cut (n = S (pred n)); [ intro | apply S_pred with 0; apply lt_le_trans with (S N); auto with arith ].
+ cut (m = S (pred m)); [ intro | apply S_pred with 0; apply Nat.lt_le_trans with (S N); auto with arith ].
+ cut (n = S (pred n)); [ intro | apply S_pred with 0; apply Nat.lt_le_trans with (S N); auto with arith ].
  generalize H0 H1; clear H1 H0.
  rewrite H2; rewrite H3; clear H2 H3.
  intros.

--- a/ftc/Partitions.v
+++ b/ftc/Partitions.v
@@ -240,7 +240,7 @@ Proof.
   clear Hj' Hf Hf0.
   cut (i < f n).
    intro.
-   cut (f j < f n); [ intro | apply le_lt_trans with i; auto ].
+   cut (f j < f n); [ intro | apply Nat.le_lt_trans with i; auto ].
    apply not_ge.
    intro; red in H1.
    apply (le_not_lt (f j) (f n)); auto with arith.

--- a/ftc/RefLemma.v
+++ b/ftc/RefLemma.v
@@ -193,7 +193,7 @@ Proof.
  elim (le_lt_eq_dec _ _ H1); clear H1; intro.
   cut (sub (S i) < sub n); [ intro | apply RL_sub_mon; assumption ].
   rewrite <- RL_sub_n.
-  apply le_lt_trans with (sub (S i)); auto; eapply le_trans; [ apply H0 | apply le_pred_n ].
+  apply Nat.le_lt_trans with (sub (S i)); auto; eapply Nat.le_trans; [ apply H0 | apply le_pred_n ].
  cut (0 < sub (S i)); [ intro | apply RL_sub_S ].
  rewrite <- RL_sub_n.
  rewrite <- b0.
@@ -329,7 +329,7 @@ Proof.
       exfalso.
       cut (0 < sub (S i)); [ intro | apply RL_sub_S ].
       cut (sub (S i) <= m); intros.
-       apply (le_not_lt _ _ H4); apply le_lt_trans with j; auto.
+       apply (le_not_lt _ _ H4); apply Nat.le_lt_trans with j; auto.
       rewrite <- RL_sub_n.
       apply RL_sub_mon'; apply Hi.
      apply mult_wd.

--- a/ftc/RefSepRef.v
+++ b/ftc/RefSepRef.v
@@ -290,11 +290,11 @@ Proof.
      apply leEq_wdl with x; assumption.
     intros; unfold f' in |- *.
     apply leEq_wdr with (P _ (le_n _)).
-     apply Partition_mon; apply le_trans with (pred n); auto with arith.
+     apply Partition_mon; apply Nat.le_trans with (pred n); auto with arith.
     apply finish.
    intros; unfold g' in |- *.
    apply leEq_wdr with (R _ (le_n _)).
-    apply Partition_mon; apply le_trans with (pred m); auto with arith.
+    apply Partition_mon; apply Nat.le_trans with (pred m); auto with arith.
    apply finish.
   exfalso; rewrite <- b0 in H'; apply (le_Sn_n _ H').
  apply leEq_reflexive.
@@ -354,7 +354,7 @@ Proof.
  elim (le_lt_dec n i); intro; simpl in |- *.
   exfalso; apply le_not_lt with n i; auto.
  elim (le_lt_dec i 0); intro; simpl in |- *.
-  exfalso; apply lt_irrefl with 0; apply lt_le_trans with i; auto.
+  exfalso; apply lt_irrefl with 0; apply Nat.lt_le_trans with i; auto.
  set (x := ProjT1 (RSR_h_f' _ (lt_pred' _ _ b1 b0))) in *.
  set (y := ProjT1 (RSR_h_f' _ (lt_pred' _ _ Hi Hi'))) in *.
  cut (x = y).
@@ -392,25 +392,25 @@ Proof.
  assert (X'':=RSR_mn0); assert (X''':=RSR_nm0).
  elim (le_lt_dec i 0); intro.
   elim (le_lt_dec j 0); intros; simpl in |- *.
-   apply lt_le_trans with j; try apply le_lt_trans with i; auto with arith.
+   apply Nat.lt_le_trans with j; try apply Nat.le_lt_trans with i; auto with arith.
   elim (le_lt_dec n j); intros; simpl in |- *.
    lia.
   apply lt_O_Sn.
  elim (le_lt_dec n i); elim (le_lt_dec j 0); intros; simpl in |- *.
-    elim (lt_irrefl 0); apply lt_le_trans with j; try apply le_lt_trans with i; auto with arith.
+    elim (lt_irrefl 0); apply Nat.lt_le_trans with j; try apply Nat.le_lt_trans with i; auto with arith.
    elim (le_lt_dec n j); intro; simpl in |- *.
     apply plus_lt_compat_l.
     apply plus_lt_reg_l with n.
     repeat rewrite <- le_plus_minus; auto.
-   elim (le_not_lt n i); auto; apply lt_trans with j; auto.
-  elim (lt_irrefl 0); apply lt_trans with i; auto; apply lt_le_trans with j; auto.
+   elim (le_not_lt n i); auto; apply Nat.lt_trans with j; auto.
+  elim (lt_irrefl 0); apply Nat.lt_trans with i; auto; apply Nat.lt_le_trans with j; auto.
  elim (le_lt_dec n j); intro; simpl in |- *.
-  apply lt_le_trans with (S (pred m + pred n)).
+  apply Nat.lt_le_trans with (S (pred m + pred n)).
    apply lt_n_S.
    apply (ProjT1 (ProjT2 (RSR_h_f' (pred i) (lt_pred' _ _ b0 b2)))).
   rewrite plus_n_Sm.
   rewrite <- S_pred with n 0.
-   2: apply lt_trans with i; auto.
+   2: apply Nat.lt_trans with i; auto.
   replace (pred m + n) with (pred (m + n)).
    auto with arith.
   cut (S (pred (m + n)) = S (pred m + n)); auto.
@@ -419,7 +419,7 @@ Proof.
   apply neq_O_lt.
   intro.
   apply lt_irrefl with 0.
-  apply lt_trans with i; auto.
+  apply Nat.lt_trans with i; auto.
   rewrite RSR_mn0; auto.
  apply lt_n_S.
  cut (~ ~ ProjT1 (RSR_h_f' (pred i) (lt_pred' _ _ b0 b2)) <
@@ -508,7 +508,7 @@ Proof.
   elim (le_lt_dec i 0); intro; simpl in |- *.
    apply le_O_n.
   elim (le_lt_dec n i); intro; simpl in |- *.
-   elim (lt_irrefl n); apply le_lt_trans with i; auto.
+   elim (lt_irrefl n); apply Nat.le_lt_trans with i; auto.
   apply plus_pred_pred_plus.
   elim (ProjT2 (RSR_h_f' _ (lt_pred' i n b1 b2))); intros.
   assumption.
@@ -545,7 +545,7 @@ Proof.
  elim (le_lt_dec m i); intro; simpl in |- *.
   exfalso; apply le_not_lt with m i; auto.
  elim (le_lt_dec i 0); intro; simpl in |- *.
-  exfalso; apply lt_irrefl with 0; apply lt_le_trans with i; auto.
+  exfalso; apply lt_irrefl with 0; apply Nat.lt_le_trans with i; auto.
  set (x := ProjT1 (RSR_h_g' _ (lt_pred' _ _ b1 b0))) in *.
  set (y := ProjT1 (RSR_h_g' _ (lt_pred' _ _ Hi Hi'))) in *.
  cut (x = y).
@@ -583,37 +583,37 @@ Proof.
  assert (X'':=RSR_mn0); assert (X''':=RSR_nm0).
  elim (le_lt_dec i 0); intro.
   elim (le_lt_dec j 0); intros; simpl in |- *.
-   apply le_lt_trans with i; try apply lt_le_trans with j; auto with arith.
+   apply Nat.le_lt_trans with i; try apply Nat.lt_le_trans with j; auto with arith.
   elim (le_lt_dec m j); intros; simpl in |- *.
    lia.
   apply lt_O_Sn.
  elim (le_lt_dec m i); elim (le_lt_dec j 0); intros; simpl in |- *.
-    elim (lt_irrefl 0); apply le_lt_trans with i; try apply lt_le_trans with j; auto with arith.
+    elim (lt_irrefl 0); apply Nat.le_lt_trans with i; try apply Nat.lt_le_trans with j; auto with arith.
    elim (le_lt_dec m j); intro; simpl in |- *.
     apply plus_lt_compat_l.
     apply plus_lt_reg_l with m.
     repeat rewrite <- le_plus_minus; auto.
-   elim (le_not_lt m i); auto; apply lt_trans with j; auto.
-  elim (lt_irrefl 0); apply lt_trans with i; auto; apply lt_le_trans with j; auto.
+   elim (le_not_lt m i); auto; apply Nat.lt_trans with j; auto.
+  elim (lt_irrefl 0); apply Nat.lt_trans with i; auto; apply Nat.lt_le_trans with j; auto.
  elim (le_lt_dec m j); intro; simpl in |- *.
-  set (H0 := RSR_nm0) in *; set (H1 := RSR_mn0) in *; apply lt_le_trans with (S (pred m + pred n)).
+  set (H0 := RSR_nm0) in *; set (H1 := RSR_mn0) in *; apply Nat.lt_le_trans with (S (pred m + pred n)).
    apply lt_n_S.
    apply (ProjT1 (ProjT2 (RSR_h_g' (pred i) (lt_pred' _ _ b0 b2)))).
   rewrite <- plus_Sn_m.
   rewrite <- S_pred with m 0.
-   2: apply lt_trans with i; auto.
+   2: apply Nat.lt_trans with i; auto.
   replace (m + pred n) with (pred (m + n)).
    auto with arith.
   cut (S (pred (m + n)) = S (m + pred n)); auto.
   rewrite plus_n_Sm.
   rewrite <- S_pred with n 0; auto with arith.
    symmetry  in |- *; apply S_pred with 0.
-   apply lt_le_trans with m; auto with arith.
-   apply lt_trans with i; auto.
+   apply Nat.lt_le_trans with m; auto with arith.
+   apply Nat.lt_trans with i; auto.
   apply neq_O_lt.
   intro.
   apply lt_irrefl with 0.
-  apply lt_trans with i; auto.
+  apply Nat.lt_trans with i; auto.
   rewrite RSR_nm0; auto.
  apply lt_n_S.
  cut (~ ~ ProjT1 (RSR_h_g' (pred i) (lt_pred' _ _ b0 b2)) <

--- a/ftc/RefSeparated.v
+++ b/ftc/RefSeparated.v
@@ -168,7 +168,7 @@ Proof.
  intros j Hj H; intros.
  elim (Cnat_total_order _ _ H0); clear H0; intro H0.
   elim (le_lt_dec j' m); intro.
-   cut (S j <= m); [ intro | clear H; apply le_trans with j'; auto ].
+   cut (S j <= m); [ intro | clear H; apply Nat.le_trans with j'; auto ].
    eapply less_wdr.
     2: apply AbsIR_minus.
    cut (R (S j) H1[<=]R j' Hj'); intros.
@@ -207,7 +207,7 @@ Proof.
    assumption.
   exfalso; apply (le_not_lt j' m); auto.
  elim (le_lt_dec j 0); intro.
-  exfalso; apply lt_n_O with j'; red in |- *; apply le_trans with j; auto.
+  exfalso; apply lt_n_O with j'; red in |- *; apply Nat.le_trans with j; auto.
  generalize Hj H H0; clear H0 H Hj.
  set (jj := pred j) in *.
  cut (j = S jj); [ intro | unfold jj in |- *; apply S_pred with 0; auto ].
@@ -498,8 +498,8 @@ Proof.
  unfold sep__sep_fun in |- *.
  elim (le_lt_dec i 0); elim (le_lt_dec j 0); intros; simpl in |- *.
     algebra.
-   exfalso; apply (lt_irrefl 0); apply lt_le_trans with j; auto; rewrite <- H; auto.
-  exfalso; apply (lt_irrefl 0); apply lt_le_trans with j; auto; rewrite <- H; auto.
+   exfalso; apply (lt_irrefl 0); apply Nat.lt_le_trans with j; auto; rewrite <- H; auto.
+  exfalso; apply (lt_irrefl 0); apply Nat.lt_le_trans with j; auto; rewrite <- H; auto.
  elim (le_lt_eq_dec _ _ Hi); elim (le_lt_eq_dec _ _ Hj); intros; simpl in |- *.
     apply sep__sep_fun_i_wd; auto.
    exfalso; rewrite H in a0; rewrite b2 in a0; apply (lt_irrefl _ a0).
@@ -534,7 +534,7 @@ Proof.
  unfold sep__sep_part in |- *; simpl in |- *.
  unfold sep__sep_fun in |- *; simpl in |- *.
  elim (le_lt_dec i 0); intro; simpl in |- *.
-  exfalso; apply lt_irrefl with 0; apply lt_le_trans with i; auto.
+  exfalso; apply lt_irrefl with 0; apply Nat.lt_le_trans with i; auto.
  elim (le_lt_eq_dec _ _ Hi); intro; simpl in |- *.
   apply sep__sep_ap.
  exfalso; rewrite b1 in H1; apply (lt_irrefl _ H1).
@@ -796,7 +796,7 @@ Proof.
    apply plus_resp_leEq_lft.
    apply less_leEq; assumption.
   exfalso; rewrite b2 in a0; apply lt_irrefl with (S n);
-    apply lt_trans with (S n); auto with arith.
+    apply Nat.lt_trans with (S n); auto with arith.
  elim (le_lt_dec i 0); intro; simpl in |- *.
   cut (i = 0); [ intro | auto with arith ].
   rewrite H0 in b1.

--- a/ftc/RefSeparating.v
+++ b/ftc/RefSeparating.v
@@ -207,7 +207,7 @@ Proof.
  cut (sep__part_h j <= sep__part_h (S j)); intros.
   2: apply sep__part_h_mon_1.
  elim (le_lt_eq_dec _ _ H0); intro.
-  apply lt_le_trans with (sep__part_h j); auto.
+  apply Nat.lt_le_trans with (sep__part_h j); auto.
   apply Hrecj; auto with arith.
  rewrite <- b0; apply sep__part_h_mon_2; auto.
 Qed.
@@ -292,7 +292,7 @@ Proof.
     2: apply cg_minus_wd; apply prf1; auto.
    apply H0.
    apply lt_pred_n_n.
-   apply le_lt_trans with (sep__part_h i).
+   apply Nat.le_lt_trans with (sep__part_h i).
     apply le_O_n.
    apply Partition_Points_mon with (P := P) (Hi := a0) (Hj := Hj).
    apply less_transitive_unfolded with (P (sep__part_h i) a0[+]delta [/]FourNZ).
@@ -319,7 +319,7 @@ Proof.
    unfold cg_minus in |- *; apply plus_resp_leEq_both.
     apply Partition_mon; assumption.
    apply inv_resp_leEq; apply Partition_mon; assumption.
-  apply le_trans with (sep__part_h (S i)).
+  apply Nat.le_trans with (sep__part_h (S i)).
    auto with arith.
   apply sep__part_h_bnd.
  apply sep__part_h_bnd.
@@ -600,7 +600,7 @@ Proof.
   rewrite sep__part_fun_i.
    2: assumption.
   intros.
-  cut (pred (sep__part_h (S i)) <= n); [ intro | eapply le_trans; [ apply le_pred_n | auto ] ].
+  cut (pred (sep__part_h (S i)) <= n); [ intro | eapply Nat.le_trans; [ apply le_pred_n | auto ] ].
   rstepl (P _ Ha[-]P _ H0[+](P _ H0[-]P _ Hb)).
   apply plus_resp_leEq_both.
    generalize Ha; pattern (sep__part_h (S i)) at 1 2 in |- *;
@@ -626,7 +626,7 @@ Proof.
    cut (i = RS'_m1); [ intro | unfold sep__part_length in b0; rewrite <- b0 in H0; auto with arith ].
    rewrite H2.
    intros.
-   cut (pred (sep__part_h (S RS'_m1)) <= n); [ intro | eapply le_trans; [ apply le_pred_n | auto ] ].
+   cut (pred (sep__part_h (S RS'_m1)) <= n); [ intro | eapply Nat.le_trans; [ apply le_pred_n | auto ] ].
    rstepl (P _ Ha0[-]P _ H3[+](P _ H3[-]P _ Hb0)).
    apply plus_resp_leEq_both.
     generalize Ha0; pattern (sep__part_h (S RS'_m1)) at 1 2 in |- *;
@@ -667,7 +667,7 @@ Proof.
      elim (ProjT2 a1); fold j in |- *; intros Hj Hj'.
      elim Hj'; clear Hj'; intros H2 H3.
      intros.
-     cut (pred j <= n); [ intro | apply le_trans with j; auto with arith ].
+     cut (pred j <= n); [ intro | apply Nat.le_trans with j; auto with arith ].
      rstepl (P j H4[-]P (pred j) H5[+](P (pred j) H5[-]P (sep__part_h i) Hb)).
      cut (0 < j); intros.
       apply plus_resp_leEq_both.
@@ -679,7 +679,7 @@ Proof.
        2: apply cg_minus_wd; apply prf1; auto.
       apply H3.
       auto with arith.
-     apply le_lt_trans with (sep__part_h i); auto with arith.
+     apply Nat.le_lt_trans with (sep__part_h i); auto with arith.
      apply Partition_Points_mon with (P := P) (Hi := a0) (Hj := Hj).
      apply less_transitive_unfolded with (P (sep__part_h i) a0[+]delta [/]FourNZ).
       apply shift_less_plus'; astepl ZeroR; apply pos_div_four; exact RS'_delta_pos.
@@ -757,7 +757,7 @@ Lemma RS'_Hsep_S :
   j <= pred (sep__part_fun (S i) Hi) -> S j <= n.
 Proof.
  intros.
- apply le_trans with (sep__part_fun (S i) Hi).
+ apply Nat.le_trans with (sep__part_fun (S i) Hi).
   2: apply sep__part_fun_bnd.
  rewrite (S_pred (sep__part_fun (S i) Hi) (sep__part_fun i (lt_le_weak _ _ Hi))) .
   auto with arith.
@@ -769,7 +769,7 @@ Lemma RS'_Hsep :
   j <= pred (sep__part_fun (S i) Hi) -> j <= n.
 Proof.
  intros.
- apply le_trans with (sep__part_fun (S i) Hi).
+ apply Nat.le_trans with (sep__part_fun (S i) Hi).
   2: apply sep__part_fun_bnd.
  rewrite (S_pred (sep__part_fun (S i) Hi) (sep__part_fun i (lt_le_weak _ _ Hi))) .
   apply le_S; assumption.
@@ -816,7 +816,7 @@ Proof.
      do 2 elim le_lt_dec; intros; simpl in |- *.
         apply cg_minus_wd; apply prf1; auto.
        exfalso; apply le_not_lt with j n.
-        apply le_trans with (S j); auto with arith.
+        apply Nat.le_trans with (S j); auto with arith.
        assumption.
       exfalso; apply le_not_lt with (S j) n.
        exact (RS'_Hsep_S _ _ Hi a1).
@@ -879,7 +879,7 @@ Proof.
       exfalso.
       apply le_not_lt with n j.
        assumption.
-      apply lt_le_trans with (sep__part_fun (S i) Hi'').
+      apply Nat.lt_le_trans with (sep__part_fun (S i) Hi'').
        assumption.
       apply sep__part_fun_bnd.
      apply mult_wd; algebra.
@@ -1024,7 +1024,7 @@ Proof.
     elim (le_lt_dec n j); intro; simpl in |- *.
      exfalso; apply (le_not_lt n j).
       assumption.
-     eapply lt_le_trans.
+     eapply Nat.lt_le_trans.
       apply H0.
      apply sep__part_fun_bnd.
     algebra.
@@ -1163,7 +1163,7 @@ Proof.
       apply H3; apply le_n.
      apply lt_n_Sn.
     apply inv_resp_leEq; apply Partition_mon.
-    eapply le_trans.
+    eapply Nat.le_trans.
      2: apply a2.
     clear Hk Hk'; lia.
    apply leEq_wdl with ZeroR.
@@ -1210,7 +1210,7 @@ Proof.
    apply sep__part_h_lemma3 with i.
     rewrite sep__part_fun_i in Hk; assumption.
    rewrite sep__part_fun_i in a0; assumption.
-  apply le_trans with (sep__part_fun (S i) H).
+  apply Nat.le_trans with (sep__part_fun (S i) H).
    auto with arith.
   apply sep__part_fun_bnd.
  apply leEq_wdl with ZeroR.

--- a/liouville/CPoly_Euclid.v
+++ b/liouville/CPoly_Euclid.v
@@ -143,7 +143,7 @@ Proof.
  assert (f[=]q[*]g[+]r and degree_lt_pair r g).
   split; [ assumption | ].
   split.
-   intros; unfold degree_le; intros; apply y0; apply le_lt_trans with n0; [ | assumption ].
+   intros; unfold degree_le; intros; apply y0; apply Nat.le_lt_trans with n0; [ | assumption ].
    unfold degree_le in H1; apply not_gt; intro; unfold gt in H3.
    set (tmp := (H1 (S n) (lt_n_S _ _ H3))); rewrite -> H in tmp.
    apply (eq_imp_not_ap _ _ _ tmp); apply ring_non_triv.

--- a/liouville/nat_Q_lists.v
+++ b/liouville/nat_Q_lists.v
@@ -80,7 +80,7 @@ Proof.
   split.
    apply list_nat_prod_spec.
     apply le_O_n.
-   apply (le_trans _ _ _ (le_pred_n _) Hdb).
+   apply (Nat.le_trans _ _ _ (le_pred_n _) Hdb).
   left.
   f_equal.
   destruct (ZL4 d).
@@ -154,7 +154,7 @@ Proof.
  split.
   apply list_nat_prod_spec.
    apply le_O_n.
-  apply (le_trans _ _ _ (le_pred_n _) Hle).
+  apply (Nat.le_trans _ _ _ (le_pred_n _) Hle).
  left.
  f_equal.
  destruct (ZL4 d).

--- a/logic/CLogic.v
+++ b/logic/CLogic.v
@@ -749,22 +749,22 @@ Qed.
 
 Lemma lt_5 : forall i n : nat, i < n -> pred i < n.
 Proof.
- intros; apply le_lt_trans with (pred n).
+ intros; apply Nat.le_lt_trans with (pred n).
   apply le_pred; auto with arith.
- apply lt_pred_n_n; apply le_lt_trans with i; auto with arith.
+ apply lt_pred_n_n; apply Nat.le_lt_trans with i; auto with arith.
 Qed.
 
 Lemma lt_8 : forall m n : nat, m < pred n -> m < n.
 Proof.
- intros; apply lt_le_trans with (pred n); auto with arith.
+ intros; apply Nat.lt_le_trans with (pred n); auto with arith.
 Qed.
 
 Lemma pred_lt : forall m n : nat, m < pred n -> S m < n.
 Proof.
- intros; apply le_lt_trans with (pred n); auto with arith.
- apply lt_pred_n_n; apply le_lt_trans with m.
+ intros; apply Nat.le_lt_trans with (pred n); auto with arith.
+ apply lt_pred_n_n; apply Nat.le_lt_trans with m.
   auto with arith.
- apply lt_le_trans with (pred n); auto with arith.
+ apply Nat.lt_le_trans with (pred n); auto with arith.
 Qed.
 
 Lemma lt_10 : forall i m n : nat,
@@ -787,7 +787,7 @@ Lemma le_1 : forall m n : nat, Cle m n -> pred m <= n.
 Proof.
  intros.
  cut (m <= n); [ intro | apply Cle_to; assumption ].
- apply le_trans with (pred n); auto with arith.
+ apply Nat.le_trans with (pred n); auto with arith.
  apply le_pred; auto.
 Qed.
 
@@ -843,7 +843,7 @@ Proof.
  elim (le_lt_eq_dec _ _ H1); intro H2.
   cut (h i < h j); [ intro | apply Hrecj; assumption ].
   cut (h j < h (S j)); [ intro | apply H ].
-  apply lt_trans with (h j); auto.
+  apply Nat.lt_trans with (h j); auto.
  rewrite H2; apply H.
 Qed.
 
@@ -858,7 +858,7 @@ Proof.
  elim (le_lt_eq_dec _ _ H0); intro H1.
   cut (h i <= h j); [ intro | apply Hrecj; auto with arith ].
   cut (h j <= h (S j)); [ intro | apply H ].
-  apply le_trans with (h j); auto.
+  apply Nat.le_trans with (h j); auto.
  rewrite H1; apply le_n.
 Qed.
 
@@ -901,7 +901,7 @@ Proof.
  induction  k as [| k Hreck].
   exists 0.
    rewrite H0; auto with arith.
-  cut (h 0 < h 1); [ intro; apply le_trans with (h 0); auto with arith | apply H; apply lt_n_Sn ].
+  cut (h 0 < h 1); [ intro; apply Nat.le_trans with (h 0); auto with arith | apply H; apply lt_n_Sn ].
  cut (h k < h (S k)); [ intro H2 | apply H; apply lt_n_Sn ].
  elim (le_lt_dec (S n) (h k)); intro H3.
   elim (Hreck H3); intros i Hi.
@@ -924,7 +924,7 @@ Proof.
    assumption.
   auto with arith.
  exists (S m).
-  apply le_lt_trans with (f m).
+  apply Nat.le_lt_trans with (f m).
    rewrite b; auto with arith.
   apply H.
   rewrite b; apply lt_n_Sn.
@@ -952,7 +952,7 @@ Proof.
  generalize k; clear k.
  induction  n as [| n Hrecn]; intros k H H0.
   elim (H 0); intros H1 H2.
-  generalize (le_trans _ _ _ H1 H2); intro H3.
+  generalize (Nat.le_trans _ _ _ H1 H2); intro H3.
   exfalso.
   inversion H3.
  elim (eq_nat_dec (k 0) (k 2)).
@@ -985,13 +985,13 @@ Proof.
   tauto.
  generalize (H 0); intro H3.
  elim H3; intros H4 H5.
- generalize (lt_le_trans _ _ _ H2 H5); intro H6.
+ generalize (Nat.lt_le_trans _ _ _ H2 H5); intro H6.
  cut (k 2 <= n).
   2: lia.
  intro H7.
  induction  i as [| i Hreci].
   assumption.
- apply le_trans with (k (S (S i))); auto.
+ apply Nat.le_trans with (k (S (S i))); auto.
 Qed.
 
 Section Predicates_to_CProp.
@@ -1174,7 +1174,7 @@ Proof.
      split.
       eapply H with (i := m); [ auto with arith | apply Hm' ].
      unfold Q' in Hj; intros j' Hj' H2.
-     cut (j' <= n); [ intro H4 | apply le_trans with m; auto with arith ].
+     cut (j' <= n); [ intro H4 | apply Nat.le_trans with m; auto with arith ].
      apply H0 with (H := le_S _ _ H4); [ auto | apply Hj; assumption ].
     elim (H1 (S n) (le_n (S n))); intro H1'.
      intro H2.

--- a/logic/CornBasics.v
+++ b/logic/CornBasics.v
@@ -860,7 +860,7 @@ Proof.
  apply Acc_intro.
  unfold ltof in |- *; intros b ltfafb.
  apply IHn.
- apply lt_le_trans with (f a); auto with arith.
+ apply Nat.lt_le_trans with (f a); auto with arith.
 Qed.
 
 

--- a/metric2/Compact.v
+++ b/metric2/Compact.v
@@ -262,7 +262,7 @@ Proof.
     apply Pos2Nat.inj_le.
     rewrite Nat2Pos.id.
     exact H1. 
-    apply (lt_le_trans _ _ _ (Pos2Nat.is_pos n)) in H1.
+    apply (Nat.lt_le_trans _ _ _ (Pos2Nat.is_pos n)) in H1.
     destruct k. inversion H1. discriminate.
     unfold Qle; simpl.
     apply (Z.mul_le_mono_nonneg_r 1 a (Z.pos n)).

--- a/metric2/FinEnum.v
+++ b/metric2/FinEnum.v
@@ -295,7 +295,7 @@ Proof.
  apply Zmult_le_compat.
  apply Pos.le_1_l.
  simpl. apply Pos2Nat.inj_le.
- apply (le_trans _ _ _ Hmd).
+ apply (Nat.le_trans _ _ _ Hmd).
  rewrite nat_of_P_o_P_of_succ_nat_eq_succ.
  apply le_S, le_refl.
  discriminate. discriminate.

--- a/model/Zmod/ZBasics.v
+++ b/model/Zmod/ZBasics.v
@@ -122,7 +122,7 @@ Qed.
 End narith.
 
 #[global]
-Hint Resolve le_trans: zarith.
+Hint Resolve Nat.le_trans: zarith.
 #[global]
 Hint Resolve minus_n_Sk: zarith.
 #[global]

--- a/model/reals/CRreal.v
+++ b/model/reals/CRreal.v
@@ -154,7 +154,7 @@ Proof.
    apply Qpos_nonneg.
   apply ball_triangle with (f n);[|apply ball_sym]; rewrite <- CRAbsSmall_ball; apply Hn.
    auto.
-  apply le_trans with m; auto.
+  apply Nat.le_trans with m; auto.
  (*Archimedean*)
  intros x.
  assert (X:=(CR_b_upperBound (1#1) x)).

--- a/ode/SimpleIntegration.v
+++ b/ode/SimpleIntegration.v
@@ -622,7 +622,7 @@ Section implements_abstract_interface.
           with (i0 * / Zpos (w01ints * k) * proj1_sig totalw).
          apply sampling_over_subdivision...
          rewrite Pmult_comm.
-         apply lt_trans with (Pos.to_nat (i * wbints true))...
+         apply Nat.lt_trans with (Pos.to_nat (i * wbints true))...
          apply inj_lt_iff.
          rewrite Zlt_Qlt.
          do 2 rewrite ZL9.
@@ -678,7 +678,7 @@ Section implements_abstract_interface.
          ((Pos.to_nat (i * wbints true) + i0)%nat * / Zpos (intervals lmu a totalw (e * (1#2)) * k) * proj1_sig totalw).
         apply (sampling_over_subdivision f a (Pos.to_nat (i * wbints true) + i0) k (e*(1#2)) totalw).
         fold w01ints.
-        apply lt_le_trans with (Pos.to_nat (i * wbints true) + Pos.to_nat (j * wbints false)%positive)%nat...
+        apply Nat.lt_le_trans with (Pos.to_nat (i * wbints true) + Pos.to_nat (j * wbints false)%positive)%nat...
         apply inj_le_iff.
         rewrite Zle_Qle.
         rewrite inj_plus.

--- a/reals/Bridges_LUB.v
+++ b/reals/Bridges_LUB.v
@@ -558,7 +558,7 @@ Proof.
    rstepr (nring (R:=R1) m).
    astepl (nring (R:=R1) 1).
     apply nring_less.
-    apply lt_trans with (m := 3).
+    apply Nat.lt_trans with (m := 3).
      constructor.
      constructor.
     apply lt_S_n.
@@ -785,7 +785,7 @@ Proof.
  induction  n as [| n Hrecn].
   apply False_rect.
   apply (lt_n_O 0).
-  apply lt_trans with (m := 1).
+  apply Nat.lt_trans with (m := 1).
    apply lt_O_Sn.
   assumption.
  case (le_lt_eq_dec 2 (S n) (lt_le_S 1 (S n) H0)).
@@ -952,11 +952,11 @@ Proof.
    rstepl (e [/]TwoNZ[+]e [/]TwoNZ).
    apply AbsSmall_plus.
     apply H2.
-    apply le_trans with (m := N1 + N2).
+    apply Nat.le_trans with (m := N1 + N2).
      apply le_plus_l.
     assumption.
    apply H3.
-   apply le_trans with (m := N1 + N2).
+   apply Nat.le_trans with (m := N1 + N2).
     apply le_plus_r.
    assumption.
   unfold B in |- *.
@@ -1053,11 +1053,11 @@ Proof.
    rstepl (e [/]TwoNZ[+]e [/]TwoNZ).
    apply AbsSmall_plus.
     apply a.
-    apply le_trans with (m := N1 + N2).
+    apply Nat.le_trans with (m := N1 + N2).
      apply le_plus_l.
     assumption.
    apply a0.
-   apply le_trans with (m := N1 + N2).
+   apply Nat.le_trans with (m := N1 + N2).
     apply le_plus_r.
    assumption.
   unfold B in |- *.

--- a/reals/Bridges_iso.v
+++ b/reals/Bridges_iso.v
@@ -333,7 +333,7 @@ Proof.
  apply Hrecn.
  intros.
  apply H.
- apply le_trans with (m := n).
+ apply Nat.le_trans with (m := n).
   assumption.
  apply le_n_Sn.
 Qed.
@@ -356,7 +356,7 @@ Proof.
  apply Hrecn.
  intros.
  apply H.
- apply le_trans with (m := n).
+ apply Nat.le_trans with (m := n).
   assumption.
  apply le_n_Sn.
 Qed.
@@ -389,12 +389,12 @@ Proof.
    apply Hrecn.
      intros.
      apply H.
-     apply le_trans with (m := n).
+     apply Nat.le_trans with (m := n).
       assumption.
      apply le_n_Sn.
     intros.
     apply H0.
-    apply le_trans with (m := n).
+    apply Nat.le_trans with (m := n).
      assumption.
     apply le_n_Sn.
    assumption.
@@ -409,7 +409,7 @@ Proof.
  apply bound_tk1.
  intros.
  apply H.
- apply le_trans with (m := n).
+ apply Nat.le_trans with (m := n).
   assumption.
  apply le_n_Sn.
 Qed.
@@ -442,12 +442,12 @@ Proof.
    apply Hrecn.
      intros.
      apply H.
-     apply le_trans with (m := n).
+     apply Nat.le_trans with (m := n).
       assumption.
      apply le_n_Sn.
     intros.
     apply H0.
-    apply le_trans with (m := n).
+    apply Nat.le_trans with (m := n).
      assumption.
     apply le_n_Sn.
    assumption.
@@ -462,7 +462,7 @@ Proof.
  apply bound_tk2.
  intros.
  apply H.
- apply le_trans with (m := n).
+ apply Nat.le_trans with (m := n).
   assumption.
  apply le_n_Sn.
 Qed.
@@ -590,7 +590,7 @@ Proof.
 (* Case HrecN.
  Intros.
  Apply H.
- Apply le_trans with m:=N.
+ Apply Nat.le_trans with m:=N.
  Assumption.
  Apply le_n_Sn.
  Intro.
@@ -623,7 +623,7 @@ Proof.
  Elim H1.
  Intros.
  Split.
- Apply le_trans with m:=N.
+ Apply Nat.le_trans with m:=N.
  Assumption.
  Apply le_n_Sn.
  Assumption.
@@ -656,7 +656,7 @@ Proof.
  case HrecN.
    intros.
    apply H.
-   apply le_trans with (m := N).
+   apply Nat.le_trans with (m := N).
     assumption.
    apply le_n_Sn.
   intro.
@@ -687,7 +687,7 @@ Proof.
  intros.
  exists j.
   apply toCle.
-  apply le_trans with (m := N).
+  apply Nat.le_trans with (m := N).
    apply Cle_to.
    assumption.
   apply le_n_Sn.
@@ -1416,7 +1416,7 @@ Proof.
  rstepl (e [/]TwoNZ[+]e [/]TwoNZ).
  apply AbsSmall_plus.
   apply a.
-  apply le_trans with (m := m).
+  apply Nat.le_trans with (m := m).
    assumption.
   apply le_plus_r.
  apply AbsSmall_minus.
@@ -1540,7 +1540,7 @@ Proof.
     intros.
     assumption.
    apply a.
-   apply le_trans with (m := m).
+   apply Nat.le_trans with (m := m).
     assumption.
    apply le_plus_l.
   apply pos_div_two'.
@@ -1574,7 +1574,7 @@ Proof.
   apply leEq_wdl with (x := CS_seq OF (tail_seq g n) j).
    simpl in |- *.
    apply sup_tail_leEq.
-   apply le_trans with (m := n).
+   apply Nat.le_trans with (m := n).
     assumption.
    apply le_plus_l.
   apply eq_symmetric_unfolded.
@@ -1640,7 +1640,7 @@ Proof.
  intro j.
  intros.
  exists (k + N + j).
-  apply le_trans with (m := k + N).
+  apply Nat.le_trans with (m := k + N).
    apply le_plus_l.
   apply le_plus_l.
  split.
@@ -1697,14 +1697,14 @@ Proof.
   rstepr (g_ m[-]g_ N1[+](g_ N1[-]g_ Nk)).
   apply AbsSmall_plus.
    apply a.
-   apply le_trans with (m := Nk).
-    apply le_trans with (m := N1 + k).
+   apply Nat.le_trans with (m := Nk).
+    apply Nat.le_trans with (m := N1 + k).
      apply le_plus_l.
     assumption.
    assumption.
   apply AbsSmall_minus.
   apply a.
-  apply le_trans with (m := N1 + k).
+  apply Nat.le_trans with (m := N1 + k).
    apply le_plus_l.
   assumption.
  apply AbsSmall_leEq_trans with (e1 := one_div_succ (R:=OF) (N1 + k)).

--- a/reals/CReals1.v
+++ b/reals/CReals1.v
@@ -231,13 +231,13 @@ Proof.
   intros n Hn.
   exists n.
   inversion_clear Hn.
-  apply le_lt_trans with (f 0); auto with arith.
+  apply Nat.le_lt_trans with (f 0); auto with arith.
  intros n H.
  elim H; clear H; intros n' Hn'.
  elim (crescF n').
  intros i Hi; elim Hi; clear Hi; intros Hi Hi'.
  exists i.
- apply le_lt_trans with (f n'); auto.
+ apply Nat.le_lt_trans with (f n'); auto.
 Qed.
 
 (* begin hide *)
@@ -271,7 +271,7 @@ Proof.
     2: apply shift_leEq_minus; astepl (seq2 (f N)); apply H2; assumption.
    eapply leEq_wdr.
     2: apply eq_symmetric_unfolded; apply AbsIR_eq_x.
-    2: apply shift_leEq_minus; astepl (seq2 (f N)); apply H2; apply le_trans with m; auto with arith.
+    2: apply shift_leEq_minus; astepl (seq2 (f N)); apply H2; apply Nat.le_trans with m; auto with arith.
    apply minus_resp_leEq.
    apply H2; auto with arith.
   eapply leEq_wdl.
@@ -279,13 +279,13 @@ Proof.
    2: apply shift_minus_leEq; astepr (seq2 (f N)); auto.
   eapply leEq_wdr.
    2: apply eq_symmetric_unfolded; apply AbsIR_eq_inv_x.
-   2: apply shift_minus_leEq; astepr (seq2 (f N)); apply H2; apply le_trans with m; auto with arith.
+   2: apply shift_minus_leEq; astepr (seq2 (f N)); apply H2; apply Nat.le_trans with m; auto with arith.
   apply inv_resp_leEq; apply minus_resp_leEq.
   apply H2; auto with arith.
  apply leEq_wdl with (AbsIR (seq1 i[-]seq1 N)).
   apply AbsSmall_imp_AbsIR; apply HN.
   apply lt_le_weak.
-  apply mon_F'; apply le_lt_trans with m; auto.
+  apply mon_F'; apply Nat.le_lt_trans with m; auto.
  apply AbsIR_wd; algebra.
 Qed.
 
@@ -303,7 +303,7 @@ Proof.
  astepr (seq2 (f m) [-]a).
  apply HN.
  cut (f i <= f m).
-  intros; apply le_trans with (f i); auto with arith.
+  intros; apply Nat.le_trans with (f i); auto with arith.
  apply monF; assumption.
 Qed.
 

--- a/reals/CauchySeq.v
+++ b/reals/CauchySeq.v
@@ -284,12 +284,12 @@ Proof.
    exists (max N1 N2); intros.
    apply less_leEq_trans with Av.
     apply H4.
-    apply le_trans with (max N1 N2).
+    apply Nat.le_trans with (max N1 N2).
      apply le_max_l.
     assumption.
    apply less_leEq.
    apply H5.
-   apply le_trans with (max N1 N2).
+   apply Nat.le_trans with (max N1 N2).
     apply le_max_r.
    assumption.
   unfold Av in |- *.
@@ -879,11 +879,11 @@ Proof.
   rstepr (seq1 m[-]y1[+] (seq2 m[-]y2)).
   apply AbsSmall_eps_div_two.
    apply H3.
-   apply le_trans with (max x x0).
+   apply Nat.le_trans with (max x x0).
     apply le_max_l.
    assumption.
   apply H4.
-  apply le_trans with (max x x0).
+  apply Nat.le_trans with (max x x0).
    apply le_max_r.
   assumption.
  apply pos_div_two.
@@ -1005,11 +1005,11 @@ Proof.
    apply H4; clear H4; intros.
     apply AbsSmall_wdr_unfolded with ([--] (seq1 m[-]y1)).
      apply inv_resp_AbsSmall.
-     apply H. apply le_trans with N; auto.
+     apply H. apply Nat.le_trans with N; auto.
      rational.
    apply AbsSmall_wdr_unfolded with ([--] (seq2 m[-]y2)).
     apply inv_resp_AbsSmall.
-    apply H0. apply le_trans with N; auto.
+    apply H0. apply Nat.le_trans with N; auto.
     rational.
   rational.
  elim (le_lt_dec N1 N2); intros.

--- a/reals/NRootIR.v
+++ b/reals/NRootIR.v
@@ -750,11 +750,11 @@ Proof.
       apply recip_resp_leEq.
        apply pos_div_two; apply AbsIR_pos; apply Hy.
       apply Hn0.
-      apply le_trans with (max N n0); auto with arith.
+      apply Nat.le_trans with (max N n0); auto with arith.
      apply less_leEq; apply recip_resp_pos; apply AbsIR_pos; apply Hy.
     apply AbsSmall_imp_AbsIR.
     apply HN.
-    apply le_trans with (max N n0); auto with arith.
+    apply Nat.le_trans with (max N n0); auto with arith.
    apply eq_transitive_unfolded with
      (AbsIR ([1][/] _[//]Hn m) [*]AbsIR ([1][/] _[//]Hy) [*]AbsIR (y[-]seq m)).
     repeat apply mult_wd; apply eq_symmetric_unfolded.

--- a/reals/Q_dense.v
+++ b/reals/Q_dense.v
@@ -637,7 +637,7 @@ Proof.
    rstepr (nring (R:=Q_as_COrdField) m).
    astepl (nring (R:=Q_as_COrdField) 1).
    apply nring_less.
-   apply lt_trans with (m := 3).
+   apply Nat.lt_trans with (m := 3).
     constructor.
     constructor.
    apply lt_S_n.
@@ -908,7 +908,7 @@ Proof.
    apply shift_zero_less_minus.
    apply l_less_r.
   apply G_conversion_rate_resp_x.
-  apply le_trans with (m := S (N + 3)).
+  apply Nat.le_trans with (m := S (N + 3)).
    apply le_n_S.
    apply le_plus_r.
   assumption.

--- a/reals/Series.v
+++ b/reals/Series.v
@@ -168,9 +168,9 @@ Proof.
    rstepl (eps [/]TwoNZ[+]eps [/]TwoNZ).
    apply AbsSmall_plus.
     apply HN.
-    apply le_trans with (max N 1); auto with arith.
+    apply Nat.le_trans with (max N 1); auto with arith.
    apply AbsSmall_minus; apply HN.
-   apply le_trans with (max N 1); auto with arith.
+   apply Nat.le_trans with (max N 1); auto with arith.
   rational.
  eapply eq_transitive_unfolded.
   apply seq_part_sum_n; auto with arith.
@@ -562,10 +562,10 @@ Proof.
   rstepr (x m[-]x N[+] (x N[-]x (max n N))).
   rstepl (e [/]TwoNZ[+]e [/]TwoNZ).
   apply AbsSmall_plus.
-   apply HN; apply le_trans with (max n N); auto with arith.
-  apply AbsSmall_minus; apply HN; apply le_trans with (max n N); auto with arith.
+   apply HN; apply Nat.le_trans with (max n N); auto with arith.
+  apply AbsSmall_minus; apply HN; apply Nat.le_trans with (max n N); auto with arith.
  apply cg_minus_wd; apply Hn.
-  apply le_trans with (max n N); auto with arith.
+  apply Nat.le_trans with (max n N); auto with arith.
  apply le_max_l.
 Qed.
 
@@ -579,9 +579,9 @@ Proof.
  exists (max n N).
  intros.
  apply AbsSmall_wdr_unfolded with (x m[-]c).
-  apply HN; apply le_trans with (max n N); auto with arith.
+  apply HN; apply Nat.le_trans with (max n N); auto with arith.
  apply cg_minus_wd; [ apply Hn | algebra ].
- apply le_trans with (max n N); auto with arith.
+ apply Nat.le_trans with (max n N); auto with arith.
 Qed.
 
 Lemma aew_series_conv : convergent x -> convergent y.
@@ -598,22 +598,22 @@ Proof.
   apply AbsSmall_plus.
    apply HN; cut (N <= k).
     lia.
-   apply le_trans with (max n N); unfold k in |- *; auto with arith.
+   apply Nat.le_trans with (max n N); unfold k in |- *; auto with arith.
   apply AbsSmall_minus; apply HN; auto.
-  apply le_trans with (max n N); unfold k in |- *; auto with arith.
+  apply Nat.le_trans with (max n N); unfold k in |- *; auto with arith.
  cut (1 <= k); intros.
   eapply eq_transitive_unfolded.
    apply seq_part_sum_n; auto.
-   apply lt_le_trans with k; auto.
+   apply Nat.lt_le_trans with k; auto.
   eapply eq_transitive_unfolded.
    2: apply eq_symmetric_unfolded; apply seq_part_sum_n; auto.
-   2: apply lt_le_trans with k; auto.
+   2: apply Nat.lt_le_trans with k; auto.
   apply Sum_wd'.
    rewrite <- S_pred with m 0; auto with arith.
-   apply lt_le_trans with k; auto.
+   apply Nat.lt_le_trans with k; auto.
   intros; apply Hn.
-  apply le_trans with (max n N); auto with arith.
-  apply le_trans with k; unfold k in |- *; auto with arith.
+  apply Nat.le_trans with (max n N); auto with arith.
+  apply Nat.le_trans with k; unfold k in |- *; auto with arith.
  unfold k in |- *; apply le_max_r.
 Qed.
 
@@ -673,18 +673,18 @@ Proof.
    apply leEq_transitive with (Sum N (pred m) (fun n : nat => AbsIR (x n))).
     apply leEq_wdl with (AbsIR (Sum N (pred m) x)).
      2: apply AbsIR_wd; apply eq_symmetric_unfolded; apply seq_part_sum_n; auto.
-     2: apply lt_le_trans with N; auto; apply le_lt_trans with k; auto with arith.
+     2: apply Nat.lt_le_trans with N; auto; apply Nat.le_lt_trans with k; auto with arith.
     apply triangle_SumIR.
     rewrite <- (S_pred m k); auto with arith.
-    apply lt_le_trans with N; auto.
+    apply Nat.lt_le_trans with N; auto.
    eapply leEq_wdr.
     2: apply eq_symmetric_unfolded; apply seq_part_sum_n; auto.
-    2: apply le_lt_trans with k; auto with arith; apply lt_le_trans with N; auto.
+    2: apply Nat.le_lt_trans with k; auto with arith; apply Nat.lt_le_trans with N; auto.
    apply Sum_resp_leEq.
     rewrite <- (S_pred m k); auto with arith.
-    apply lt_le_trans with N; auto.
+    apply Nat.lt_le_trans with N; auto.
    intros.
-   apply Hk; apply le_trans with N; auto with arith.
+   apply Hk; apply Nat.le_trans with N; auto with arith.
   eapply leEq_transitive.
    apply leEq_AbsIR.
   apply AbsSmall_imp_AbsIR.
@@ -699,7 +699,7 @@ Proof.
  rstepr (seq_part_sum y m[-]seq_part_sum y N[+] (seq_part_sum y N[-]seq_part_sum y (S (max N k)))).
  rstepl (e [/]TwoNZ[+]e [/]TwoNZ).
  apply AbsSmall_plus.
-  apply HN; apply le_trans with (max N k); auto with arith.
+  apply HN; apply Nat.le_trans with (max N k); auto with arith.
  apply AbsSmall_minus; apply HN; auto with arith.
 Qed.
 
@@ -764,7 +764,7 @@ Proof.
     (seq_part_sum y M[-]seq_part_sum y (S (max N M) + k))).
   apply AbsSmall_plus.
    apply HM.
-   apply le_trans with (max N M); auto with arith.
+   apply Nat.le_trans with (max N M); auto with arith.
   apply AbsSmall_minus.
   apply HM.
   auto with arith.
@@ -773,18 +773,18 @@ Proof.
   unfold Sum, Sum1 in |- *.
   rewrite <- S_pred with (m := 0).
    algebra.
-  apply lt_le_trans with (S (max N M)); auto with arith.
+  apply Nat.lt_le_trans with (S (max N M)); auto with arith.
  astepr (Sum (S (max N M)) (pred m) x).
   2: unfold Sum, Sum1 in |- *.
   2: rewrite <- S_pred with (m := 0).
    2: algebra.
-  2: apply lt_le_trans with (S (max N M)); auto with arith.
+  2: apply Nat.lt_le_trans with (S (max N M)); auto with arith.
  replace (pred (m + k)) with (pred m + k).
   apply eq_symmetric_unfolded; apply Sum_big_shift.
    intros; apply HN.
-   apply le_trans with (max N M); auto with arith.
+   apply Nat.le_trans with (max N M); auto with arith.
   rewrite <- S_pred with (m := 0); auto.
-  apply lt_le_trans with (S (max N M)); auto with arith.
+  apply Nat.lt_le_trans with (S (max N M)); auto with arith.
  lia.
 Qed.
 
@@ -806,16 +806,16 @@ Proof.
    apply HM.
    apply (fun p n m : nat => plus_le_reg_l n m p) with k.
    rewrite <- le_plus_minus.
-    apply le_trans with (max N M + k); auto with arith.
+    apply Nat.le_trans with (max N M + k); auto with arith.
     rewrite plus_comm; auto with arith.
-   apply le_trans with (S (max N M + k)); auto with arith.
+   apply Nat.le_trans with (S (max N M + k)); auto with arith.
   apply AbsSmall_minus.
   apply HM.
   apply (fun p n m : nat => plus_le_reg_l n m p) with k.
   rewrite <- le_plus_minus.
-   apply le_trans with (max N M + k); auto.
+   apply Nat.le_trans with (max N M + k); auto.
    rewrite plus_comm; auto with arith.
-  apply le_trans with (S (max N M + k)); auto with arith.
+  apply Nat.le_trans with (S (max N M + k)); auto with arith.
  unfold seq_part_sum in |- *.
  apply eq_transitive_unfolded with (Sum (S (max N M + k) - k) (pred (m - k)) x).
   unfold Sum, Sum1 in |- *.
@@ -833,11 +833,11 @@ Proof.
   2: lia.
  apply Sum_big_shift.
   intros; apply HN.
-  apply le_trans with (max N M); auto with arith.
+  apply Nat.le_trans with (max N M); auto with arith.
   lia.
  rewrite <- S_pred with (m := 0); auto.
   lia.
- apply lt_le_trans with (S (max N M)); auto with arith.
+ apply Nat.lt_le_trans with (S (max N M)); auto with arith.
  lia.
 Qed.
 
@@ -919,7 +919,7 @@ Proof.
   intro n.
   cut (S N <= max (S N) n); [ intro | apply le_max_l ].
   elim (H _ H0); intros m Hm; elim Hm; clear H Hm; intros Hm H; exists m.
-   apply le_trans with (max (S N) n); auto with arith.
+   apply Nat.le_trans with (max (S N) n); auto with arith.
   assumption.
  intros; exists n.
  split.
@@ -1225,7 +1225,7 @@ Proof.
   elim (even_odd_dec N); intro.
    apply AbsIR_wd.
    eapply eq_transitive_unfolded.
-    apply seq_part_sum_n; auto; apply lt_le_trans with N; auto.
+    apply seq_part_sum_n; auto; apply Nat.lt_le_trans with N; auto.
    eapply eq_transitive_unfolded.
     2: apply Sum_comm_scal'.
    apply Sum_wd.
@@ -1241,7 +1241,7 @@ Proof.
    2: apply eq_symmetric_unfolded; apply AbsIR_inv.
   apply AbsIR_wd.
   eapply eq_transitive_unfolded.
-   apply seq_part_sum_n; auto; apply lt_le_trans with N; auto.
+   apply seq_part_sum_n; auto; apply Nat.lt_le_trans with N; auto.
   rstepr ( [--] ( [--][1][^]N) [*]Sum N (pred m) y).
   eapply eq_transitive_unfolded.
    2: apply Sum_comm_scal'.

--- a/reals/fast/CRGeometricSum.v
+++ b/reals/fast/CRGeometricSum.v
@@ -210,7 +210,7 @@ Proof.
     assert (forall p : nat, (p < 2 ^ fuel)%nat -> filter (Str_nth_tl p s) = false) as firstHalf.
     { intros. apply (H p).
       simpl. rewrite Nat.add_0_r.
-      apply (lt_le_trans _ (0+2^fuel)).
+      apply (Nat.lt_le_trans _ (0+2^fuel)).
       exact H0. apply Nat.add_le_mono_r, le_0_n. }
     rewrite IHfuel, IHfuel.
     3: exact firstHalf.
@@ -273,14 +273,14 @@ Proof.
       rewrite (@InfiniteSum_fat_add_stop _ p).
       3: exact H0.
       rewrite <- (@InfiniteSum_fat_add_stop (2^fuel)).
-      2: apply (le_trans _ (S p) _ (le_S _ _ (le_refl p)) H).
+      2: apply (Nat.le_trans _ (S p) _ (le_S _ _ (le_refl p)) H).
       2: exact H0.
       rewrite <- IHfuel.
       apply (@InfiniteSum_raw_N_cont_invariant fuel p).
       exact H. exact H0.
-      apply (le_trans _ (2^fuel + 0)).
+      apply (Nat.le_trans _ (2^fuel + 0)).
       rewrite Nat.add_0_r.
-      apply (le_trans _ (S p) _ (le_S _ _ (le_refl p)) H).
+      apply (Nat.le_trans _ (S p) _ (le_S _ _ (le_refl p)) H).
       apply Nat.add_le_mono_l, le_0_n.
     + rewrite InfiniteSum_fat_add_pass. 2: exact H.
       rewrite <- IHfuel. rewrite <- IHfuel.

--- a/reals/fast/CRcorrect.v
+++ b/reals/fast/CRcorrect.v
@@ -179,8 +179,8 @@ Proof.
  autorewrite with QposElim.
  repeat (eapply AbsSmall_plus).
    apply AbsSmall_minus.
-   apply Ha;unfold n;apply le_trans with (max a b); auto with *.
-  apply Hb; unfold n;apply le_trans with (max a b); auto with *.
+   apply Ha;unfold n;apply Nat.le_trans with (max a b); auto with *.
+  apply Hb; unfold n;apply Nat.le_trans with (max a b); auto with *.
  apply Hc; unfold n;auto with *.
 Qed.
 
@@ -256,13 +256,13 @@ Proof.
    rewrite Zpos_eq_Z_of_nat_o_nat_of_P.
    apply inj_lt.
    apply le_lt_n_Sm.
-   apply le_trans with (max n (nat_of_P ed));auto with *.
+   apply Nat.le_trans with (max n (nat_of_P ed));auto with *.
   change (1*P_of_succ_nat m <= en * P_of_succ_nat m)%Z.
   apply Zmult_lt_0_le_compat_r;auto with *.
  stepl ((1#2)*(Z.pos en#ed)+(1#2)*(Z.pos en#ed))%Q; [| simpl; ring].
  rstepr ((x m[-]x n)[+](x n[-]x n')).
  assert (Y:n <= m).
-  apply le_trans with (max n (nat_of_P ed));auto with *.
+  apply Nat.le_trans with (max n (nat_of_P ed));auto with *.
  apply AbsSmall_plus.
   apply Hn.
   assumption.
@@ -490,8 +490,8 @@ Proof.
   simpl in H2.
   set (m:=max n (max n1 n2)).
   assert (m1:n<=m);[unfold m; auto with *|].
-  assert (m2:n1<=m);[unfold m; apply le_trans with (max n1 n2); auto with *|].
-  assert (m3:n2<=m);[unfold m; apply le_trans with (max n1 n2); auto with *|].
+  assert (m2:n1<=m);[unfold m; apply Nat.le_trans with (max n1 n2); auto with *|].
+  assert (m3:n2<=m);[unfold m; apply Nat.le_trans with (max n1 n2); auto with *|].
   apply (Qle_not_lt _ _ H1').
   eapply inv_cancel_less;simpl.
   clear H1'.
@@ -532,10 +532,10 @@ Proof.
  stepl (-((1 # 2) * proj1_sig e) + - ((1 # 2) * proj1_sig e))%Q; [| simpl; ring].
  apply plus_resp_leEq_both.
   refine (proj1 (Hn2 _ _)).
-  apply le_trans with n; [unfold n;auto with *|assumption].
+  apply Nat.le_trans with n; [unfold n;auto with *|assumption].
  apply inv_resp_leEq.
  refine (proj2 (Hn1 _ _)).
- apply le_trans with n; [unfold n;auto with *|assumption].
+ apply Nat.le_trans with n; [unfold n;auto with *|assumption].
 Qed.
 
 #[global]
@@ -587,15 +587,15 @@ Proof.
    apply Qpos_ispos.
    stepl (((1#2)*proj1_sig e/ proj1_sig z)* proj1_sig z)%Q;
      [| simpl;field;apply Qpos_nonzero].
-  apply mult_AbsSmall;[apply Hn1|apply Hz]; unfold n; apply le_trans with (max n1 N); auto with *.
+  apply mult_AbsSmall;[apply Hn1|apply Hz]; unfold n; apply Nat.le_trans with (max n1 N); auto with *.
  intros w Hw.
  simpl.
  destruct (Hy (proj1_sig w) (Qpos_ispos w)) as [n2 Hn2].
  pose (n:=(max (max n1 n2) (max n3 N))).
- assert (n1 <= n);[unfold n; apply le_trans with (max n1 n2); auto with *|].
- assert (n2 <= n);[unfold n; apply le_trans with (max n1 n2); auto with *|].
- assert (n3 <= n);[unfold n; apply le_trans with (max n3 N); auto with *|].
- assert (N <= n);[unfold n; apply le_trans with (max n3 N); auto with *|].
+ assert (n1 <= n);[unfold n; apply Nat.le_trans with (max n1 n2); auto with *|].
+ assert (n2 <= n);[unfold n; apply Nat.le_trans with (max n1 n2); auto with *|].
+ assert (n3 <= n);[unfold n; apply Nat.le_trans with (max n3 N); auto with *|].
+ assert (N <= n);[unfold n; apply Nat.le_trans with (max n3 N); auto with *|].
  change (Qball (proj1_sig e+proj1_sig e))
    with (@ball Q_as_MetricSpace (proj1_sig e + proj1_sig e)).
  apply ball_triangle with (x n * y n)%Q;[|eapply Hn3; assumption].
@@ -817,7 +817,7 @@ Proof.
  simpl in y.
  set (m:=max (max a n) (max b c)).
  assert (Hm1: c<=m).
-  unfold m; apply le_trans with (max b c); auto with *.
+  unfold m; apply Nat.le_trans with (max b c); auto with *.
  change (@ball Q_as_MetricSpace (proj1_sig e+proj1_sig e) (/ Qmax (proj1_sig z) (x b))%Q (y c)).
  apply ball_triangle with (y m);[|eapply Hc;assumption].
  clear Hc.
@@ -825,7 +825,7 @@ Proof.
  destruct (lt_le_dec m a) as [Z|Z].
   elim (le_not_lt _ _ Z).
   unfold m.
-  apply lt_le_trans with (S (max a n)); auto with *.
+  apply Nat.lt_le_trans with (S (max a n)); auto with *.
  change (AbsSmall (proj1_sig e) (/ Qmax (proj1_sig z) (x b)-1 * / x m))%Q.
  clear y.
  assert (T:(~ (x m == 0)%Q /\ ~ (Qmax (proj1_sig z) (x b) == 0)%Q)).
@@ -833,7 +833,7 @@ Proof.
    apply Qlt_le_trans with (proj1_sig z).
     apply Qpos_ispos.
    apply Hn.
-   apply le_trans with (max a n).
+   apply Nat.le_trans with (max a n).
     auto with *.
    unfold m; auto with *.
   apply Qlt_le_trans with (proj1_sig z); auto with *.
@@ -853,22 +853,22 @@ Proof.
   apply Qle_trans with (proj1_sig z).
    apply Qpos_nonneg.
   apply Hn.
-  apply le_trans with (max a n); unfold m; auto with *.
+  apply Nat.le_trans with (max a n); unfold m; auto with *.
  simpl in x_.
  apply (AbsSmall_leEq_trans _ (proj1_sig z*proj1_sig z*proj1_sig e)%Q).
   apply mult_resp_leEq_rht;[apply mult_resp_leEq_both|]; try apply Qpos_nonneg.
    apply Qmax_ub_l.
   apply Hn.
-  apply le_trans with (max a n); unfold m; auto with *.
+  apply Nat.le_trans with (max a n); unfold m; auto with *.
  assert (W:AbsSmall (R:=Q_as_COrdField) (proj1_sig z * proj1_sig z * proj1_sig e)%Q (x m - x b)%Q).
   apply Hb.
-  apply le_trans with (max b c); unfold m; auto with *.
+  apply Nat.le_trans with (max b c); unfold m; auto with *.
  apply Qmax_case;intros C;[|assumption].
  apply leEq_imp_AbsSmall.
   unfold Qminus.
   rewrite <- Qle_minus_iff.
   apply Hn.
-  apply le_trans with (max a n); unfold m; auto with *.
+  apply Nat.le_trans with (max a n); unfold m; auto with *.
  apply Qle_trans with (x m - x b)%Q.
   rewrite -> Qle_minus_iff.
   stepr (proj1_sig z + - x b)%Q; [| simpl; ring].

--- a/reals/fast/CRexp.v
+++ b/reals/fast/CRexp.v
@@ -145,7 +145,7 @@ Proof.
   apply Pos2Nat.inj_le.
   rewrite Nat2Pos.id.
   2: apply fact_neq_0.
-  refine (le_trans _ _ _ _ H).
+  refine (Nat.le_trans _ _ _ _ H).
   clear H. generalize p.
   apply Pos.peano_ind.
   + apply le_refl.

--- a/reals/fast/MultivariatePolynomials.v
+++ b/reals/fast/MultivariatePolynomials.v
@@ -271,7 +271,7 @@ Proof.
   change (L[<=]R).
   rstepr (R[*][1]).
   rewrite <- (@one_MVP_apply Q_as_CRing _ (Vector.cons _ a _ v0)).
-  stepr (R[*](@MVP_apply Q_as_CRing (S n) (@Sumx (cpoly_cring _) _ (fun i H => Bernstein _ (lt_n_Sm_le i m (lt_le_trans _ _ _ H (le_refl _))))) (Vector.cons _ a _ v0))).
+  stepr (R[*](@MVP_apply Q_as_CRing (S n) (@Sumx (cpoly_cring _) _ (fun i H => Bernstein _ (lt_n_Sm_le i m (Nat.lt_le_trans _ _ _ H (le_refl _))))) (Vector.cons _ a _ v0))).
    fold (MultivariatePolynomial Q_as_CRing n).
    unfold L, R; clear L R.
    generalize (le_refl (S m)).
@@ -290,22 +290,22 @@ Proof.
    simpl (evalBernsteinBasisH (MultivariatePolynomial Q_as_CRing n)
      (Vector.cons (MultivariatePolynomial Q_as_CRing n) a0 n1 b) l).
    simpl (Sumx (fun (i : nat) (H : (i < S n1)%nat) => Bernstein (MultivariatePolynomial Q_as_CRing n)
-     (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) H l)))).
+     (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) H l)))).
    do 2 rewrite -> MVP_plus_apply.
    rewrite ->  (Qplus_comm (@MVP_apply Q_as_CRing (S n) (Sumx (fun (i : nat) (l0 : (i < n1)%nat) =>
      Bernstein (MultivariatePolynomial Q_as_CRing n)
-       (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) (lt_S i n1 l0) l)))) (Vector.cons Q a n v0))).
+       (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) (lt_S i n1 l0) l)))) (Vector.cons Q a n v0))).
    rewrite -> Qmult_comm.
    rewrite -> Qmult_plus_distr_l.
    apply Qplus_le_compat; rewrite -> Qmult_comm; rewrite -> Qmax_mult_pos_distr_l.
       replace LHS with (MVP_apply Q_as_CRing a0 v0 * @MVP_apply Q_as_CRing (S n)
         (Bernstein (MultivariatePolynomial Q_as_CRing n)
-          (lt_n_Sm_le n1 m (lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))) (Vector.cons _ a _ v0)).
+          (lt_n_Sm_le n1 m (Nat.lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))) (Vector.cons _ a _ v0)).
        apply Qmax_ub_l.
       simpl.
       rewrite <- (MVP_mult_apply Q_as_CRing).
       apply: MVP_apply_wd; try reflexivity.
-      replace (lt_n_Sm_le n1 m (lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))
+      replace (lt_n_Sm_le n1 m (Nat.lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))
         with (Le.le_S_n n1 m l) by apply le_irrelevent.
       apply c_mult_apply.
      apply MVP_BernsteinNonNeg; auto.
@@ -317,32 +317,32 @@ Proof.
             Qmax (MVP_apply Q_as_CRing c v0) rec) n1 b) in *.
     replace RHS with (R*@MVP_apply Q_as_CRing (S n) (Sumx (fun (i : nat) (l0 : (i < n1)%nat) =>
       Bernstein (MultivariatePolynomial Q_as_CRing n)
-        (lt_n_Sm_le i m (lt_le_trans i n1 (S m) l0 (le_Sn_le _ _ l))))) (Vector.cons _ a _ v0)).
+        (lt_n_Sm_le i m (Nat.lt_le_trans i n1 (S m) l0 (le_Sn_le _ _ l))))) (Vector.cons _ a _ v0)).
      apply IHb.
     apply: mult_wdr.
     apply MVP_apply_wd; try reflexivity.
     apply Sumx_wd.
     intros i H.
-    replace (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) (lt_S i n1 H) l))
-      with (lt_n_Sm_le i m (lt_le_trans i n1 (S m) H (le_Sn_le n1 (S m) l))) by apply le_irrelevent.
+    replace (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) (lt_S i n1 H) l))
+      with (lt_n_Sm_le i m (Nat.lt_le_trans i n1 (S m) H (le_Sn_le n1 (S m) l))) by apply le_irrelevent.
     reflexivity.
    clear - Ha0 Ha1.
    induction n1.
     rewrite -> zero_MVP_apply.
     auto with *.
    simpl (Sumx (fun (i : nat) (l0 : (i < S n1)%nat) => Bernstein (MultivariatePolynomial Q_as_CRing n)
-     (lt_n_Sm_le i m (lt_le_trans i (S (S n1)) (S m) (lt_S i (S n1) l0) l)))).
+     (lt_n_Sm_le i m (Nat.lt_le_trans i (S (S n1)) (S m) (lt_S i (S n1) l0) l)))).
    rewrite -> MVP_plus_apply.
    apply: plus_resp_nonneg.
     stepr (@MVP_apply Q_as_CRing (S n) (Sumx (fun (i : nat) (l0 : (i < n1)%nat) =>
       Bernstein (MultivariatePolynomial Q_as_CRing n)
-        (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) (lt_S i n1 l0) (le_Sn_le _ _ l))))) (Vector.cons _ a _ v0)).
+        (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) (lt_S i n1 l0) (le_Sn_le _ _ l))))) (Vector.cons _ a _ v0)).
      apply IHn1.
     apply MVP_apply_wd; try reflexivity.
     apply Sumx_wd.
     intros i H.
-    replace (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) (lt_S i n1 H) (le_Sn_le (S n1) (S m) l)))
-      with (lt_n_Sm_le i m (lt_le_trans i (S (S n1)) (S m) (lt_S i (S n1) (lt_S i n1 H)) l))
+    replace (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) (lt_S i n1 H) (le_Sn_le (S n1) (S m) l)))
+      with (lt_n_Sm_le i m (Nat.lt_le_trans i (S (S n1)) (S m) (lt_S i (S n1) (lt_S i n1 H)) l))
         by apply le_irrelevent.
     reflexivity.
    apply MVP_BernsteinNonNeg; auto with *.
@@ -352,7 +352,7 @@ Proof.
   rewrite <- (fun X => partitionOfUnity X m).
   apply Sumx_wd.
   intros i H.
-  replace (lt_n_Sm_le i m (lt_le_trans i (S m) (S m) H (le_refl (S m))))
+  replace (lt_n_Sm_le i m (Nat.lt_le_trans i (S m) (S m) H (le_refl (S m))))
     with (lt_n_Sm_le i m H) by apply le_irrelevent.
   reflexivity.
  clear - IHn Hv.
@@ -399,7 +399,7 @@ Proof.
  change (R[<=]L).
  rstepl (R[*][1]).
  rewrite <- (@one_MVP_apply Q_as_CRing _ (Vector.cons _ a _ v0)).
- stepl (R[*](@MVP_apply Q_as_CRing (S n) (@Sumx (cpoly_cring _) _ (fun i H => Bernstein _ (lt_n_Sm_le i m (lt_le_trans _ _ _ H (le_refl _))))) (Vector.cons _ a _ v0))).
+ stepl (R[*](@MVP_apply Q_as_CRing (S n) (@Sumx (cpoly_cring _) _ (fun i H => Bernstein _ (lt_n_Sm_le i m (Nat.lt_le_trans _ _ _ H (le_refl _))))) (Vector.cons _ a _ v0))).
   fold (MultivariatePolynomial Q_as_CRing n).
   unfold L, R; clear L R.
   generalize (le_refl (S m)).
@@ -418,22 +418,22 @@ Proof.
   simpl (evalBernsteinBasisH (MultivariatePolynomial Q_as_CRing n)
     (Vector.cons _ a0 _ b) l).
   simpl (Sumx (fun (i : nat) (H : (i < S n1)%nat) => Bernstein (MultivariatePolynomial Q_as_CRing n)
-    (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) H l)))).
+    (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) H l)))).
   do 2 rewrite -> MVP_plus_apply.
   rewrite ->  (Qplus_comm (@MVP_apply Q_as_CRing (S n) (Sumx (fun (i : nat) (l0 : (i < n1)%nat) =>
     Bernstein (MultivariatePolynomial Q_as_CRing n)
-      (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) (lt_S i n1 l0) l)))) (Vector.cons _ a _ v0))).
+      (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) (lt_S i n1 l0) l)))) (Vector.cons _ a _ v0))).
   rewrite ->  Qmult_comm.
   rewrite -> Qmult_plus_distr_l.
   apply Qplus_le_compat; rewrite -> Qmult_comm; rewrite -> Qmin_mult_pos_distr_l.
      replace RHS with (MVP_apply Q_as_CRing a0 v0 * @MVP_apply Q_as_CRing (S n)
        (Bernstein (MultivariatePolynomial Q_as_CRing n)
-         (lt_n_Sm_le n1 m (lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))) (Vector.cons _ a _ v0)).
+         (lt_n_Sm_le n1 m (Nat.lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))) (Vector.cons _ a _ v0)).
       apply Qmin_lb_l.
      simpl.
      rewrite <- (MVP_mult_apply Q_as_CRing).
      apply: MVP_apply_wd; try reflexivity.
-     replace (lt_n_Sm_le n1 m (lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))
+     replace (lt_n_Sm_le n1 m (Nat.lt_le_trans n1 (S n1) (S m) (lt_n_Sn n1) l))
        with (Le.le_S_n n1 m l) by apply le_irrelevent.
      apply c_mult_apply.
     apply MVP_BernsteinNonNeg; auto.
@@ -445,32 +445,32 @@ Proof.
            Qmin (MVP_apply Q_as_CRing c v0) rec) n1 b) in *.
    replace LHS with (R*@MVP_apply Q_as_CRing (S n) (Sumx (fun (i : nat) (l0 : (i < n1)%nat) =>
      Bernstein (MultivariatePolynomial Q_as_CRing n)
-       (lt_n_Sm_le i m (lt_le_trans i n1 (S m) l0 (le_Sn_le _ _ l))))) (Vector.cons _ a _ v0)).
+       (lt_n_Sm_le i m (Nat.lt_le_trans i n1 (S m) l0 (le_Sn_le _ _ l))))) (Vector.cons _ a _ v0)).
     apply IHb.
    apply: mult_wdr.
    apply MVP_apply_wd; try reflexivity.
    apply Sumx_wd.
    intros i H.
-   replace (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) (lt_S i n1 H) l))
-     with (lt_n_Sm_le i m (lt_le_trans i n1 (S m) H (le_Sn_le n1 (S m) l))) by apply le_irrelevent.
+   replace (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) (lt_S i n1 H) l))
+     with (lt_n_Sm_le i m (Nat.lt_le_trans i n1 (S m) H (le_Sn_le n1 (S m) l))) by apply le_irrelevent.
    reflexivity.
   clear - Ha0 Ha1.
   induction n1.
    rewrite -> zero_MVP_apply.
    auto with *.
   simpl (Sumx (fun (i : nat) (l0 : (i < S n1)%nat) => Bernstein (MultivariatePolynomial Q_as_CRing n)
-    (lt_n_Sm_le i m (lt_le_trans i (S (S n1)) (S m) (lt_S i (S n1) l0) l)))).
+    (lt_n_Sm_le i m (Nat.lt_le_trans i (S (S n1)) (S m) (lt_S i (S n1) l0) l)))).
   rewrite -> MVP_plus_apply.
   apply: plus_resp_nonneg.
    stepr (@MVP_apply Q_as_CRing (S n) (Sumx (fun (i : nat) (l0 : (i < n1)%nat) =>
      Bernstein (MultivariatePolynomial Q_as_CRing n)
-       (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) (lt_S i n1 l0) (le_Sn_le _ _ l))))) (Vector.cons _ a _ v0)).
+       (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) (lt_S i n1 l0) (le_Sn_le _ _ l))))) (Vector.cons _ a _ v0)).
     apply IHn1.
    apply MVP_apply_wd; try reflexivity.
    apply Sumx_wd.
    intros i H.
-   replace (lt_n_Sm_le i m (lt_le_trans i (S n1) (S m) (lt_S i n1 H) (le_Sn_le (S n1) (S m) l)))
-     with (lt_n_Sm_le i m (lt_le_trans i (S (S n1)) (S m) (lt_S i (S n1) (lt_S i n1 H)) l))
+   replace (lt_n_Sm_le i m (Nat.lt_le_trans i (S n1) (S m) (lt_S i n1 H) (le_Sn_le (S n1) (S m) l)))
+     with (lt_n_Sm_le i m (Nat.lt_le_trans i (S (S n1)) (S m) (lt_S i (S n1) (lt_S i n1 H)) l))
        by apply le_irrelevent.
    reflexivity.
   apply MVP_BernsteinNonNeg; auto with *.
@@ -480,7 +480,7 @@ Proof.
  rewrite <- (fun X => partitionOfUnity X m).
  apply Sumx_wd.
  intros i H.
- replace (lt_n_Sm_le i m (lt_le_trans i (S m) (S m) H (le_refl (S m))))
+ replace (lt_n_Sm_le i m (Nat.lt_le_trans i (S m) (S m) H (le_refl (S m))))
    with (lt_n_Sm_le i m H) by apply le_irrelevent.
  reflexivity.
 Qed.

--- a/reals/fast/Plot.v
+++ b/reals/fast/Plot.v
@@ -419,7 +419,7 @@ Proof.
     rewrite <- Qmult_assoc.
     setoid_replace ((1 # m) * inject_Z (Z.pos m)) with 1%Q by reflexivity.
     rewrite Qmult_1_r. ring.
-    apply (le_trans _ (S j)).
+    apply (Nat.le_trans _ (S j)).
     apply le_S, le_refl. exact ltjm. 
   - unfold canonical_names.equiv, stdlib_rationals.Q_eq.
     rewrite Nat2Z.inj_sub.
@@ -433,6 +433,6 @@ Proof.
     rewrite <- Qmult_assoc.
     setoid_replace ((1 # n) * inject_Z (Z.pos n)) with 1%Q by reflexivity.
     rewrite Qmult_1_r. ring.
-    apply (le_trans _ (S i)).
+    apply (Nat.le_trans _ (S i)).
     apply le_S, le_refl. exact ltin.
 Qed.

--- a/reals/fast/RasterQ.v
+++ b/reals/fast/RasterQ.v
@@ -244,7 +244,7 @@ Proof.
  destruct H as [i [ilt H]].
  rewrite combine_length, map_length, iterateN_succ_length in ilt.
  assert (i < Pos.to_nat m)%nat.
- { apply (lt_le_trans _ _ _ ilt), Nat.le_min_l. }
+ { apply (Nat.lt_le_trans _ _ _ ilt), Nat.le_min_l. }
  clear ilt.
  rewrite combine_nth in H.
  2: rewrite map_length, iterateN_succ_length, H1; reflexivity.
@@ -264,7 +264,7 @@ Proof.
  inversion H. clear H H4 x.
  rewrite combine_length, map_length, iterateN_succ_length in jlt.
  assert (j < Pos.to_nat n)%nat.
- { apply (lt_le_trans _ _ _ jlt). apply Nat.le_min_l. }
+ { apply (Nat.lt_le_trans _ _ _ jlt). apply Nat.le_min_l. }
  clear jlt.
  exists (i,j). split.
  - simpl.

--- a/reals/iso_CReals.v
+++ b/reals/iso_CReals.v
@@ -94,11 +94,11 @@ Proof.
        apply inv_resp_leEq.
        assumption.
       apply H3.
-      apply le_trans with (m := N1 + N2).
+      apply Nat.le_trans with (m := N1 + N2).
        apply le_plus_l.
       assumption.
      apply H5.
-     apply le_trans with (m := N1 + N2).
+     apply Nat.le_trans with (m := N1 + N2).
       apply le_plus_r.
      assumption.
     apply H1.
@@ -384,11 +384,11 @@ Proof.
       apply AbsSmall_plus.
        apply AbsSmall_minus.
        apply H6.
-       apply le_trans with (m := N1 + N2).
+       apply Nat.le_trans with (m := N1 + N2).
         apply le_plus_l.
        assumption.
       apply H7.
-      apply le_trans with (m := N1 + N2).
+      apply Nat.le_trans with (m := N1 + N2).
        apply le_plus_r.
       assumption.
      apply H4.
@@ -438,12 +438,12 @@ Proof.
      astepr (CS_seq IR g m[-]Lim g[+](Lim h[-]CS_seq IR h m)).
       apply AbsSmall_plus.
        apply H5.
-       apply le_trans with (m := N1 + N2).
+       apply Nat.le_trans with (m := N1 + N2).
         apply le_plus_l.
        assumption.
       apply AbsSmall_minus.
       apply H6.
-      apply le_trans with (m := N1 + N2).
+      apply Nat.le_trans with (m := N1 + N2).
        apply le_plus_r.
       assumption.
      apply eq_transitive_unfolded with (y := CS_seq IR g m[-]CS_seq IR h m[+](Lim h[-]Lim g)).
@@ -599,11 +599,11 @@ Proof.
    rstepl (e [/]TwoNZ[+]e [/]TwoNZ).
    apply AbsSmall_plus.
     apply H3.
-    apply le_trans with (m := N1 + N2).
+    apply Nat.le_trans with (m := N1 + N2).
      apply le_plus_l.
     assumption.
    apply H5.
-   apply le_trans with (m := N1 + N2).
+   apply Nat.le_trans with (m := N1 + N2).
     apply le_plus_r.
    assumption.
   apply (ax_Lim _ _ (crl_proof IR) h).
@@ -673,20 +673,20 @@ Proof.
            change (AbsSmall (inj_Q IR (e [/]ThreeNZ)) (CS_seq IR (inj_Q_G_as_CauchySeq IR (x[+]y)) m[-](x[+]y)))
              in |- *.
            apply H8.
-           apply le_trans with (m := K + (N1 + N2)).
+           apply Nat.le_trans with (m := K + (N1 + N2)).
             apply le_plus_l.
            assumption.
           apply AbsSmall_minus.
           change (AbsSmall (inj_Q IR (e [/]ThreeNZ)) (CS_seq IR (inj_Q_G_as_CauchySeq IR x) m[-]x)) in |- *.
           apply a.
-          apply le_trans with (m := K + (N1 + N2)).
+          apply Nat.le_trans with (m := K + (N1 + N2)).
            rewrite -> plus_permute with (m := N1).
            apply le_plus_l.
           assumption.
          apply AbsSmall_minus.
          change (AbsSmall (inj_Q IR (e [/]ThreeNZ)) (CS_seq IR (inj_Q_G_as_CauchySeq IR y) m[-]y)) in |- *.
          apply H5.
-         apply le_trans with (m := K + (N1 + N2)).
+         apply Nat.le_trans with (m := K + (N1 + N2)).
           rewrite -> plus_comm with (m := N2).
           rewrite -> plus_permute with (m := N2).
           apply le_plus_l.
@@ -827,20 +827,20 @@ Proof.
    apply AbsSmall_plus.
     apply AbsSmall_mult.
      apply H5.
-     apply le_trans with (m := N1 + (N2 + M1)).
+     apply Nat.le_trans with (m := N1 + (N2 + M1)).
       rewrite -> plus_comm with (m := M1).
       rewrite -> plus_permute with (m := M1).
       apply le_plus_l.
      assumption.
     apply H12.
-    apply le_trans with (m := N1 + (N2 + M1)).
+    apply Nat.le_trans with (m := N1 + (N2 + M1)).
      rewrite -> plus_permute with (m := N2).
      apply le_plus_l.
     assumption.
    apply AbsSmall_mult.
     assumption.
    apply H11.
-   apply le_trans with (m := N1 + (N2 + M1)).
+   apply Nat.le_trans with (m := N1 + (N2 + M1)).
     apply le_plus_l.
    assumption.
   apply Greater_imp_ap.
@@ -954,7 +954,7 @@ Proof.
          unfold inj_Q_G_as_CauchySeq in H14.
          unfold CS_seq at 1 in H14.
          apply H14.
-         apply le_trans with (m := N1 + (N2 + (N3 + M1))).
+         apply Nat.le_trans with (m := N1 + (N2 + (N3 + M1))).
           rewrite -> plus_permute with (m := N3).
           rewrite -> plus_permute with (m := N3).
           apply le_plus_l.
@@ -969,14 +969,14 @@ Proof.
         unfold inj_Q_G_as_CauchySeq in H13.
         unfold CS_seq at 1 in H13.
         apply H13.
-        apply le_trans with (m := N1 + (N2 + (N3 + M1))).
+        apply Nat.le_trans with (m := N1 + (N2 + (N3 + M1))).
          rewrite ->  plus_permute with (m := N2).
          apply le_plus_l.
         assumption.
        apply AbsSmall_mult.
         apply inj_Q_AbsSmall.
         apply H6.
-        apply le_trans with (m := N1 + (N2 + (N3 + M1))).
+        apply Nat.le_trans with (m := N1 + (N2 + (N3 + M1))).
          rewrite -> plus_comm with (m := M1).
          rewrite -> plus_permute with (m := M1).
          rewrite -> plus_permute with (m := M1).
@@ -986,7 +986,7 @@ Proof.
        unfold inj_Q_G_as_CauchySeq in H12.
        unfold CS_seq at 1 in H12.
        apply H12.
-       apply le_trans with (m := N1 + (N2 + (N3 + M1))).
+       apply Nat.le_trans with (m := N1 + (N2 + (N3 + M1))).
         apply le_plus_l.
        assumption.
       apply eq_transitive_unfolded with (y := inj_Q IR (G IR (x[*]y) m)[-]inj_Q IR (G IR x m[*]G IR y m)).

--- a/reals/stdlib/CMTFullSets.v
+++ b/reals/stdlib/CMTFullSets.v
@@ -168,9 +168,9 @@ Proof.
   { intros. unfold diagPlane. apply plus_lt_le_compat. assumption.
     apply Nat.div_le_mono. auto. apply mult_le_compat.
     apply plus_le_compat. apply le_refl. unfold lt in H0.
-    apply (le_trans _ (S a)). apply le_S. apply le_refl. assumption.
+    apply (Nat.le_trans _ (S a)). apply le_S. apply le_refl. assumption.
     apply le_n_S. apply plus_le_compat. apply le_refl. unfold lt in H0.
-    apply (le_trans _ (S a)). apply le_S. apply le_refl. assumption. }
+    apply (Nat.le_trans _ (S a)). apply le_S. apply le_refl. assumption. }
   pose proof (CR_complete R _ cvDiag) as [lim cvlim].
   destruct (SubSeriesCv (fun k : nat =>
                 CRabs _ (partialApply (diagSeq fnk k) x (xnDiag k)))
@@ -486,7 +486,7 @@ Proof.
     rewrite (CRsum_eq (fun i : nat => un (N + S i)%nat) (fun i : nat => un (S N + i)%nat)).
     rewrite CRplus_assoc.
     rewrite <- sum_assoc. rewrite CRplus_comm. simpl in maj. apply maj.
-    apply (le_trans k (S i)). assumption. simpl.
+    apply (Nat.le_trans k (S i)). assumption. simpl.
     apply le_n_S. rewrite plus_comm. rewrite <- (plus_0_r i). rewrite <- plus_assoc.
     apply Nat.add_le_mono_l. apply le_0_n.
     intros. rewrite Nat.add_succ_r. reflexivity. apply le_n_S.
@@ -506,7 +506,7 @@ Proof.
   exists (S N + k)%nat. (* translated same modulus of convergence *)
   intros n kLen.
   destruct (Nat.le_exists_sub (S N) n) as [m [inf _]].
-  apply (le_trans _ (S N + k)). rewrite <- (plus_0_r (S N)).
+  apply (Nat.le_trans _ (S N + k)). rewrite <- (plus_0_r (S N)).
   rewrite <- plus_assoc. apply Nat.add_le_mono_l. apply le_0_n.
   assumption.
   subst n. replace (m + S N)%nat with (S N + m)%nat. rewrite sum_assoc.
@@ -521,7 +521,7 @@ Proof.
   rewrite (CRplus_comm (-s)). rewrite <- CRplus_assoc.
   rewrite (CRsum_eq _ (fun i : nat => un (N + S i)%nat)). apply maj.
   rewrite plus_comm in kLen. apply Nat.add_le_mono_r in kLen.
-  apply (le_trans k m). assumption. apply le_S. apply le_refl.
+  apply (Nat.le_trans k m). assumption. apply le_S. apply le_refl.
   intros. rewrite Nat.add_succ_r. reflexivity. apply le_n_S.
   apply le_0_n. rewrite plus_comm. reflexivity.
 Qed.
@@ -540,7 +540,7 @@ Proof.
     destruct (n - N)%nat eqn:des. exfalso. apply (Nat.sub_gt n N); assumption.
     rewrite <- (Nat.sub_add N n). rewrite des. rewrite plus_comm.
     exact d. subst d.
-    apply (le_trans N (S N)). apply le_S. apply le_refl. assumption.
+    apply (Nat.le_trans N (S N)). apply le_S. apply le_refl. assumption.
 Qed.
 
 Definition domainInfiniteSumPackInc
@@ -585,13 +585,13 @@ Proof.
     specialize (s eps) as [k maj].
     exists (S N + k)%nat. (* translated modulus of convergence *)
     intros n H0. destruct (Nat.le_exists_sub N n) as [m [inf _]].
-    apply (le_trans _ (S N + k)).
+    apply (Nat.le_trans _ (S N + k)).
     simpl. apply le_S. rewrite <- (plus_0_r N).
     rewrite <- plus_assoc. apply Nat.add_le_mono_l.
     apply le_0_n. assumption. subst n.
     rewrite <- (applyPackFirstSum X fn m N x x1 x0).
     apply maj. apply (Nat.add_le_mono_l k m (S N)).
-    apply (le_trans _ (m + N)). assumption. rewrite plus_comm.
+    apply (Nat.le_trans _ (m + N)). assumption. rewrite plus_comm.
     apply Nat.add_le_mono_r. apply le_S. apply le_refl.
 Qed.
 
@@ -1239,7 +1239,7 @@ Proof.
                           CMTIntegrableFunctions.IntFnL.
   specialize (IntAbsSumCv p) as [j jmaj].
   exists j. intros. apply jmaj.
-  apply (le_trans _ (0+i) _ H). apply Nat.add_le_mono_r, le_0_n.
+  apply (Nat.le_trans _ (0+i) _ H). apply Nat.add_le_mono_r, le_0_n.
 Defined.
 
 Lemma IntegralRepresentationShiftVal
@@ -1263,7 +1263,7 @@ Proof.
   apply CR_cv_minus. 2: apply CR_cv_const.
   intro p.
   pose proof (IntegralCv fInt p) as [k kmaj]. exists k.
-  intros. apply kmaj. apply (le_trans _ (0+i) _ H).
+  intros. apply kmaj. apply (Nat.le_trans _ (0+i) _ H).
   apply Nat.add_le_mono_r, le_0_n.
 Qed.
 

--- a/reals/stdlib/CMTIntegrableFunctions.v
+++ b/reals/stdlib/CMTIntegrableFunctions.v
@@ -376,7 +376,7 @@ Proof.
                CRsum (fun _ : nat => 0)
                  (if Nat.even (i * 2) then Init.Nat.pred i else i)
            end) with (CR_of_Q R 0) in cv.
-    rewrite CRplus_0_r in cv. apply cv. apply (le_trans _ i).
+    rewrite CRplus_0_r in cv. apply cv. apply (Nat.le_trans _ i).
     assumption. rewrite mult_comm. simpl. rewrite <- (plus_0_r i).
     rewrite <- plus_assoc. apply Nat.add_le_mono_l. apply le_0_n.
     destruct (i*2)%nat eqn:des. reflexivity.
@@ -407,8 +407,8 @@ Proof.
       exfalso. assert (Nat.Odd (1+n*2)). exists n. rewrite plus_comm.
       rewrite mult_comm. reflexivity. apply Nat.odd_spec in H3.
       unfold Nat.odd in H3. rewrite des in H3. inversion H3.
-      apply cv. apply (le_trans N n). assumption.
-      apply (le_trans n (n*2)). rewrite <- (mult_1_r n).
+      apply cv. apply (Nat.le_trans N n). assumption.
+      apply (Nat.le_trans n (n*2)). rewrite <- (mult_1_r n).
       rewrite <- mult_assoc. apply Nat.mul_le_mono_nonneg_l.
       apply le_0_n. apply le_S. apply le_refl.
       rewrite <- (plus_0_l (n*2)). rewrite plus_assoc.
@@ -435,15 +435,15 @@ Proof.
     setoid_replace (1 # n)%Q with ((1 # (2*n)) + (1 # (2*n)))%Q.
     apply le_S_n in H1. rewrite CR_of_Q_plus. apply CRplus_le_compat.
     apply H. rewrite <- (Nat.div_mul N 2). apply Nat.div_le_mono.
-    auto. apply (le_trans (N*2) (N*2 + (S N0)*2)). apply Nat.le_add_r.
-    apply (le_trans _ i). assumption.
+    auto. apply (Nat.le_trans (N*2) (N*2 + (S N0)*2)). apply Nat.le_add_r.
+    apply (Nat.le_trans _ i). assumption.
     apply le_S. apply le_refl. auto.
     apply H0. assert (N0 = pred (S N0)). reflexivity.
     rewrite H2. apply le_pred. rewrite <- (Nat.div_mul (S N0) 2).
     apply Nat.div_le_mono. auto.
-    apply (le_trans _ (N*2 + (S N0)*2)).
+    apply (Nat.le_trans _ (N*2 + (S N0)*2)).
     rewrite plus_comm. apply Nat.le_add_r.
-    apply (le_trans (N*2 + (S N0)*2) i). assumption. apply le_S. apply le_refl. auto.
+    apply (Nat.le_trans (N*2 + (S N0)*2) i). assumption. apply le_S. apply le_refl. auto.
     rewrite Qinv_plus_distr. reflexivity.
     unfold CRminus. do 2 rewrite CRplus_assoc.
     apply CRplus_morph. reflexivity. rewrite CRopp_plus_distr, CRplus_comm.
@@ -454,15 +454,15 @@ Proof.
     setoid_replace (1 # n)%Q with ((1 # (2*n)) + (1 # (2*n)))%Q.
     apply le_S_n in H1. rewrite CR_of_Q_plus. apply CRplus_le_compat.
     apply H. rewrite <- (Nat.div_mul N 2). apply Nat.div_le_mono.
-    auto. apply (le_trans (N*2) (N*2 + (S N0)*2)). apply Nat.le_add_r.
-    apply (le_trans _ i). assumption. apply le_S. apply le_refl. auto.
+    auto. apply (Nat.le_trans (N*2) (N*2 + (S N0)*2)). apply Nat.le_add_r.
+    apply (Nat.le_trans _ i). assumption. apply le_S. apply le_refl. auto.
     apply H0. rewrite <- (Nat.div_mul N0 2).
     apply Nat.div_le_mono. auto.
-    apply (le_trans (N0*2) (N*2 + (S N0)*2)). rewrite plus_comm.
-    apply (le_trans (N0 * 2) (S N0 * 2)).
+    apply (Nat.le_trans (N0*2) (N*2 + (S N0)*2)). rewrite plus_comm.
+    apply (Nat.le_trans (N0 * 2) (S N0 * 2)).
     apply mult_le_compat_r. apply le_S. apply le_refl.
     apply Nat.le_add_r.
-    apply (le_trans _ i). assumption. apply le_S. apply le_refl. auto.
+    apply (Nat.le_trans _ i). assumption. apply le_S. apply le_refl. auto.
     rewrite Qinv_plus_distr. reflexivity.
     unfold CRminus. do 2 rewrite CRplus_assoc.
     apply CRplus_morph. reflexivity. rewrite CRopp_plus_distr, CRplus_comm.
@@ -485,7 +485,7 @@ Proof.
       { rewrite <- (CRsum_eq (fun k => 0)). rewrite sum_const.
         apply CRmult_0_l. intros.
         destruct (le_dec (S N + i)). exfalso. assert (S N <= N)%nat.
-        apply (le_trans (S N) (S N + i)). apply Nat.le_add_r. assumption.
+        apply (Nat.le_trans (S N) (S N + i)). apply Nat.le_add_r. assumption.
         exact (Nat.nle_succ_diag_l N H1). reflexivity. }
       rewrite H0. rewrite CRplus_0_r.
       rewrite (CRsum_eq u (fun n1 : nat => if le_dec n1 N then u n1 else 0)).

--- a/reals/stdlib/CMTIntegrableSets.v
+++ b/reals/stdlib/CMTIntegrableSets.v
@@ -499,7 +499,7 @@ Proof.
     + intros. simpl in H.
       destruct H.
       specialize (IHn x) as [H0 _].
-      destruct (H0 H). exists x0. split. apply (le_trans _ n).
+      destruct (H0 H). exists x0. split. apply (Nat.le_trans _ n).
       apply H1. apply le_S, le_refl. apply H1.
       exists (S n). split. apply le_refl. apply H.
     + intros. destruct H as [p [pxp H]].
@@ -523,7 +523,7 @@ Proof.
     + intros. apply Nat.le_succ_r in H0. destruct H0.
       apply IHn. apply H. exact H0. subst p. apply H.
     + intros. split. apply IHn. intros. apply H.
-      apply (le_trans _ _ _ H0). apply le_S, le_refl.
+      apply (Nat.le_trans _ _ _ H0). apply le_S, le_refl.
       apply H. apply le_refl.
 Qed.
 
@@ -732,7 +732,7 @@ Proof.
       rewrite pcv in X. exact (CRlt_asym _ _ X X).
       destruct k. contradiction. simpl in n0. apply n0.
       right. exact abs. apply n. apply applyUnionIterate.
-      exists k. split. unfold lt in l. apply (le_trans _ (S k)).
+      exists k. split. unfold lt in l. apply (Nat.le_trans _ (S k)).
       apply le_S, le_refl. exact l. exact abs.
     + intros. apply applyPointwiseLimit. simpl.
       destruct xD as [xn xcv]. destruct xG.
@@ -753,7 +753,7 @@ Proof.
       split. exact H0. destruct (xn n).
       exfalso. apply n0. apply applyUnionIterate in u.
       destruct u. apply applyUnionIterate. exists x0. split.
-      apply (le_trans _ n). apply H1. exact H0. apply H1.
+      apply (Nat.le_trans _ n). apply H1. exact H0. apply H1.
       exfalso. destruct ncv. apply H1, CRzero_lt_one.
       exists O. intros n0 _. destruct (xn n0). exfalso.
       apply n. apply applyUnionIterate in u. destruct u. exists x0. apply H0.
@@ -796,7 +796,7 @@ Proof.
       specialize (X (RealT (ElemFunc IS))) as H0.
       rewrite pcv in H0. exact (CRlt_asym _ _ H0 H0).
       rewrite applyIntersectIterate in i. apply i.
-      apply (le_trans _ (S n)).
+      apply (Nat.le_trans _ (S n)).
       apply le_S, le_refl. exact l.
       right. intro abs. apply n. rewrite applyIntersectIterate. intros.
       apply abs.
@@ -818,7 +818,7 @@ Proof.
       specialize (X (RealT (ElemFunc IS))).
       rewrite pcv in X. exact (CRlt_asym _ _ X X).
       rewrite applyIntersectIterate in i0. apply i0.
-      apply (le_trans _ (S n1)). apply le_S, le_refl. exact l.
+      apply (Nat.le_trans _ (S n1)). apply le_S, le_refl. exact l.
       (* So it is not in the intersection at p *)
       specialize (pcv i H0). destruct (xn i).
       exfalso. pose proof CRzero_lt_one.
@@ -851,7 +851,7 @@ Proof.
   induction n.
   - apply le_0_n.
   - specialize (H n). unfold lt in H.
-    apply (le_trans _ (S (un n))). apply le_n_S, IHn. exact H.
+    apply (Nat.le_trans _ (S (un n))). apply le_n_S, IHn. exact H.
 Qed.
 
 Lemma SliceBar
@@ -896,7 +896,7 @@ Proof.
       unfold INR. rewrite <- CR_of_Q_plus. apply CR_of_Q_morph.
       rewrite Qinv_plus_distr. rewrite <- Nat2Z.inj_add.
       rewrite Nat.sub_add. reflexivity. specialize (H (S k)).
-      apply (le_trans _ (S (nk (S k)))). apply le_S, le_refl.
+      apply (Nat.le_trans _ (S (nk (S k)))). apply le_S, le_refl.
       apply H. rewrite CRplus_comm. unfold CRminus.
       rewrite CRplus_assoc, CRplus_opp_l, CRplus_0_r.
       reflexivity. }
@@ -907,7 +907,7 @@ Proof.
   apply (CRle_trans _ (INR n)). apply CRlt_asym, nmaj.
   apply CR_of_Q_le. unfold Qle; simpl.
   do 2 rewrite Z.mul_1_r. apply Nat2Z.inj_le.
-  apply (le_trans _ _ _ H3). apply (le_trans _ (S i)).
+  apply (Nat.le_trans _ _ _ H3). apply (Nat.le_trans _ (S i)).
   apply le_S, le_refl. apply growing_infinite. exact H.
 Qed.
 
@@ -991,7 +991,7 @@ Lemma StartZeroInc : forall (un : nat -> nat),
 Proof.
   intros. destruct n.
   - simpl. destruct (un O) eqn:des.
-    apply (le_lt_trans _ (un O)). apply le_0_n. apply H.
+    apply (Nat.le_lt_trans _ (un O)). apply le_0_n. apply H.
     apply le_n_S, le_0_n.
   - simpl. destruct (un O); apply H.
 Qed.

--- a/reals/stdlib/CMTMeasurableFunctions.v
+++ b/reals/stdlib/CMTMeasurableFunctions.v
@@ -789,7 +789,7 @@ Proof.
       exfalso. apply n0. apply applyUnionIterate.
       apply applyUnionIterate in u. destruct u. exists x0.
       destruct H, H0. repeat split; try assumption.
-      apply (le_trans _ _ _ H), le_S, le_refl.
+      apply (Nat.le_trans _ _ _ H), le_S, le_refl.
       destruct xdg. apply CRlt_asym, CRzero_lt_one. apply CRle_refl.
     + intros. apply IntegralNonDecreasing. intros x xdf xdg.
       simpl. destruct xdf. destruct xdg. apply CRle_refl.
@@ -1786,7 +1786,7 @@ Proof.
     apply CRinv_0_lt_compat, H. }
   specialize (fnCvZero idom_support0 idom_int0 _ H0) as [N Nmaj].
   exists (max N idom_idx0). intros.
-  specialize (Nmaj i (le_trans _ _ _ (Nat.le_max_l _ _) H1)) as [[C Cint] Cmaj].
+  specialize (Nmaj i (Nat.le_trans _ _ _ (Nat.le_max_l _ _) H1)) as [[C Cint] Cmaj].
   unfold sa_approx in Cmaj.
   assert (Integral
             (MeasurableIntersectIntegrable
@@ -1802,7 +1802,7 @@ Proof.
     contradict n. split; apply a.
     destruct xdg. apply CRlt_asym, CRzero_lt_one. apply CRle_refl. }
   assert (le idom_idx0 i).
-  { apply (le_trans _ (max N idom_idx0)). apply Nat.le_max_r. exact H1. }
+  { apply (Nat.le_trans _ (max N idom_idx0)). apply Nat.le_max_r. exact H1. }
   specialize (idom_dom0 _ _ _ H3 H2). clear H2 H3.
   apply (CRle_lt_trans
            _ (Integral

--- a/reals/stdlib/CMTPositivity.v
+++ b/reals/stdlib/CMTPositivity.v
@@ -80,7 +80,7 @@ Proof.
   intros. simpl.
   destruct (Un_cv_nat_real un l cv (bound (S n)) (boundPos (S n))),
   (ControlSubSeqCv un l bound cv boundPos n).
-  apply (lt_le_trans _ (S x0)). apply le_n_S, le_refl.
+  apply (Nat.lt_le_trans _ (S x0)). apply le_n_S, le_refl.
   apply Nat.le_max_r.
 Qed.
 
@@ -323,7 +323,7 @@ Proof.
       reflexivity. do 2 rewrite <- Nat.sub_1_r.
       rewrite Nat.add_sub_assoc.
       rewrite Nat.add_comm, Nat.sub_add. reflexivity.
-      rewrite <- des. apply (le_trans _ (S (n (S n0)))).
+      rewrite <- des. apply (Nat.le_trans _ (S (n (S n0)))).
       apply le_S, le_refl. exact (ninc (S n0)).
       rewrite <- des. apply Nat.le_add_le_sub_r. apply ninc.
       apply CRlt_asym, CRpow_gt_zero. simpl.

--- a/reals/stdlib/CMTProductIntegral.v
+++ b/reals/stdlib/CMTProductIntegral.v
@@ -230,7 +230,7 @@ Proof.
   - exists O. split. apply le_refl. reflexivity.
   - simpl. destruct IHl as [k [H H0]]. destruct a.
     + exists k. split. rewrite app_length, map_length, map_length.
-      apply (lt_le_trans _ (0+length (FreeSubsets (length l)))).
+      apply (Nat.lt_le_trans _ (0+length (FreeSubsets (length l)))).
       exact H. rewrite <- Nat.add_le_mono_r. apply le_0_n.
       rewrite app_nth1.
       rewrite (nth_indep _ nil (true::nil)), map_nth, H0.
@@ -243,7 +243,7 @@ Proof.
       rewrite (nth_indep _ nil (false::nil)), map_nth, H0.
       reflexivity. rewrite map_length. exact H.
       rewrite map_length.
-      apply (le_trans _ (0+length (FreeSubsets (length l)))).
+      apply (Nat.le_trans _ (0+length (FreeSubsets (length l)))).
       apply le_refl. rewrite <- Nat.add_le_mono_r. apply le_0_n.
 Qed.
 
@@ -711,7 +711,7 @@ Proof.
                    _ (@nil bool, @nil bool)).
   rewrite (nth_list_prod
                 (FreeSubsets (length hn)) (FreeSubsets (length hn)) nil nil i
-                (lt_trans _ _ _ H H0)).
+                (Nat.lt_trans _ _ _ H H0)).
   rewrite (nth_list_prod
                 (FreeSubsets (length hn)) (FreeSubsets (length hn)) nil nil j H0).
   unfold fst, snd.
@@ -760,7 +760,7 @@ Proof.
     apply nth_In. subst a.
     apply Nat.div_lt_upper_bound. intro abs.
     rewrite abs in lenPos. exact (lt_irrefl 0 lenPos).
-    exact (lt_trans _ _ _ H H0).
+    exact (Nat.lt_trans _ _ _ H H0).
     apply nth_In. exact cin.
     rewrite (FreeSubsetsLength (length hn)).
     rewrite map_length. reflexivity. apply nth_In. exact cin.
@@ -769,7 +769,7 @@ Proof.
     subst a.
     apply Nat.div_lt_upper_bound. intro abs.
     rewrite abs in lenPos. exact (lt_irrefl 0 lenPos).
-    exact (lt_trans _ _ _ H H0).
+    exact (Nat.lt_trans _ _ _ H H0).
 Qed.
 
 Fixpoint ProdIntegrableSubsetLeft
@@ -1191,7 +1191,7 @@ Proof.
         specialize (H0 n).
         rewrite map_length in H1. intro abs. apply H0.
         unfold ProdIntegrableSimplify. rewrite map_length, prod_length.
-        apply (lt_le_trans _ (1 * length (FreeSubsets (length hn)))).
+        apply (Nat.lt_le_trans _ (1 * length (FreeSubsets (length hn)))).
         rewrite Nat.mul_1_l. rewrite <- H1. exact H2.
         apply Nat.mul_le_mono_nonneg_r. apply le_0_n. exact flen.
         clear H0.
@@ -1206,11 +1206,11 @@ Proof.
                                nil nil n).
         unfold snd. rewrite Nat.mod_small. rewrite <- H1, H3. exact abs.
         rewrite <- H1. exact H2.
-        apply (lt_le_trans _ (1 * length (FreeSubsets (length hn)))).
+        apply (Nat.lt_le_trans _ (1 * length (FreeSubsets (length hn)))).
         rewrite Nat.mul_1_l. rewrite <- H1. exact H2.
         apply Nat.mul_le_mono_nonneg_r. apply le_0_n. exact flen.
         rewrite map_length, prod_length.
-        apply (lt_le_trans _ (1 * length (FreeSubsets (length hn)))).
+        apply (Nat.lt_le_trans _ (1 * length (FreeSubsets (length hn)))).
         rewrite Nat.mul_1_l. rewrite <- H1. exact H2.
         apply Nat.mul_le_mono_nonneg_r. apply le_0_n. exact flen. }
       intros. right. rewrite Forall_forall in H1.
@@ -1239,7 +1239,7 @@ Proof.
           < length (ProdIntegrableSimplify hn))%nat.
   { unfold ProdIntegrableSimplify. rewrite map_length, prod_length.
     destruct H.
-    apply (lt_le_trans _ (length (FreeSubsets (length hn))
+    apply (Nat.lt_le_trans _ (length (FreeSubsets (length hn))
                           + kf * length (FreeSubsets (length hn)))).
     rewrite <- Nat.add_lt_mono_r. apply H0.
     apply (Nat.mul_le_mono_nonneg_r (S kf) _ (length (FreeSubsets (length hn)))).
@@ -1320,7 +1320,7 @@ Proof.
     2: rewrite map_length, prod_length; exact H3.
     clear H4.
     assert (0 < length (FreeSubsets (length hn)))%nat as lenPos.
-    { apply (le_lt_trans _ kg _ (le_0_n _)). apply H0. }
+    { apply (Nat.le_lt_trans _ kg _ (le_0_n _)). apply H0. }
     destruct (Nat.eq_dec (k / length (FreeSubsets (length hn))) kf).
     + rewrite e in p0. clear p. simpl in p0.
       apply (ProdIntegrableSubsetsDisjoint
@@ -2174,7 +2174,7 @@ Proof.
     unfold CRminus. rewrite CRopp_0, CRplus_0_r, CRabs_right.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden.
     do 2 rewrite Z.mul_1_l. apply Pos2Z.pos_le_pos, Pos2Nat.inj_le.
-    rewrite Nat2Pos.id. 2: discriminate. apply (le_trans _ _ _ H1).
+    rewrite Nat2Pos.id. 2: discriminate. apply (Nat.le_trans _ _ _ H1).
     apply le_S, le_refl. apply CR_of_Q_le. discriminate.
 Qed.
 

--- a/reals/stdlib/CMTReals.v
+++ b/reals/stdlib/CMTReals.v
@@ -1163,7 +1163,7 @@ Proof.
     rewrite CRopp_0, CRplus_0_r. rewrite CRabs_right.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_l.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
-    rewrite Nat2Pos.id. apply (le_trans _ _ _ H0). rewrite Nat.add_comm.
+    rewrite Nat2Pos.id. apply (Nat.le_trans _ _ _ H0). rewrite Nat.add_comm.
     apply le_S, le_S, le_refl. intro abs. rewrite Nat.add_comm in abs. discriminate.
     apply CR_of_Q_le. discriminate.
     rewrite CRmult_0_l. reflexivity. rewrite CRplus_0_r. reflexivity. }
@@ -1191,9 +1191,9 @@ Proof.
     simpl. rewrite CSUCTrapezePlateau. unfold CRminus.
     rewrite CRplus_opp_r, CRabs_right. 
     apply CR_of_Q_le. discriminate. apply CRle_refl.
-    split; apply CRlt_asym. apply c. apply (le_trans _ (max x1 x2)).
+    split; apply CRlt_asym. apply c. apply (Nat.le_trans _ (max x1 x2)).
     apply Nat.le_max_l. exact H2. apply c0.
-    apply (le_trans _ (max x1 x2)). apply Nat.le_max_r. exact H2. }
+    apply (Nat.le_trans _ (max x1 x2)). apply Nat.le_max_r. exact H2. }
 
   assert (forall n:nat, a + (b - a) * CR_of_Q R (1 # Pos.of_nat (n + 2))
                  <= b - (b - a) * CR_of_Q R (1 # Pos.of_nat (n + 2))) as fnL.

--- a/reals/stdlib/CMTprofile.v
+++ b/reals/stdlib/CMTprofile.v
@@ -212,8 +212,8 @@ Proof.
   - rewrite CRabs_opp, CRabs_right. apply CR_of_Q_le.
     unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_l.
     apply Pos2Z.pos_le_pos. rewrite Pos2Nat.inj_le, Nat2Pos.id.
-    2: discriminate. apply (le_trans _ _ _ H). simpl.
-    apply le_S. apply (le_trans _ (i+0)).
+    2: discriminate. apply (Nat.le_trans _ _ _ H). simpl.
+    apply le_S. apply (Nat.le_trans _ (i+0)).
     rewrite Nat.add_comm. apply le_refl.
     apply Nat.add_le_mono_l, le_0_n.
     apply CR_of_Q_le. discriminate.
@@ -979,11 +979,11 @@ Proof.
       apply CRle_refl.
       apply StepApproxIntegralIncr.
       apply BinarySubdivInside. apply CRlt_asym, ltab.
-      apply le_S_n in l0. apply (le_trans _ (S j)).
+      apply le_S_n in l0. apply (Nat.le_trans _ (S j)).
       apply le_S, le_refl. exact l0.
       apply (CRle_trans _ b). apply BinarySubdivInside.
       apply CRlt_asym, ltab. apply le_S_n, l0. apply CRlt_asym, (snd beta).
-      exfalso. pose proof (lt_le_trans _ _ _ l l0).
+      exfalso. pose proof (Nat.lt_le_trans _ _ _ l l0).
       apply (lt_not_le _ _ H0). apply le_S, le_refl.
       apply StepApproxIntegralIncr.
       apply CRlt_asym, BinarySubdivIncr. exact (pair aPos ltab).
@@ -1014,20 +1014,20 @@ Proof.
     apply StepApproxIntegralIncr.
     apply (CRle_trans _ a). apply CRlt_asym, (snd aeta).
     apply BinarySubdivInside. apply CRlt_asym, ltab.
-    apply le_S_n in l. apply (le_trans _ (S i)). apply le_S, le_refl.
+    apply le_S_n in l. apply (Nat.le_trans _ (S i)). apply le_S, le_refl.
     exact l. apply BinarySubdivInside. apply CRlt_asym, ltab.
     apply le_S_n, l.
   - exfalso. inversion H.
   - destruct (le_lt_dec (S (2 ^ n)) (S j)), (le_lt_dec (S (2 ^ S n)) (S i)).
     + apply CRle_refl.
     + exfalso. apply le_S_n in l0.
-      apply (le_trans _ _ _ H) in l0. clear H.
+      apply (Nat.le_trans _ _ _ H) in l0. clear H.
       apply (Nat.mul_le_mono_pos_l _ _ 2) in l0.
-      apply (le_trans _ _ _ l) in l0. apply (le_not_lt _ _ l0 (le_refl _)).
+      apply (Nat.le_trans _ _ _ l) in l0. apply (le_not_lt _ _ l0 (le_refl _)).
       apply le_n_S, le_0_n.
     + apply StepApproxIntegralIncr.
       apply BinarySubdivInside. apply CRlt_asym, ltab.
-      apply le_S_n in l. apply (le_trans _ (S j)).
+      apply le_S_n in l. apply (Nat.le_trans _ (S j)).
       apply le_S, le_refl. exact l. apply (CRle_trans _ b).
       apply BinarySubdivInside. apply CRlt_asym, ltab.
       apply le_S_n, l. apply CRlt_asym, (snd beta).
@@ -1043,7 +1043,7 @@ Proof.
       unfold Qmult, Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
       replace 2%Z with (Z.of_nat 2). 2: reflexivity.
       rewrite <- Nat2Z.inj_mul. apply Nat2Z.inj_le.
-      apply le_S_n. apply (le_trans _ (2*S j)). 2: exact H.
+      apply le_S_n. apply (Nat.le_trans _ (2*S j)). 2: exact H.
       rewrite Nat.mul_comm.
       simpl. rewrite Nat.add_0_r, Nat.add_succ_r. apply le_S, le_refl.
       apply CRplus_le_compat_l.
@@ -1057,7 +1057,7 @@ Proof.
       unfold Qmult, Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
       replace 2%Z with (Z.of_nat 2). 2: reflexivity.
       rewrite <- Nat2Z.inj_mul. apply Nat2Z.inj_le.
-      apply (le_trans _ (2*S j)). 2: exact H.
+      apply (Nat.le_trans _ (2*S j)). 2: exact H.
       rewrite Nat.mul_comm. apply le_refl.
 Qed.
 
@@ -1085,20 +1085,20 @@ Proof.
     apply StepApproxIntegralIncr. apply (CRle_trans _ a).
     apply CRlt_asym, aeta.
     apply BinarySubdivInside. apply CRlt_asym, ltab.
-    apply le_S_n in l. apply (le_trans _ (S j)). apply le_S, le_refl.
+    apply le_S_n in l. apply (Nat.le_trans _ (S j)). apply le_S, le_refl.
     exact l. apply BinarySubdivInside. apply CRlt_asym, ltab.
     apply le_S_n, l.
   - destruct (le_lt_dec (S (2 ^ n)) (S j)), (le_lt_dec (S (2 ^ S n)) (S i)).
     + apply CRle_refl.
     + apply StepApproxIntegralIncr.
       apply BinarySubdivInside. apply CRlt_asym, ltab.
-      apply le_S_n in l0. apply (le_trans _ (S i)). apply le_S, le_refl.
+      apply le_S_n in l0. apply (Nat.le_trans _ (S i)). apply le_S, le_refl.
       exact l0. apply (CRle_trans _ b).
       apply BinarySubdivInside. apply CRlt_asym, ltab.
       apply le_S_n, l0. apply CRlt_asym, (snd beta).
     + exfalso. apply le_S_n in l0. apply le_S_n in l.
-      apply (le_trans _ _ (2^S n)) in H.
-      apply (le_trans _ _ _ H) in l0. apply (le_not_lt _ _ l0).
+      apply (Nat.le_trans _ _ (2^S n)) in H.
+      apply (Nat.le_trans _ _ _ H) in l0. apply (le_not_lt _ _ l0).
       apply le_S, le_refl. apply Nat.mul_le_mono_nonneg_l.
       apply le_0_n. exact l.
     + clear l l0.
@@ -1130,7 +1130,7 @@ Proof.
       replace 2%Z with (Z.of_nat 2). 2: reflexivity.
       rewrite <- (Nat2Z.inj_mul (S j) 2). apply Nat2Z.inj_le.
       replace (S j * 2)%nat with (S (S (2*j))). apply le_n_S.
-      apply (le_trans _ _ _ H). apply le_S, le_refl.
+      apply (Nat.le_trans _ _ _ H). apply le_S, le_refl.
       rewrite (Nat.mul_comm (S j)). simpl.
       rewrite Nat.add_0_r, Nat.add_succ_r. reflexivity.
 Qed.
@@ -1270,7 +1270,7 @@ Proof.
       rewrite <- CR_of_Q_plus. apply CR_of_Q_le.
       unfold Qplus, Qle, Qnum, Qden. do 4 rewrite Z.mul_1_r.
       replace 1%Z with (Z.of_nat 1). rewrite <- Nat2Z.inj_add.
-      apply Nat2Z.inj_le. apply (le_trans _ i _ l1).
+      apply Nat2Z.inj_le. apply (Nat.le_trans _ i _ l1).
       rewrite Nat.add_comm. apply le_S, le_refl.
       reflexivity.
       rewrite <- CR_of_Q_mult. apply CR_of_Q_morph. reflexivity.
@@ -1304,7 +1304,7 @@ Proof.
         replace 1%Z with (Z.of_nat 1). rewrite <- Nat2Z.inj_add. 2: reflexivity.
         replace 2%Z with (Z.of_nat 2). rewrite <- Nat2Z.inj_mul. 2: reflexivity.
         apply Nat2Z.inj_le. apply le_S_n.
-        apply (le_trans _ _ _ l1).
+        apply (Nat.le_trans _ _ _ l1).
         rewrite (Nat.mul_comm (i+1)). apply le_S. rewrite Nat.add_comm.
         apply le_refl.
 Qed.
@@ -1367,7 +1367,7 @@ Proof.
     destruct (le_lt_dec (S (2 ^ n)) (S j)).
     exfalso. apply le_S_n in l1. exact (le_not_lt _ _ l1 l0).
     destruct (le_lt_dec (S (2 ^ n)) (S i)).
-    apply le_S_n in l1. apply le_S_n in l2. exact (le_trans _ _ _ l1 l2).
+    apply le_S_n in l1. apply le_S_n in l2. exact (Nat.le_trans _ _ _ l1 l2).
     destruct (le_lt_dec (S j) i). exact l3. exfalso.
     apply (StepApproxIntegralIncr
              f fInt
@@ -2038,13 +2038,13 @@ Proof.
     rewrite CRopp_0, CRplus_0_r. rewrite CRabs_right.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_l.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
-    rewrite Nat2Pos.id. apply (le_trans _ _ _ H3).
+    rewrite Nat2Pos.id. apply (Nat.le_trans _ _ _ H3).
     apply le_S, le_refl. discriminate.
     apply CR_of_Q_le. discriminate. }
   destruct (CR_cv_open_above an x 0 stepCv H2) as [i imaj].
   destruct (CRup_nat x) as [j jmaj].
   specialize (imaj (max n (max i j))
-                   (le_trans _ _ _ (Nat.le_max_l i j) (Nat.le_max_r _ _))).
+                   (Nat.le_trans _ _ _ (Nat.le_max_l i j) (Nat.le_max_r _ _))).
   specialize (H5 (max n (max i j))).
   destruct (H1 (max n (max i j))) as [s a0], a0, H6, H7.
   (* Locate x in an open interval ]s k, s (k+1)[ *)
@@ -2052,9 +2052,9 @@ Proof.
   split. rewrite H3. exact imaj. rewrite H6.
   apply (CRlt_le_trans _ _ _ jmaj). apply CR_of_Q_le.
   unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_r.
-  apply Nat2Z.inj_le. apply (le_trans _ (2+j)).
+  apply Nat2Z.inj_le. apply (Nat.le_trans _ (2+j)).
   apply le_S, le_S, le_refl. apply le_n_S, le_n_S.
-  exact (le_trans _ _ _ (Nat.le_max_r i _) (Nat.le_max_r _ _)).
+  exact (Nat.le_trans _ _ _ (Nat.le_max_r i _) (Nat.le_max_r _ _)).
   apply le_refl.
   destruct (IntervalOpenEta (s k) (s (S k)) x kmaj) as [eta etamaj].
   destruct etamaj.

--- a/reals/stdlib/ConstructiveCauchyIntegral.v
+++ b/reals/stdlib/ConstructiveCauchyIntegral.v
@@ -56,7 +56,7 @@ Proof.
   - intros. inversion H. apply CRle_refl.
   - intros. apply Nat.le_succ_r in H. destruct H.
     + apply (CRle_trans _ (ipt_seq P p)). apply (IHp H).
-      apply (le_trans _ (ipt_last P)). apply le_S_n. exact H0.
+      apply (Nat.le_trans _ (ipt_last P)). apply le_S_n. exact H0.
       apply le_S, le_refl. apply P. apply le_S_n. exact H0.
     + subst n. apply CRle_refl.
 Qed.
@@ -102,7 +102,7 @@ Proof.
   - intros. inversion H. apply CRmax_l.
   - intros.
     assert (forall n : nat, le n ipt_last0 -> (ipt_seq0 n <= ipt_seq0 (S n))).
-    { intros. apply ipt_ordered0. apply (le_trans _ ipt_last0 _ H0).
+    { intros. apply ipt_ordered0. apply (Nat.le_trans _ ipt_last0 _ H0).
       apply le_S, le_refl. }
     specialize (IHipt_last0 H0). apply Nat.le_succ_r in H.
     destruct H.
@@ -148,16 +148,16 @@ Proof.
     apply (CRle_trans _ (ipt_seq Q i)).
     apply (CRle_trans _ (ipt_seq Q (subseq n))).
     destruct H1. rewrite H1. apply CRle_refl.
-    apply (le_trans _ _ _ H2). apply le_S, le_refl.
+    apply (Nat.le_trans _ _ _ H2). apply le_S, le_refl.
     apply ipt_ordered_transit. exact H3.
-    destruct H1. apply (le_trans _ (subseq (S n))).
-    apply (le_trans _ (S i)). apply le_S, le_refl. exact H4.
+    destruct H1. apply (Nat.le_trans _ (subseq (S n))).
+    apply (Nat.le_trans _ (S i)). apply le_S, le_refl. exact H4.
     apply H5. apply le_n_S. exact H2.
     apply H0. destruct H1.
-    apply le_S_n. apply (le_trans _ _ _ H4).
+    apply le_S_n. apply (Nat.le_trans _ _ _ H4).
     apply H5, le_n_S, H2.
     apply (CRle_trans _ (ipt_seq Q (S i))). apply H0.
-    apply le_S_n. apply (le_trans _ _ _ H4). destruct H1.
+    apply le_S_n. apply (Nat.le_trans _ _ _ H4). destruct H1.
     apply H5, le_n_S, H2.
     destruct H1.
     apply (CRle_trans _ (ipt_seq Q (subseq (S n)))).
@@ -180,7 +180,7 @@ Proof.
   intros. pose proof (ipt_ordered_transit a b P).
   destruct P; unfold ipt_seq; simpl in H,H0,H2. split.
   - fold (a <= ipt_seq0 p). rewrite ipt_head0. apply H2. apply le_0_n.
-    apply (le_trans _ _ _ H1). exact H.
+    apply (Nat.le_trans _ _ _ H1). exact H.
   - intro abs. rewrite <- H0 in abs. apply (H2 p n).
     exact H1. exact H. exact abs.
 Qed.
@@ -252,7 +252,7 @@ Proof.
     reflexivity. symmetry. rewrite (partition_before_start _ _ _ (subseq O)).
     reflexivity.
     apply H1, le_0_n. rewrite H. symmetry. apply P.
-    apply le_0_n. rewrite des. apply (le_trans _ _ _ H3).
+    apply le_0_n. rewrite des. apply (Nat.le_trans _ _ _ H3).
     apply le_S, le_refl.
     rewrite (partition_before_start _ _ _ (subseq O)). reflexivity.
     apply H1, le_0_n. rewrite H. symmetry. apply P.
@@ -265,7 +265,7 @@ Proof.
   - replace (pred (subseq (S (ipt_last P))))
       with (pred (shiftSubseq (S (ipt_last P)))).
     apply (sum_by_packets (fun n : nat => (f (y n) * (ipt_seq Q (S n) - ipt_seq Q n)))).
-    intros. unfold shiftSubseq. destruct k. apply (le_lt_trans _ (subseq O)).
+    intros. unfold shiftSubseq. destruct k. apply (Nat.le_lt_trans _ (subseq O)).
     apply le_0_n. apply H0. auto. apply le_n_S. exact H2.
     apply H0. apply le_refl. apply le_n_S. exact H2. reflexivity.
     reflexivity.
@@ -301,16 +301,16 @@ Proof.
     reflexivity. rewrite H. symmetry. apply P. apply le_refl.
     rewrite <- (Nat.add_0_r (subseq (S (ipt_last P)))).
     rewrite <- Nat.add_assoc. apply Nat.add_le_mono_l, le_0_n.
-    apply (le_trans _ (subseq (S (ipt_last P)) + p)).
+    apply (Nat.le_trans _ (subseq (S (ipt_last P)) + p)).
     apply Nat.add_le_mono_l. exact H5. rewrite Nat.add_comm, H3.
     apply le_S, le_refl.
     rewrite (partition_after_end _ _ _ (subseq (S (ipt_last P)))).
     reflexivity. rewrite H. symmetry. apply P. apply le_refl.
-    apply (le_trans _ (S (subseq (S (ipt_last P))))).
+    apply (Nat.le_trans _ (S (subseq (S (ipt_last P))))).
     apply le_S, le_refl. apply le_n_S.
     rewrite <- (Nat.add_0_r (subseq (S (ipt_last P)))).
     rewrite <- Nat.add_assoc. apply Nat.add_le_mono_l, le_0_n.
-    apply le_n_S. apply (le_trans _ (subseq (S (ipt_last P)) + p)).
+    apply le_n_S. apply (Nat.le_trans _ (subseq (S (ipt_last P)) + p)).
     apply Nat.add_le_mono_l. exact H5. rewrite Nat.add_comm, H3.
     apply le_refl. rewrite H4, H3. rewrite Nat.add_comm. reflexivity.
 Qed.
@@ -366,7 +366,7 @@ Proof.
       apply CRplus_le_compat. 2: apply CRle_refl.
       apply ipt_ordered.
       apply le_S_n. apply le_n_S in H5.
-      apply (le_trans _ (subseq (S n))).
+      apply (Nat.le_trans _ (subseq (S n))).
       rewrite Nat.succ_pred in H5.
       rewrite Nat.add_comm. apply Nat.lt_add_lt_sub_l. exact H5.
       intro abs.
@@ -386,7 +386,7 @@ Proof.
       apply (ipt_ordered Q).
       apply le_n_S in H5. rewrite Nat.succ_pred in H5.
       apply le_S_n.
-      apply (le_trans _ (subseq (S n))).
+      apply (Nat.le_trans _ (subseq (S n))).
       rewrite Nat.add_comm. apply Nat.lt_add_lt_sub_l. exact H5.
       apply H2, le_n_S, H4.
       intro abs.
@@ -398,7 +398,7 @@ Proof.
       2: exact H3.
       apply (in_refinement_packet a b n (n0 + subseq n) x y P Q subseq H0 H1 H2 H4).
       apply le_n_S in H5. rewrite Nat.succ_pred in H5.
-      apply (le_trans _ (0 + subseq n)). apply le_refl.
+      apply (Nat.le_trans _ (0 + subseq n)). apply le_refl.
       apply Nat.add_le_mono_r. apply le_0_n.
       intro abs.
       destruct H2, H2. specialize (H2 n (S n) (le_refl _)).
@@ -417,12 +417,12 @@ Proof.
       replace (S (pred (subseq (S n) - subseq n) + subseq n))
         with (subseq (S n)).
       destruct H2. rewrite H2. 2: apply le_n_S, H4. rewrite H2. apply CRle_refl.
-      apply (le_trans _ _ _ H4). apply le_S, le_refl.
+      apply (Nat.le_trans _ _ _ H4). apply le_S, le_refl.
       replace (S (Init.Nat.pred (subseq (S n) - subseq n) + subseq n))
         with (S (Init.Nat.pred (subseq (S n) - subseq n)) + subseq n)%nat.
       2: reflexivity. rewrite Nat.succ_pred.
       rewrite Nat.sub_add. reflexivity.
-      apply (le_trans _ (S (subseq n))). apply le_S, le_refl. apply H2.
+      apply (Nat.le_trans _ (S (subseq n))). apply le_S, le_refl. apply H2.
       apply le_refl. apply le_n_S, H4.
       intro abs.
       destruct H2, H5.
@@ -441,12 +441,12 @@ Proof.
       replace (S (pred (subseq (S i) - subseq i) + subseq i))
         with (subseq (S i)).
       destruct H2. rewrite (H2 i). rewrite (H2 (S i)). reflexivity.
-      apply le_n_S, H4. apply (le_trans _ _ _ H4), le_S, le_refl.
+      apply le_n_S, H4. apply (Nat.le_trans _ _ _ H4), le_S, le_refl.
       replace (S (Init.Nat.pred (subseq (S i) - subseq i) + subseq i))
         with (S (Init.Nat.pred (subseq (S i) - subseq i)) + subseq i)%nat.
       2: reflexivity. rewrite Nat.succ_pred.
       rewrite Nat.sub_add. reflexivity.
-      apply (le_trans _ (S (subseq i))). apply le_S, le_refl. apply H2.
+      apply (Nat.le_trans _ (S (subseq i))). apply le_S, le_refl. apply H2.
       apply le_refl. apply le_n_S, H4.
       intro abs.
       destruct H2, H5.
@@ -865,7 +865,7 @@ Proof.
           (ipt_last (IntervalEquiPartition a b (Init.Nat.max n0 x0) leab)) - x)).
     rewrite CRabs_opp. apply u.
     unfold IntervalEquiPartition, ipt_last.
-    apply (le_trans _ _ _ H1), Nat.le_max_l.
+    apply (Nat.le_trans _ _ _ H1), Nat.le_max_l.
     unfold CRminus. do 2 rewrite CRopp_plus_distr.
     rewrite <- CRplus_assoc. apply CRplus_morph. 2: reflexivity.
     rewrite CRplus_comm, <- CRplus_assoc, CRplus_opp_l.
@@ -877,7 +877,7 @@ Proof.
     rewrite CRabs_right.
     apply CR_of_Q_le. unfold Qle, Qnum, Qden. do 2 rewrite Z.mul_1_l.
     apply Pos2Z.pos_le_pos. apply Pos2Nat.inj_le.
-    rewrite Nat2Pos.id. apply (le_trans _ _ _ H1), le_S, le_refl.
+    rewrite Nat2Pos.id. apply (Nat.le_trans _ _ _ H1), le_S, le_refl.
     discriminate. apply CR_of_Q_le. discriminate.
     unfold CRminus.
     rewrite CRplus_comm, <- CRplus_assoc, CRplus_opp_l, CRplus_0_l.
@@ -1171,14 +1171,14 @@ Proof.
   - apply P.
   - unfold ConcatSequences.
     destruct (lt_dec (S (S (ipt_last P) + ipt_last Q)) (S (ipt_last P))).
-    + exfalso. apply (lt_not_le _ _ l), le_n_S, (le_trans _ (S (ipt_last P) + 0)).
+    + exfalso. apply (lt_not_le _ _ l), le_n_S, (Nat.le_trans _ (S (ipt_last P) + 0)).
       rewrite Nat.add_0_r. apply le_S, le_refl. apply Nat.add_le_mono_l, le_0_n.
     + replace (S (S (ipt_last P) + ipt_last Q) - (S (ipt_last P)))%nat
         with (S (ipt_last Q)).
       apply Q. rewrite Nat.sub_succ. simpl plus.
       rewrite Nat.sub_succ_l. apply f_equal.
       rewrite Nat.add_comm, Nat.add_sub. reflexivity.
-      apply (le_trans _ (ipt_last P + 0)). rewrite Nat.add_comm. apply le_refl.
+      apply (Nat.le_trans _ (ipt_last P + 0)). rewrite Nat.add_comm. apply le_refl.
       apply Nat.add_le_mono_l, le_0_n.
   - intros. unfold ConcatSequences.
     destruct (lt_dec (S n) (S (ipt_last P))).
@@ -1193,7 +1193,7 @@ Proof.
       rewrite Nat.add_succ_r. exact H. clear n0.
       apply ipt_ordered_transit. apply Nat.le_sub_le_add_r.
       rewrite Nat.sub_add. apply le_S, le_refl.
-      apply Nat.nlt_ge in n1. apply le_n_S, (le_trans _ (S (ipt_last P))).
+      apply Nat.nlt_ge in n1. apply le_n_S, (Nat.le_trans _ (S (ipt_last P))).
       apply le_S, le_refl. exact n1. apply Nat.le_sub_le_add_r.
       simpl. apply le_n_S. rewrite Nat.add_comm. exact H.
 Defined.
@@ -1227,12 +1227,12 @@ Proof.
   - apply CRsum_eq. intros. unfold ConcatSequences.
     destruct (lt_dec (S ipt_last0 + i) (S ipt_last0)).
     exfalso. apply (lt_not_le _ _ l).
-    apply (le_trans _ (S ipt_last0 + 0)).
+    apply (Nat.le_trans _ (S ipt_last0 + 0)).
     rewrite Nat.add_0_r. apply le_refl. apply Nat.add_le_mono_l, le_0_n.
     clear n.
     destruct (lt_dec (S (S ipt_last0 + i)) (S ipt_last0)).
     exfalso. apply lt_not_le in l. apply l, le_n_S.
-    apply (le_trans _ (S ipt_last0 + 0)).
+    apply (Nat.le_trans _ (S ipt_last0 + 0)).
     rewrite Nat.add_0_r. apply le_S, le_refl. apply Nat.add_le_mono_l, le_0_n.
     clear n.
     replace (S ipt_last0 + i - S ipt_last0)%nat with i.
@@ -1281,10 +1281,10 @@ Proof.
         with (yn (S p) - yn p).
       apply H0. unfold ConcatSequences.
       destruct (lt_dec (S (n + p)) n). exfalso. apply (lt_not_le _ _ l).
-      apply (le_trans _ (S n + 0)). rewrite Nat.add_0_r. apply le_S, le_refl.
+      apply (Nat.le_trans _ (S n + 0)). rewrite Nat.add_0_r. apply le_S, le_refl.
       simpl. apply le_n_S, Nat.add_le_mono_l, le_0_n.
       clear n0. destruct (lt_dec (n + p) n). exfalso. apply (lt_not_le _ _ l).
-      apply (le_trans _ (n + 0)). rewrite Nat.add_0_r. apply le_refl.
+      apply (Nat.le_trans _ (n + 0)). rewrite Nat.add_0_r. apply le_refl.
       apply Nat.add_le_mono_l, le_0_n. clear n0.
       rewrite (Nat.add_comm n), Nat.add_sub. apply CRplus_morph.
       2: reflexivity.
@@ -1367,8 +1367,8 @@ Proof.
   - intros. unfold ConcatSequences.
     destruct (lt_dec n (S ipt_last0)).
     + rewrite app_nth1. apply H1. apply le_S_n in l.
-      apply (le_trans _ ipt_last0 _ l), le_S, le_refl.
-      rewrite H. apply (lt_trans _ _ _ l), le_refl.
+      apply (Nat.le_trans _ ipt_last0 _ l), le_S, le_refl.
+      rewrite H. apply (Nat.lt_trans _ _ _ l), le_refl.
     + destruct (Nat.lt_trichotomy n (S ipt_last0)).
       contradiction. destruct H4. subst n.
       rewrite app_nth1. rewrite Nat.sub_diag, <- ipt_head1.
@@ -1739,7 +1739,7 @@ Proof.
         with (2 + ipt_last P + ipt_last Q)%nat.
       reflexivity. rewrite (Nat.add_comm 2), Nat.add_assoc. reflexivity.
       rewrite H. apply le_n_S, le_0_n.
-      rewrite MergeLength. apply (lt_trans _ (0 + length x0)).
+      rewrite MergeLength. apply (Nat.lt_trans _ (0 + length x0)).
       simpl. rewrite H1. apply le_n_S, le_0_n.
       apply Nat.add_lt_mono_r. rewrite H. apply le_n_S, le_0_n.
     + rewrite LastNth, MergeLength in H3.
@@ -1751,7 +1751,7 @@ Proof.
         with (2 + ipt_last P + ipt_last Q)%nat.
       reflexivity. rewrite (Nat.add_comm 2), <- Nat.add_assoc. reflexivity.
       rewrite H1. apply le_n_S, le_0_n.
-      rewrite MergeLength. apply (lt_trans _ (0 + length x0)).
+      rewrite MergeLength. apply (Nat.lt_trans _ (0 + length x0)).
       simpl. rewrite H1. apply le_n_S, le_0_n.
       apply Nat.add_lt_mono_r. rewrite H. apply le_n_S, le_0_n.
   - pose proof (PartitionRationalLocSorted
@@ -1763,7 +1763,7 @@ Proof.
     pose proof (Sorted_merge x x0 sortP sortQ).
     apply (LocSortedFun _ H n).
     rewrite MergeLength. destruct a0, a1. rewrite H0, H3.
-    simpl. apply le_n_S, le_n_S. apply (le_trans _ _ _ H1).
+    simpl. apply le_n_S, le_n_S. apply (Nat.le_trans _ _ _ H1).
     do 2 rewrite Nat.add_succ_r. apply le_refl.
 Defined.
 
@@ -1775,8 +1775,8 @@ Proof.
   induction p.
   - intros. exfalso. inversion H0.
   - intros. apply Nat.le_succ_r in H0. destruct H0.
-    apply (lt_trans _ (xn p)). apply IHp. exact H0.
-    apply (le_trans _ (S p)). apply le_S, le_refl. exact H1.
+    apply (Nat.lt_trans _ (xn p)). apply IHp. exact H0.
+    apply (Nat.le_trans _ (S p)). apply le_S, le_refl. exact H1.
     apply H. exact H1. inversion H0. subst n.
     apply H. exact H1.
 Qed.
@@ -1824,7 +1824,7 @@ Proof.
     + unfold RationalPartitionMerge, ipt_last.
       destruct P,Q; simpl in a0, a1.
       intros. destruct a0, a1. apply le_S_n.
-      apply (le_trans _ (S (S ipt_last0) + S (S ipt_last1))).
+      apply (Nat.le_trans _ (S (S ipt_last0) + S (S ipt_last1))).
       rewrite <- H0, <- H2.
       apply (MergeInjectLBound (S (2 + ipt_last0 + (2+ ipt_last1)))).
       rewrite H0, H2. apply le_refl.
@@ -1848,7 +1848,7 @@ Proof.
     + unfold RationalPartitionMerge, ipt_last.
       destruct P,Q; simpl in a0, a1.
       intros. destruct a0, a1. apply le_S_n.
-      apply (le_trans _ (S (S ipt_last0) + S (S ipt_last1))).
+      apply (Nat.le_trans _ (S (S ipt_last0) + S (S ipt_last1))).
       rewrite <- H0, <- H2.
       apply (MergeInjectRBound (S (2 + ipt_last0 + (2+ ipt_last1)))).
       rewrite H0, H2. apply le_refl.

--- a/reals/stdlib/ConstructiveDiagonal.v
+++ b/reals/stdlib/ConstructiveDiagonal.v
@@ -39,7 +39,7 @@ Lemma SubSeqAboveId : forall (un : SubSeq) (n : nat),
 Proof.
   intros [un inc]. induction n. simpl. apply le_0_n.
   simpl. simpl in IHn. specialize (inc n (S n)).
-  unfold lt in inc. apply (le_trans _ (S (un n))).
+  unfold lt in inc. apply (Nat.le_trans _ (S (un n))).
   apply le_n_S. assumption. apply inc. apply le_refl.
 Qed.
 
@@ -93,7 +93,7 @@ Proof.
       specialize (IHk H p H0). contradiction. subst p. contradiction.
     + intros. simpl. destruct (Nat.eq_dec (proj1_sig un (S k)) n).
       exfalso. specialize (H (S k) (le_refl _)). contradiction.
-      apply IHk. intros. apply H. apply (le_trans _ k). assumption.
+      apply IHk. intros. apply H. apply (Nat.le_trans _ k). assumption.
       apply le_S. apply le_refl.
 Qed.
 
@@ -165,7 +165,7 @@ Proof.
     intro absurd. (* sub reaches a number between sub n and sub (S n) *)
     destruct sub as [sub inc]. simpl in absurd, H0, H.
     assert (sub p < sub (S n))%nat.
-    { rewrite absurd. apply (lt_le_trans _ (S (sub n)
+    { rewrite absurd. apply (Nat.lt_le_trans _ (S (sub n)
                                             + (sub (S n) - S (sub n)))).
       simpl. apply le_n_S. apply Nat.add_lt_mono_l. assumption. rewrite plus_comm.
       rewrite Nat.sub_add. apply le_refl. apply inc. apply le_refl. }
@@ -194,7 +194,7 @@ Lemma SubSeqCv : forall {R : ConstructiveReals} (un : nat -> CRcarrier R)
     CR_cv R un l -> CR_cv R (fun n => un (proj1_sig sub n)) l.
 Proof.
   intros. intros p. specialize (H p) as [N cv].
-  exists N. intros. apply cv. apply (le_trans _ i).
+  exists N. intros. apply cv. apply (Nat.le_trans _ i).
   assumption. apply SubSeqAboveId.
 Qed.
 
@@ -426,7 +426,7 @@ Lemma DiagTriangleShift : forall (p n : nat),
     le (i + j) n -> le p (diagPlane 0 n).
 Proof.
   intros. destruct (diagPlaneInv p) as [i j] eqn:des. intros.
-  apply (le_trans p (diagPlane 0 (i+j))).
+  apply (Nat.le_trans p (diagPlane 0 (i+j))).
   replace (diagPlane 0 (i + j)) with (p + i)%nat.
   rewrite <- (plus_0_r p). rewrite <- plus_assoc. apply Nat.add_le_mono_l.
   apply le_0_n. pose proof (diagPlaneSurject p).
@@ -477,12 +477,12 @@ Proof.
     specialize (H0 (S n) (Pos.of_nat epsN)) as [p lim].
     exists (p + pp)%nat. intros. apply Nat.le_succ_r in H0.
     apply CRltEpsilon. destruct H0.
-    + apply CRltForget. apply geo. assumption. apply (le_trans pp (p + pp)).
+    + apply CRltForget. apply geo. assumption. apply (Nat.le_trans pp (p + pp)).
       rewrite <- (plus_0_l pp). rewrite plus_assoc. apply Nat.add_le_mono_r.
       apply le_0_n. assumption.
     + subst k. apply CRltForget.
       apply (CRle_lt_trans _ (CR_of_Q R (1 # Pos.of_nat epsN))).
-      apply lim. apply (le_trans p (p + pp)).
+      apply lim. apply (Nat.le_trans p (p + pp)).
       rewrite <- (plus_0_r p). rewrite <- plus_assoc. apply Nat.add_le_mono_l.
       apply le_0_n. assumption.
       apply (CRmult_lt_compat_l eps) in maj. 2: exact H.
@@ -690,7 +690,7 @@ Proof.
       apply (CRle_lt_trans _ _ _ (CRle_abs _)).
       rewrite CRabs_minus_sym.
       apply H2. pose proof (DiagTriangleShift Nabs (S n +p)). rewrite desNabs in H3.
-      apply H3. apply (le_trans _ n). assumption. simpl. apply le_S.
+      apply H3. apply (Nat.le_trans _ n). assumption. simpl. apply le_S.
       rewrite <- (plus_0_r n). rewrite <- plus_assoc.
       apply Nat.add_le_mono_l. apply le_0_n.
       intros. unfold diagSeq. destruct (diagPlaneInv i0). reflexivity.
@@ -713,7 +713,7 @@ Proof.
       reflexivity. rewrite <- CRplus_assoc, CRplus_opp_l, CRplus_0_l. reflexivity.
       apply (CRlt_trans _ (eps * CRpow (CR_of_Q R (1 # 2)) 3 * CR_of_Q R 2)).
       apply (DiagSeqNegTriangle _ _ _ _ sAbs). intros. apply H2.
-      apply (le_trans _ (diagPlane 0 n)); assumption. rewrite <- (CRmult_comm (CR_of_Q R 2)).
+      apply (Nat.le_trans _ (diagPlane 0 n)); assumption. rewrite <- (CRmult_comm (CR_of_Q R 2)).
       rewrite CRmult_assoc. apply CRmult_lt_compat_r. apply CRmult_lt_0_compat.
       assumption. apply CRpow_gt_zero. simpl.
       apply CR_of_Q_lt. reflexivity.
@@ -888,9 +888,9 @@ Proof.
     specialize (H O). rewrite H0 in H. apply H.
   - destruct (FindPointInSubdivision Pn n H H0) as [k kmaj].
     destruct (le_lt_dec (Pn (S k)) (S n)).
-    + exists (S k). split. apply l. apply (lt_le_trans _ (S (Pn (S k)))).
+    + exists (S k). split. apply l. apply (Nat.lt_le_trans _ (S (Pn (S k)))).
       apply le_n_S. apply kmaj. apply (H (S k)).
-    + exists k. split. 2: apply l. apply (le_trans _ n).
+    + exists k. split. 2: apply l. apply (Nat.le_trans _ n).
       apply kmaj. apply le_S. apply le_refl.
 Qed.
 
@@ -904,7 +904,7 @@ Proof.
   - intros. apply le_0_n.
   - intros. destruct (FindPointInSubdivision Pn n Pinc Pzero) as [r rmaj].
     simpl in IHi. simpl. assert (i <= r)%nat.
-    apply IHi. apply (le_trans _ (Pn (S i))). 2: apply H.
+    apply IHi. apply (Nat.le_trans _ (Pn (S i))). 2: apply H.
     specialize (Pinc i). apply le_S in Pinc. apply le_S_n in Pinc. apply Pinc.
     clear IHi. apply le_n_S in H0. apply Nat.le_succ_r in H0.
     destruct H0. apply H0. exfalso. inversion H0. subst i.
@@ -946,8 +946,8 @@ Proof.
   { induction q.
     - intros. inversion H3. apply le_refl.
     - intros. apply Nat.le_succ_r in H3. destruct H3.
-      apply (le_trans _ (Pn q)). apply IHq. apply H3.
-      apply (le_trans _ (S (Pn q))). apply le_S. apply le_refl.
+      apply (Nat.le_trans _ (Pn q)). apply IHq. apply H3.
+      apply (Nat.le_trans _ (S (Pn q))). apply le_S. apply le_refl.
       apply H. subst p. apply le_refl. }
   assert (forall p:nat,
              CRsum (fun n : nat => CRsum (fun k : nat => xn (k + Pn n))%nat (Pn (S n) - Pn n - 1)) p
@@ -958,7 +958,7 @@ Proof.
       rewrite plus_0_r. reflexivity.
     - simpl. rewrite IHp. clear IHp.
       destruct (Nat.le_exists_sub 1 (Pn (S p))) as [r [H3 _]].
-      specialize (H p). apply (le_trans _ (S (Pn p))). 2: apply H.
+      specialize (H p). apply (Nat.le_trans _ (S (Pn p))). 2: apply H.
       apply le_n_S. apply le_0_n.
       assert (r+1 = S r)%nat. rewrite plus_comm. reflexivity.
       rewrite H3. rewrite Nat.add_sub.
@@ -968,7 +968,7 @@ Proof.
         with (Pn (S (S p)) - 1)%nat.
       reflexivity. rewrite Nat.add_sub_assoc.
       rewrite <- H4. rewrite plus_comm. rewrite Nat.sub_add.
-      reflexivity. rewrite <- H3. apply (le_trans _ (S (Pn (S p)))).
+      reflexivity. rewrite <- H3. apply (Nat.le_trans _ (S (Pn (S p)))).
       apply le_S. apply le_refl. apply H. rewrite <- H3.
       destruct (Nat.le_exists_sub (S (Pn (S p))) (Pn (S (S p)))).
       apply H. destruct H5. rewrite H5. simpl.
@@ -987,7 +987,7 @@ Proof.
     repeat rewrite assocSum. split.
     apply pos_sum_more. apply H0. destruct p.
     exfalso. apply Nat.le_ngt in H3. destruct pmaj. contradiction.
-    simpl. rewrite Nat.sub_0_r. apply (le_trans _ (Pn (S p))).
+    simpl. rewrite Nat.sub_0_r. apply (Nat.le_trans _ (Pn (S p))).
     2: apply pmaj. apply Nat.le_sub_l.
     apply pos_sum_more. apply H0. apply Nat.le_add_le_sub_r.
     rewrite plus_comm. apply pmaj. }
@@ -1002,14 +1002,14 @@ Proof.
            _ _ (CRsum (fun n : nat => CRsum (fun k : nat => xn (k + Pn n)%nat) (Pn (S n) - Pn n - 1)) (q-1))
            _ (CRsum (fun n : nat => CRsum (fun k : nat => xn (k + Pn n)%nat) (Pn (S n) - Pn n - 1)) q)).
   split; apply H3.
-  apply (le_trans _ (Pn (S p))). 2: apply H2.
+  apply (Nat.le_trans _ (Pn (S p))). 2: apply H2.
   apply PnInc. apply le_n_S. apply le_0_n.
-  apply (le_trans _ (Pn (S p))). 2: apply H2.
+  apply (Nat.le_trans _ (Pn (S p))). 2: apply H2.
   apply PnInc. apply le_n_S. apply le_0_n.
   rewrite CRabs_minus_sym.
   apply pmaj. apply Nat.le_add_le_sub_r.
   rewrite plus_comm. apply H5.
   rewrite CRabs_minus_sym; apply pmaj.
-  apply (le_trans _ (S p)).
+  apply (Nat.le_trans _ (S p)).
   apply le_S. apply le_refl. apply H5.
 Qed.

--- a/reals/stdlib/ConstructiveUniformCont.v
+++ b/reals/stdlib/ConstructiveUniformCont.v
@@ -412,7 +412,7 @@ Proof.
     rewrite Nat.sub_0_r. reflexivity.
   - intros.
     assert (forall k : nat, k <= n -> Pn k < Pn (S k))%nat.
-    { intros. apply H. apply (le_trans _ n _ H1). apply le_S, le_refl. }
+    { intros. apply H. apply (Nat.le_trans _ n _ H1). apply le_S, le_refl. }
     specialize (IHn H1 H0). clear H1. simpl.
     rewrite IHn.
     destruct (Pn (S (S n)) - Pn (S n))%nat eqn:des.
@@ -435,7 +435,7 @@ Proof.
     rewrite <- des. rewrite Nat.add_comm. rewrite Nat.sub_add.
     reflexivity. destruct (le_lt_dec n2 n1).
     apply Nat.sub_0_le in l. rewrite l in des. discriminate.
-    apply (le_trans _ (S n1)). apply le_S, le_refl. exact l.
+    apply (Nat.le_trans _ (S n1)). apply le_S, le_refl. exact l.
 Qed.
 
 
@@ -446,7 +446,7 @@ Proof.
   induction n.
   - apply le_0_n.
   - destruct sub; simpl. simpl in IHn. specialize (l n (S n) (le_refl _)).
-    apply (le_trans _ (S (x n))). apply le_n_S, IHn. exact l.
+    apply (Nat.le_trans _ (S (x n))). apply le_n_S, IHn. exact l.
 Qed.
 
 Lemma SubSeqCvMerge : forall {R : ConstructiveReals} (un : nat -> CRcarrier R)
@@ -456,7 +456,7 @@ Lemma SubSeqCvMerge : forall {R : ConstructiveReals} (un : nat -> CRcarrier R)
 Proof.
   intros. intros n. specialize (H0 n) as [p pmaj].
   exists p. intros. apply pmaj.
-  apply (le_trans _ i _ H0), H.
+  apply (Nat.le_trans _ i _ H0), H.
 Qed.
 
 Lemma Qpower_positive : forall (q : Q) (n : nat),
@@ -1204,7 +1204,7 @@ Proof.
       apply CRmult_lt_reg_r in kmaj. 2: apply (fst fUC).
       destruct (Q_dec (Z.pos p # 1) (Z.of_nat k # 1)). destruct s.
       unfold Qlt, Qnum, Qden in q.
-      apply le_S_n. apply (le_trans _ k).
+      apply le_S_n. apply (Nat.le_trans _ k).
       apply Nat2Z.inj_lt. rewrite positive_nat_Z.
       do 2 rewrite Z.mul_1_r in q. exact q.
       apply le_S, le_refl. exfalso. apply (CR_of_Q_lt R) in q.

--- a/transc/Pi.v
+++ b/transc/Pi.v
@@ -403,7 +403,7 @@ Proof.
        apply Sum_resp_leEq.
         rewrite <- H3; auto.
        intros; apply pi_seq_bnd''.
-       apply le_trans with (S (S N)); auto with arith.
+       apply Nat.le_trans with (S (S N)); auto with arith.
       eapply leEq_wdl.
        2: apply eq_symmetric; apply Sum_comm_scal with (s := fun i : nat => z[^]pred i).
       rstepl (Sum (S (S N)) (pred m) (fun i : nat => z[^]pred i) [*] (pi_seq 2[-]pi_seq 1)).

--- a/transc/PowerSeries.v
+++ b/transc/PowerSeries.v
@@ -269,7 +269,7 @@ Proof.
   apply pos_max_one.
  apply leEq_transitive with (c[*]AbsIR (a n)).
   apply H0.
-  apply le_trans with (max N y); auto; apply le_max_l.
+  apply Nat.le_trans with (max N y); auto; apply le_max_l.
  apply shift_leEq_div.
   apply pos_max_one.
  rstepl (c[*]Max (Max b x0[-]Min a0 x0) [1][*]AbsIR (a n)).
@@ -284,7 +284,7 @@ Proof.
  apply nring_less.
  red in |- *.
  cut (y <= n); intros; auto with arith.
- apply le_trans with (max N y); auto with arith.
+ apply Nat.le_trans with (max N y); auto with arith.
 Qed.
 
 Lemma FPowerSeries'_conv : fun_series_convergent_IR realline FPowerSeries'.


### PR DESCRIPTION
The naked variants lt_trans, le_trans, lt_le_trans, le_lt_trans, are all deprecated and being replaced with variants from Nat.