### PR TITLE
More fixes for deprecated notation warnings

### DIFF
--- a/algebra/Bernstein.v
+++ b/algebra/Bernstein.v
@@ -279,7 +279,7 @@ match v in Vector.t _ i return i <= n -> cpoly_cring R with
 |Vector.nil => fun _ => [0]
 |Vector.cons a i' v' =>
   match n as n return (S i' <= n) -> cpoly_cring R with
-  | O => fun p => False_rect _ (le_Sn_O _ p)
+  | O => fun p => False_rect _ (Nat.nle_succ_0 _ p)
   | S n' => fun p => _C_ a[*]Bernstein (le_S_n _ _ p)[+]evalBernsteinBasisH v' (le_Sn_le _ _ p)
   end
 end.
@@ -399,7 +399,7 @@ Fixpoint BernsteinBasisTimesXH (n i:nat) (v:Vector.t R i) : i <= n -> Vector.t R
 match v in Vector.t _ i return i <= n -> Vector.t R (S i) with
 | Vector.nil => fun _ => Vector.cons [0] _ Vector.nil
 | Vector.cons a i' v' => match n as n return S i' <= n -> Vector.t R (S (S i')) with
-  | O => fun p => False_rect _ (le_Sn_O _ p)
+  | O => fun p => False_rect _ (Nat.nle_succ_0 _ p)
   | S n' => fun p => Vector.cons (eta(Qred (i#P_of_succ_nat n'))[*]a) _ (BernsteinBasisTimesXH v' (le_Sn_le _ _ p))
   end
 end.

--- a/algebra/CAbGroups.v
+++ b/algebra/CAbGroups.v
@@ -327,7 +327,7 @@ Qed.
 Lemma nmult_mult : forall n m x, nmult (nmult x m) n [=] nmult x (m * n).
 Proof.
  simple induction n.
-  intro. rewrite mult_0_r. algebra.
+  intro. rewrite Nat.mul_0_r. algebra.
   clear n; intros.
  simpl in |- *.
  rewrite Nat.mul_comm. simpl in |- *.

--- a/algebra/COrdCauchy.v
+++ b/algebra/COrdCauchy.v
@@ -306,7 +306,7 @@ Proof.
   exists 1.
   repeat split. 1-2: reflexivity.
   intros.
-  rewrite <- (le_antisym _ _ H H0).
+  rewrite <- (Nat.le_antisymm _ _ H H0).
   astepr (a 1[+][0]).
   unfold cg_minus in |- *.
   apply plus_resp_leEq_lft.

--- a/algebra/COrdFields2.v
+++ b/algebra/COrdFields2.v
@@ -1016,7 +1016,7 @@ Proof.
   astepr ((x[^]2)[^]m).
   apply nexp_resp_pos.
   apply pos_square. auto.
-  rewrite y. unfold double in |- *. lia.
+  rewrite y. unfold Nat.double in |- *. lia.
 Qed.
 
 

--- a/algebra/CPoly_Degree.v
+++ b/algebra/CPoly_Degree.v
@@ -170,7 +170,7 @@ Qed.
 Lemma degree_le_x_ : degree_le 1 (_X_:RX).
 Proof.
  unfold degree_le in |- *.
- intro. elim m. intros. elim (lt_n_O _ H).
+ intro. elim m. intros. elim (Nat.nlt_0_r _ H).
  intro. elim n. intros. elim (Nat.lt_irrefl _ H0).
  intros. simpl in |- *. algebra.
 Qed.

--- a/algebra/CRings.v
+++ b/algebra/CRings.v
@@ -1104,7 +1104,7 @@ Proof.
  intros x n H.
  elim (even_2n n); try assumption.
  intros m H0.
- rewrite H0. unfold double in |- *.
+ rewrite H0. unfold Nat.double in |- *.
  astepl ( [--]x[^]m[*] [--]x[^]m).
  astepl (( [--]x[*] [--]x) [^]m).
  astepl ((x[*]x) [^]m).

--- a/complex/NRootCC.v
+++ b/complex/NRootCC.v
@@ -134,7 +134,7 @@ Proof.
  intros n' H.
  rewrite H.
  exists (n' * n' + n').
- unfold double in |- *.
+ unfold Nat.double in |- *.
  ring.
 Qed.
 
@@ -1318,15 +1318,15 @@ End NRootCC_4.
 
 Section NRootCC_5.
 
-Lemma nrCC_5a2 : forall n : nat, double n = 2 * n.
+Lemma nrCC_5a2 : forall n : nat, Nat.double n = 2 * n.
 Proof.
  intros.
- unfold double in |- *.
+ unfold Nat.double in |- *.
  unfold mult in |- *.
  auto with arith.
 Qed.
 
-Lemma nrCC_5a3 : forall (n : nat) (z : CC), (z[^]2) [^]n [=] z[^]double n.
+Lemma nrCC_5a3 : forall (n : nat) (z : CC), (z[^]2) [^]n [=] z[^]Nat.double n.
 Proof.
  intros.
  (* astepl z[^] (mult (2) n). *)
@@ -1345,7 +1345,7 @@ Hint Resolve nrCC_5a3: algebra.
 Variable c : CC.
 Hypothesis c_ : c [#] [0].
 
-Lemma nrCC_5a4 : forall n, 0 < n -> {z : CC | z[^]n [=] c} -> {z : CC | z[^]double n [=] c}.
+Lemma nrCC_5a4 : forall n, 0 < n -> {z : CC | z[^]n [=] c} -> {z : CC | z[^]Nat.double n [=] c}.
 Proof.
  intros n H H0.
  elim H0. intros x H1.

--- a/fta/KeyLemma.v
+++ b/fta/KeyLemma.v
@@ -121,7 +121,7 @@ Proof.
    Step_final (NRoot a_0_eps_nonneg gt_n_0[^]n).
   intros i H1 H2.
   replace i with n.
-   2: apply le_antisym; auto.
+   2: apply Nat.le_antisymm; auto.
   astepl ([1][*]NRoot a_0_eps_nonneg gt_n_0[^]n).
   astepl (NRoot a_0_eps_nonneg gt_n_0[^]n).
   astepl (a_0[-]eps).

--- a/ftc/COrdLemmas.v
+++ b/ftc/COrdLemmas.v
@@ -435,7 +435,7 @@ Proof.
      unfold f' in |- *.
      elim (le_lt_dec i m); elim (le_lt_dec (S i) m); intros; simpl in |- *.
         apply H1; apply Nat.lt_succ_diag_r.
-       cut (i = m); [ intro | apply le_antisym; auto with arith ].
+       cut (i = m); [ intro | apply Nat.le_antisymm; auto with arith ].
        generalize a; clear a; pattern i at 1 2 in |- *; rewrite H5; intro.
        set (x := f m a) in *.
        cut (x = f m (le_n m)).

--- a/ftc/FunctSequence.v
+++ b/ftc/FunctSequence.v
@@ -803,7 +803,7 @@ Proof.
  intros H H' e H0.
  elim (convF _ (pos_div_two _ _ H0)); intros Nf HNf.
  elim (convG _ (pos_div_two _ _ H0)); intros Ng HNg.
- cut (Nf <= Nat.max Nf Ng); [ intro | apply le_max_l ].
+ cut (Nf <= Nat.max Nf Ng); [ intro | apply Nat.le_max_l ].
  cut (Ng <= Nat.max Nf Ng); [ intro | apply le_max_r ].
  exists (Nat.max Nf Ng); intros.
  apply leEq_wdl with (AbsIR (Part _ _ (incf n x Hx) [+]Part _ _ (incg n x Hx) [-]
@@ -826,7 +826,7 @@ Proof.
  intros H H' e H0.
  elim (convF _ (pos_div_two _ _ H0)); intros Nf HNf.
  elim (convG _ (pos_div_two _ _ H0)); intros Ng HNg.
- cut (Nf <= Nat.max Nf Ng); [ intro | apply le_max_l ].
+ cut (Nf <= Nat.max Nf Ng); [ intro | apply Nat.le_max_l ].
  cut (Ng <= Nat.max Nf Ng); [ intro | apply le_max_r ].
  exists (Nat.max Nf Ng); intros.
  apply leEq_wdl with (AbsIR (Part _ _ (incf n x Hx) [-]Part _ _ (incg n x Hx) [-]
@@ -860,7 +860,7 @@ Proof.
     intro Hef.
     elim (convF _ Hef); intros NF HNF; clear convF.
     elim (convG _ Heg); intros NG HNG; clear convG.
-    cut (NF <= Nat.max NF NG); [ intro | apply le_max_l ].
+    cut (NF <= Nat.max NF NG); [ intro | apply Nat.le_max_l ].
     cut (NG <= Nat.max NF NG); [ intro | apply le_max_r ].
     exists (Nat.max NF NG); intros.
     apply leEq_transitive with ee.

--- a/ftc/FunctSequence.v
+++ b/ftc/FunctSequence.v
@@ -804,7 +804,7 @@ Proof.
  elim (convF _ (pos_div_two _ _ H0)); intros Nf HNf.
  elim (convG _ (pos_div_two _ _ H0)); intros Ng HNg.
  cut (Nf <= Nat.max Nf Ng); [ intro | apply Nat.le_max_l ].
- cut (Ng <= Nat.max Nf Ng); [ intro | apply le_max_r ].
+ cut (Ng <= Nat.max Nf Ng); [ intro | apply Nat.le_max_r ].
  exists (Nat.max Nf Ng); intros.
  apply leEq_wdl with (AbsIR (Part _ _ (incf n x Hx) [+]Part _ _ (incg n x Hx) [-]
    (Part _ _ (incF x Hx) [+]Part _ _ (incG x Hx)))).
@@ -827,7 +827,7 @@ Proof.
  elim (convF _ (pos_div_two _ _ H0)); intros Nf HNf.
  elim (convG _ (pos_div_two _ _ H0)); intros Ng HNg.
  cut (Nf <= Nat.max Nf Ng); [ intro | apply Nat.le_max_l ].
- cut (Ng <= Nat.max Nf Ng); [ intro | apply le_max_r ].
+ cut (Ng <= Nat.max Nf Ng); [ intro | apply Nat.le_max_r ].
  exists (Nat.max Nf Ng); intros.
  apply leEq_wdl with (AbsIR (Part _ _ (incf n x Hx) [-]Part _ _ (incg n x Hx) [-]
    (Part _ _ (incF x Hx) [-]Part _ _ (incG x Hx)))).
@@ -861,7 +861,7 @@ Proof.
     elim (convF _ Hef); intros NF HNF; clear convF.
     elim (convG _ Heg); intros NG HNG; clear convG.
     cut (NF <= Nat.max NF NG); [ intro | apply Nat.le_max_l ].
-    cut (NG <= Nat.max NF NG); [ intro | apply le_max_r ].
+    cut (NG <= Nat.max NF NG); [ intro | apply Nat.le_max_r ].
     exists (Nat.max NF NG); intros.
     apply leEq_transitive with ee.
      2: unfold ee in |- *; apply Min_leEq_lft.

--- a/ftc/FunctSeries.v
+++ b/ftc/FunctSeries.v
@@ -675,7 +675,7 @@ Proof.
  elim (convG _ H2).
  intros N HN; exists (S (Nat.max N k)).
  cut (N <= Nat.max N k); [ intro | apply Nat.le_max_l ].
- cut (k <= Nat.max N k); [ intro | apply le_max_r ].
+ cut (k <= Nat.max N k); [ intro | apply Nat.le_max_r ].
  split.
   auto with arith.
  intros m H5 x H6 Hx Hx'.

--- a/ftc/FunctSeries.v
+++ b/ftc/FunctSeries.v
@@ -674,7 +674,7 @@ Proof.
   apply HN; assumption.
  elim (convG _ H2).
  intros N HN; exists (S (Nat.max N k)).
- cut (N <= Nat.max N k); [ intro | apply le_max_l ].
+ cut (N <= Nat.max N k); [ intro | apply Nat.le_max_l ].
  cut (k <= Nat.max N k); [ intro | apply le_max_r ].
  split.
   auto with arith.

--- a/ftc/Integral.v
+++ b/ftc/Integral.v
@@ -1147,7 +1147,7 @@ Proof.
         assumption.
        apply nring_less.
        apply Nat.le_lt_trans with p.
-        unfold p in |- *; apply le_max_r.
+        unfold p in |- *; apply Nat.le_max_r.
        auto with arith.
       unfold EP2 in |- *; eapply less_wdl.
        2: apply eq_symmetric_unfolded; apply even_partition_Mesh.

--- a/ftc/Integral.v
+++ b/ftc/Integral.v
@@ -832,7 +832,7 @@ Proof.
  unfold partition_join_fun in |- *.
  elim (le_lt_dec 0 n); intro; simpl in |- *.
   apply start.
- exfalso; apply (lt_n_O _ b0).
+ exfalso; apply (Nat.nlt_0_r _ b0).
 Qed.
 
 Lemma partition_join_finish : forall H, partition_join_fun (S (n + m)) H [=] b.

--- a/ftc/Integral.v
+++ b/ftc/Integral.v
@@ -808,7 +808,7 @@ Proof.
  unfold partition_join_fun in |- *.
  elim (le_lt_dec i n); elim (le_lt_dec (S i) n); intros; simpl in |- *.
     apply prf2.
-   cut (n = i); [ intro | apply le_antisym; auto with arith ].
+   cut (n = i); [ intro | apply Nat.le_antisymm; auto with arith ].
    change (P i a0 [<=] Q (S i - S n) (partition_join_aux _ _ _ b0 H')) in |- *.
    generalize H' a0 b0; clear H' a0 b0.
    rewrite <- H0; intros.
@@ -942,7 +942,7 @@ Proof.
       apply b0.
      apply prf1; auto.
     exfalso; clear H'; rewrite b0 in a0; apply (Nat.nle_succ_diag_l _ a0).
-   cut (i = n); [ intro | clear H'; apply le_antisym; auto with arith ].
+   cut (i = n); [ intro | clear H'; apply Nat.le_antisymm; auto with arith ].
    generalize H a0 b0 H'; clear H' a0 b0 H; rewrite H0; intros.
    apply compact_wd with c.
     2: apply eq_symmetric_unfolded; apply pjp_2; auto.
@@ -1073,7 +1073,7 @@ Proof.
    apply lft_leEq_Max.
   exfalso; apply le_not_lt with i n; auto with arith.
  elim le_lt_dec; intro; simpl in |- *.
-  cut (i = n); [ intro | apply le_antisym; auto with arith ].
+  cut (i = n); [ intro | apply Nat.le_antisymm; auto with arith ].
   generalize a0 b0 Hi'; clear Hx Hi Hi' a0 b0.
   rewrite H0; intros.
   apply leEq_wdl with ZeroR.

--- a/ftc/Integral.v
+++ b/ftc/Integral.v
@@ -183,7 +183,7 @@ Proof.
     assumption.
    apply leEq_transitive with (nring (R:=IR) N).
     exact (ProjT2 (Archimedes (b[-]a[/] d[//]pos_ap_zero _ _ H0))).
-   apply nring_leEq; apply le_n_Sn.
+   apply nring_leEq; apply Nat.le_succ_diag_r.
   unfold e' in |- *.
   rstepl (e[*] (b[-]a) [/] _[//]max_one_ap_zero (b[-]a)).
   apply shift_div_leEq.

--- a/ftc/Integral.v
+++ b/ftc/Integral.v
@@ -1158,7 +1158,7 @@ Proof.
        assumption.
       apply nring_less.
       apply Nat.le_lt_trans with p.
-       unfold p in |- *; apply le_max_l.
+       unfold p in |- *; apply Nat.le_max_l.
       auto with arith.
      red in |- *; do 3 intro.
      rewrite H2; clear H2; intros.

--- a/ftc/Integral.v
+++ b/ftc/Integral.v
@@ -1057,7 +1057,7 @@ Proof.
  unfold Mesh at 1 in |- *.
  apply maxlist_leEq.
   apply length_Part_Mesh_List.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
  intros x H.
  elim (Part_Mesh_List_lemma _ _ _ _ _ _ H); intros i Hi.
  elim Hi; clear Hi; intros Hi Hi'.

--- a/ftc/MoreFunctions.v
+++ b/ftc/MoreFunctions.v
@@ -1411,7 +1411,7 @@ Lemma Deriv_lemma : forall F diffF, Derivative I pI F (Deriv F diffF).
 Proof.
  intros; unfold Deriv in |- *.
  apply Derivative_wdl with (N_Deriv 0 F
-   (le_imp_Diffble_n 0 1 (le_n_Sn 0) F (Diffble_imp_Diffble_n _ diffF))).
+   (le_imp_Diffble_n 0 1 (Nat.le_succ_diag_r 0) F (Diffble_imp_Diffble_n _ diffF))).
   apply Derivative_n_unique with 0 F.
    apply N_Deriv_lemma.
   apply Derivative_n_O; elim diffF; auto.

--- a/ftc/NthDerivative.v
+++ b/ftc/NthDerivative.v
@@ -274,7 +274,7 @@ Proof.
  intros n F H; induction  n as [| n Hrecn].
   simpl in H; Included.
  apply Hrecn.
- exact (le_imp_Diffble_I _ _ (le_n_Sn n) _ H).
+ exact (le_imp_Diffble_I _ _ (Nat.le_succ_diag_r n) _ H).
 Qed.
 
 (**

--- a/ftc/NthDerivative.v
+++ b/ftc/NthDerivative.v
@@ -488,11 +488,11 @@ Proof.
   cut (n = pred (S n)); [ intro | simpl in |- *; reflexivity ].
   rewrite H1.
   apply Diffble_I_imp_le with F.
-    apply lt_O_Sn.
+    apply Nat.lt_0_succ.
    assumption.
   unfold f' in |- *; apply projT2.
  apply Diffble_I_n_imp_diffble with (S n).
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
  assumption.
 Defined.
 
@@ -561,7 +561,7 @@ Proof.
   intros.
   apply Derivative_I_wdl with F.
    FEQ.
-  apply Derivative_I_wdr with (PartInt (ProjT1 (Diffble_I_n_imp_diffble _ _ _ _ (lt_O_Sn 0) _ HS))).
+  apply Derivative_I_wdr with (PartInt (ProjT1 (Diffble_I_n_imp_diffble _ _ _ _ (Nat.lt_0_succ 0) _ HS))).
    apply eq_imp_Feq.
      Included.
     Included.
@@ -615,7 +615,7 @@ Proof.
    FEQ.
    apply n_deriv_inc.
   cut (Diffble_I_n Hab' (m + n)
-    (PartInt (ProjT1 (Diffble_I_n_imp_diffble _ _ _ (S n) (lt_O_Sn n) F H0)))).
+    (PartInt (ProjT1 (Diffble_I_n_imp_diffble _ _ _ (S n) (Nat.lt_0_succ n) F H0)))).
    intro H1.
    eapply Derivative_I_n_wdr.
     2: eapply Derivative_I_n_wdl.

--- a/ftc/Partitions.v
+++ b/ftc/Partitions.v
@@ -118,7 +118,7 @@ Proof.
 Qed.
 
 Definition Partition_Dom a b Hab n P :
-  Partition a _ (part_pred_lemma a b Hab (S n) P n (le_n_Sn n)) n.
+  Partition a _ (part_pred_lemma a b Hab (S n) P n (Nat.le_succ_diag_r n)) n.
 Proof.
  intros.
  apply Build_Partition with (fun (i : nat) (Hi : i <= n) => P i (le_S _ _ Hi)).
@@ -146,7 +146,7 @@ Proof.
   apply (@nil IR).
  apply cons.
   apply (P _ (le_n (S n)) [-]P _ (le_S _ _ (le_n n))).
- apply Hrecn with a (P _ (le_n_Sn n)) (part_pred_lemma _ _ _ _ P n (le_n_Sn n)).
+ apply Hrecn with a (P _ (Nat.le_succ_diag_r n)) (part_pred_lemma _ _ _ _ P n (Nat.le_succ_diag_r n)).
  apply Partition_Dom.
 Defined.
 
@@ -655,7 +655,7 @@ Proof.
  cut (0 <> n); intro.
   eapply eq_transitive_unfolded.
    apply Mesh_wd' with (Q := Even_Partition (part_pred_lemma _ _ Hab (S n) (Even_Partition Hab _ Hm) n
-     (le_n_Sn n)) _ H0).
+     (Nat.le_succ_diag_r n)) _ H0).
    intros; simpl in |- *; rational.
   eapply eq_transitive_unfolded.
    apply H.

--- a/ftc/RefLemma.v
+++ b/ftc/RefLemma.v
@@ -183,7 +183,7 @@ Qed.
 Lemma RL_sub_S : forall i : nat, 0 < sub (S i).
 Proof.
  rewrite <- RL_sub_0.
- intro; apply RL_sub_mon; apply lt_O_Sn.
+ intro; apply RL_sub_mon; apply Nat.lt_0_succ.
 Qed.
 
 Let H : forall i j : nat, i < n -> j <= pred (sub (S i)) -> j < m.

--- a/ftc/RefLemma.v
+++ b/ftc/RefLemma.v
@@ -193,7 +193,7 @@ Proof.
  elim (le_lt_eq_dec _ _ H1); clear H1; intro.
   cut (sub (S i) < sub n); [ intro | apply RL_sub_mon; assumption ].
   rewrite <- RL_sub_n.
-  apply Nat.le_lt_trans with (sub (S i)); auto; eapply Nat.le_trans; [ apply H0 | apply le_pred_n ].
+  apply Nat.le_lt_trans with (sub (S i)); auto; eapply Nat.le_trans; [ apply H0 | apply Nat.le_pred_l ].
  cut (0 < sub (S i)); [ intro | apply RL_sub_S ].
  rewrite <- RL_sub_n.
  rewrite <- b0.

--- a/ftc/RefSepRef.v
+++ b/ftc/RefSepRef.v
@@ -138,8 +138,8 @@ Lemma RSR_f'_ap_g' : forall (i j : nat) Hi Hj, f' i Hi[#]g' j Hj.
 Proof.
  intros.
  unfold f', g' in |- *; apply RSR_H'.
-    apply lt_O_Sn.
-   apply lt_O_Sn.
+    apply Nat.lt_0_succ.
+   apply Nat.lt_0_succ.
   apply pred_lt; assumption.
  apply pred_lt; assumption.
 Qed.
@@ -395,7 +395,7 @@ Proof.
    apply Nat.lt_le_trans with j; try apply Nat.le_lt_trans with i; auto with arith.
   elim (le_lt_dec n j); intros; simpl in |- *.
    lia.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
  elim (le_lt_dec n i); elim (le_lt_dec j 0); intros; simpl in |- *.
     elim (Nat.lt_irrefl 0); apply Nat.lt_le_trans with j; try apply Nat.le_lt_trans with i; auto with arith.
    elim (le_lt_dec n j); intro; simpl in |- *.
@@ -586,7 +586,7 @@ Proof.
    apply Nat.le_lt_trans with i; try apply Nat.lt_le_trans with j; auto with arith.
   elim (le_lt_dec m j); intros; simpl in |- *.
    lia.
-  apply lt_O_Sn.
+  apply Nat.lt_0_succ.
  elim (le_lt_dec m i); elim (le_lt_dec j 0); intros; simpl in |- *.
     elim (Nat.lt_irrefl 0); apply Nat.le_lt_trans with i; try apply Nat.lt_le_trans with j; auto with arith.
    elim (le_lt_dec m j); intro; simpl in |- *.

--- a/ftc/RefSeparated.v
+++ b/ftc/RefSeparated.v
@@ -207,7 +207,7 @@ Proof.
    assumption.
   exfalso; apply (le_not_lt j' m); auto.
  elim (le_lt_dec j 0); intro.
-  exfalso; apply lt_n_O with j'; red in |- *; apply Nat.le_trans with j; auto.
+  exfalso; apply Nat.nlt_0_r with j'; red in |- *; apply Nat.le_trans with j; auto.
  generalize Hj H H0; clear H0 H Hj.
  set (jj := pred j) in *.
  cut (j = S jj); [ intro | unfold jj in |- *; apply S_pred with 0; auto ].

--- a/ftc/RefSeparated.v
+++ b/ftc/RefSeparated.v
@@ -453,7 +453,7 @@ Proof.
  intros.
  unfold sep__sep_fun in |- *.
  elim (le_lt_dec (S i) 0); intro; simpl in |- *.
-  exfalso; apply (le_Sn_O _ a0).
+  exfalso; apply (Nat.nle_succ_0 _ a0).
  elim (le_lt_dec i 0); intro; simpl in |- *.
   elim (le_lt_eq_dec _ _ Hi'); intro; simpl in |- *.
    apply less_leEq_trans with (P (S i) Hi').

--- a/ftc/RefSeparating.v
+++ b/ftc/RefSeparating.v
@@ -1050,7 +1050,7 @@ Proof.
  apply sep__part_h_mon_3.
   rewrite <- sep__part_fun_i with (H := Nat.le_0_l m).
    2: apply RS'_pos_m.
-  2: apply lt_O_Sn.
+  2: apply Nat.lt_0_succ.
  rewrite <- sep__part_fun_m with (H := le_n m).
  apply sep__part_fun_mon.
  apply RS'_pos_m.

--- a/ftc/RefSeparating.v
+++ b/ftc/RefSeparating.v
@@ -600,7 +600,7 @@ Proof.
   rewrite sep__part_fun_i.
    2: assumption.
   intros.
-  cut (pred (sep__part_h (S i)) <= n); [ intro | eapply Nat.le_trans; [ apply le_pred_n | auto ] ].
+  cut (pred (sep__part_h (S i)) <= n); [ intro | eapply Nat.le_trans; [ apply Nat.le_pred_l | auto ] ].
   rstepl (P _ Ha[-]P _ H0[+](P _ H0[-]P _ Hb)).
   apply plus_resp_leEq_both.
    generalize Ha; pattern (sep__part_h (S i)) at 1 2 in |- *;
@@ -626,7 +626,7 @@ Proof.
    cut (i = RS'_m1); [ intro | unfold sep__part_length in b0; rewrite <- b0 in H0; auto with arith ].
    rewrite H2.
    intros.
-   cut (pred (sep__part_h (S RS'_m1)) <= n); [ intro | eapply Nat.le_trans; [ apply le_pred_n | auto ] ].
+   cut (pred (sep__part_h (S RS'_m1)) <= n); [ intro | eapply Nat.le_trans; [ apply Nat.le_pred_l | auto ] ].
    rstepl (P _ Ha0[-]P _ H3[+](P _ H3[-]P _ Hb0)).
    apply plus_resp_leEq_both.
     generalize Ha0; pattern (sep__part_h (S RS'_m1)) at 1 2 in |- *;

--- a/ftc/RefSeparating.v
+++ b/ftc/RefSeparating.v
@@ -235,7 +235,7 @@ Proof.
  apply SPap_n.
  rewrite H in Hm.
  simpl in Hm.
- apply le_antisym; auto with arith.
+ apply Nat.le_antisymm; auto with arith.
 Qed.
 
 Lemma sep__part_h_lemma :
@@ -1112,7 +1112,7 @@ Proof.
       rewrite H4 in a2.
       rewrite H3 in Hk'.
       rewrite H4.
-      apply le_antisym; auto.
+      apply Nat.le_antisymm; auto.
      elim (ProjT2 sep__part_app_n); fold RS'_m1 in |- *; intros.
      auto.
     rewrite H0; exact sep__part_fun_m.

--- a/ftc/RefSeparating.v
+++ b/ftc/RefSeparating.v
@@ -634,7 +634,7 @@ Proof.
      apply Mesh_lemma.
     symmetry  in |- *; apply S_pred with (sep__part_h RS'_m1); apply sep__part_h_mon_2.
     cut (RS'_m1 <= m).
-     2: rewrite H0; apply le_n_Sn.
+     2: rewrite H0; apply Nat.le_succ_diag_r.
     intro.
     rewrite <- sep__part_fun_i with (H := H4).
      apply sep__part_fun_bnd'.

--- a/liouville/CPoly_Euclid.v
+++ b/liouville/CPoly_Euclid.v
@@ -147,7 +147,7 @@ Proof.
    unfold degree_le in H1; apply not_gt; intro; unfold gt in H3.
    set (tmp := (H1 (S n) (lt_n_S _ _ H3))); rewrite -> H in tmp.
    apply (eq_imp_not_ap _ _ _ tmp); apply ring_non_triv.
-  intro; unfold degree_le in H1; rewrite -> H1 in H; [ | apply lt_O_Sn ].
+  intro; unfold degree_le in H1; rewrite -> H1 in H; [ | apply Nat.lt_0_succ ].
   destruct (eq_imp_not_ap _ _ _ H); apply ap_symmetric; apply ring_non_triv.
  exists (q,r); [ | assumption ].
  intros y1 X0; destruct y1 as [q1 r1]; simpl (fst (q1, r1)); simpl (snd (q1, r1)) in X0.

--- a/liouville/CPoly_Euclid.v
+++ b/liouville/CPoly_Euclid.v
@@ -137,7 +137,7 @@ Proof.
   split; [ | reflexivity ].
   unfold degree_le; intros; apply nth_coeff_zero.
  destruct (@cpoly_div1 (Nat.max (lth_of_poly f) n) n f g); [ | destruct H; assumption | apply le_max_r | ].
-  apply (@degree_le_mon _ _ (lth_of_poly f)); [ apply le_max_l | apply poly_degree_lth ].
+  apply (@degree_le_mon _ _ (lth_of_poly f)); [ apply Nat.le_max_l | apply poly_degree_lth ].
  destruct H; destruct x as [q r].
  rewrite -> H, one_nexp, mult_one in y.
  assert (f[=]q[*]g[+]r and degree_lt_pair r g).

--- a/liouville/CPoly_Euclid.v
+++ b/liouville/CPoly_Euclid.v
@@ -136,7 +136,7 @@ Proof.
   split; [ rewrite -> s, <- c_one; ring | ].
   split; [ | reflexivity ].
   unfold degree_le; intros; apply nth_coeff_zero.
- destruct (@cpoly_div1 (Nat.max (lth_of_poly f) n) n f g); [ | destruct H; assumption | apply le_max_r | ].
+ destruct (@cpoly_div1 (Nat.max (lth_of_poly f) n) n f g); [ | destruct H; assumption | apply Nat.le_max_r | ].
   apply (@degree_le_mon _ _ (lth_of_poly f)); [ apply Nat.le_max_l | apply poly_degree_lth ].
  destruct H; destruct x as [q r].
  rewrite -> H, one_nexp, mult_one in y.

--- a/liouville/Liouville.v
+++ b/liouville/Liouville.v
@@ -94,7 +94,7 @@ Proof.
  destruct (Cpoly_ex_degree _ (AbsPoly P)) as [m HdegA].
  unfold CPoly_bound.
  generalize (degree_le_mon _ _ _ _ (Nat.le_max_l n m) Hdeg).
- generalize (degree_le_mon _ _ _ _ (le_max_r n m) HdegA).
+ generalize (degree_le_mon _ _ _ _ (Nat.le_max_r n m) HdegA).
  revert HI.
  generalize (Nat.max n m). clear.
  intros n HI HdegP HdegA.

--- a/liouville/Liouville.v
+++ b/liouville/Liouville.v
@@ -93,7 +93,7 @@ Proof.
  destruct (Cpoly_ex_degree _ P) as [n Hdeg].
  destruct (Cpoly_ex_degree _ (AbsPoly P)) as [m HdegA].
  unfold CPoly_bound.
- generalize (degree_le_mon _ _ _ _ (le_max_l n m) Hdeg).
+ generalize (degree_le_mon _ _ _ _ (Nat.le_max_l n m) Hdeg).
  generalize (degree_le_mon _ _ _ _ (le_max_r n m) HdegA).
  revert HI.
  generalize (Nat.max n m). clear.

--- a/liouville/QX_extract_roots.v
+++ b/liouville/QX_extract_roots.v
@@ -168,7 +168,7 @@ Proof.
  revert Heq.
  unfold QX_deg; rewrite (RX_deg_wd _ Q_dec _ _ (RX_div_spec _ p a)).
  rewrite RX_deg_sum.
-  rewrite max_comm.
+  rewrite Nat.max_comm.
   rewrite -> QX_deg_mult.
     unfold QX_deg; rewrite RX_deg_minus.
      rewrite RX_deg_c_, RX_deg_x_, RX_deg_c_; fold QX_deg.

--- a/liouville/QX_root_loc.v
+++ b/liouville/QX_root_loc.v
@@ -166,7 +166,7 @@ Proof.
   rewrite Zmult_1_r; intro H; rewrite H.
   apply Zdivides_zero_rht.
  rewrite -> Sum_last.
- rewrite minus_diag.
+ rewrite Nat.sub_diag.
  simpl (q[^]0).
  rewrite -> mult_one.
  generalize (nth_coeff (S n) P[*]p[^]S n); intro r.

--- a/liouville/RX_deg.v
+++ b/liouville/RX_deg.v
@@ -172,7 +172,7 @@ Proof.
  case (RX_dec q [0]).
   intro H; rewrite (RX_deg_wd _ _  H).
   transitivity (RX_deg p); [apply RX_deg_wd; rewrite -> H; unfold RX; ring|].
-  rewrite RX_deg_zero; rewrite max_comm; reflexivity.
+  rewrite RX_deg_zero; rewrite Nat.max_comm; reflexivity.
  intros Hq Hp.
  set (RX_deg_spec _ Hp).
  set (RX_deg_spec _ Hq).

--- a/liouville/RX_deg.v
+++ b/liouville/RX_deg.v
@@ -177,7 +177,7 @@ Proof.
  set (RX_deg_spec _ Hp).
  set (RX_deg_spec _ Hq).
  case (le_lt_dec (RX_deg p) (RX_deg q)); intro.
-  rewrite max_r; [|assumption].
+  rewrite Nat.max_r; [|assumption].
   inversion l.
    destruct (Hneq H0).
   apply (degree_inj (p[+]q)).

--- a/liouville/RX_deg.v
+++ b/liouville/RX_deg.v
@@ -190,7 +190,7 @@ Proof.
   apply (degree_plus_rht _ _ _ m); [| |apply le_n].
    apply (degree_le_mon _ _ (RX_deg p)); [assumption|apply d].
   rewrite H; apply RX_deg_spec; assumption.
- rewrite max_l; [|apply Nat.lt_le_incl; assumption].
+ rewrite Nat.max_l; [|apply Nat.lt_le_incl; assumption].
  apply (degree_inj (p[+]q)).
   apply RX_deg_spec.
   case (RX_dec (p[+]q) [0]); [|tauto].

--- a/liouville/nat_Q_lists.v
+++ b/liouville/nat_Q_lists.v
@@ -80,7 +80,7 @@ Proof.
   split.
    apply list_nat_prod_spec.
     apply Nat.le_0_l.
-   apply (Nat.le_trans _ _ _ (le_pred_n _) Hdb).
+   apply (Nat.le_trans _ _ _ (Nat.le_pred_l _) Hdb).
   left.
   f_equal.
   destruct (ZL4 d).
@@ -154,7 +154,7 @@ Proof.
  split.
   apply list_nat_prod_spec.
    apply Nat.le_0_l.
-  apply (Nat.le_trans _ _ _ (le_pred_n _) Hle).
+  apply (Nat.le_trans _ _ _ (Nat.le_pred_l _) Hle).
  left.
  f_equal.
  destruct (ZL4 d).

--- a/logic/CLogic.v
+++ b/logic/CLogic.v
@@ -750,7 +750,7 @@ Qed.
 Lemma lt_5 : forall i n : nat, i < n -> pred i < n.
 Proof.
  intros; apply Nat.le_lt_trans with (pred n).
-  apply le_pred; auto with arith.
+  apply Nat.pred_le_mono; auto with arith.
  apply lt_pred_n_n; apply Nat.le_lt_trans with i; auto with arith.
 Qed.
 
@@ -788,7 +788,7 @@ Proof.
  intros.
  cut (m <= n); [ intro | apply Cle_to; assumption ].
  apply Nat.le_trans with (pred n); auto with arith.
- apply le_pred; auto.
+ apply Nat.pred_le_mono; auto.
 Qed.
 
 Lemma le_2 : forall i j : nat, i < j -> i <= pred j.

--- a/logic/CLogic.v
+++ b/logic/CLogic.v
@@ -965,7 +965,7 @@ Proof.
     assumption.
    rewrite <- H1.
    auto.
-  apply le_antisym.
+  apply Nat.le_antisymm.
    rewrite H1.
    apply H0.
   apply H0.

--- a/logic/CLogic.v
+++ b/logic/CLogic.v
@@ -1080,7 +1080,7 @@ Proof.
      rewrite <- (even_double n0). assumption.
       assumption.
     apply H2.
-     apply lt_div2. assumption.
+     apply Nat.lt_div2. assumption.
      rewrite (even_double n0) in H3.
      apply H. assumption.
      assumption.

--- a/logic/CLogic.v
+++ b/logic/CLogic.v
@@ -1066,9 +1066,9 @@ Proof.
 Qed.
 
 Lemma odd_double_ind : forall P : nat -> CProp, (forall n, odd n -> P n) ->
- (forall n, 0 < n -> P n -> P (double n)) -> forall n, 0 < n -> P n.
+ (forall n, 0 < n -> P n -> P (Nat.double n)) -> forall n, 0 < n -> P n.
 Proof.
- cut (forall n : nat, 0 < double n -> 0 < n). intro.
+ cut (forall n : nat, 0 < Nat.double n -> 0 < n). intro.
   intro. intro H0. intro H1. intro n.
   pattern n in |- *.
   apply lt_wf_rect. intros n0 H2 H3.
@@ -1086,7 +1086,7 @@ Proof.
      assumption.
    assumption.
   exact (H0 n0).
- unfold double in |- *. intros.
+ unfold Nat.double in |- *. intros.
  case (zerop n). intro.
   absurd (0 < n + n).
    rewrite e. auto with arith.

--- a/metrics/CMetricSpaces.v
+++ b/metrics/CMetricSpaces.v
@@ -671,7 +671,7 @@ Proof.
    cut (Nat.max x y = Nat.max y x -> seq (Nat.max x y)[=]seq (Nat.max y x)).
     intro H17.
     apply H17.
-    apply max_comm.
+    apply Nat.max_comm.
    intro H17.
    rewrite H17.
    apply eq_reflexive.

--- a/model/Zmod/ZGcd.v
+++ b/model/Zmod/ZGcd.v
@@ -63,7 +63,7 @@ Proof.
  assert (forall (n : nat) (a b : positive), nat_of_P b < n -> Acc pp_lt (a, b)).
   simple induction n.
    intros a b H0.
-   elim (lt_n_O _ H0).
+   elim (Nat.nlt_0_r _ H0).
   intros n0 Hind a b HSn0.
   assert (Hdisj : nat_of_P b < n0 \/ nat_of_P b = n0).
    lia.

--- a/model/reals/CRreal.v
+++ b/model/reals/CRreal.v
@@ -112,7 +112,7 @@ Proof.
    | Qpos2QposInf e => let (n,_) := Hf (inject_Q_CR (proj1_sig e)) (CRlt_Qlt _ _ (Qpos_ispos e)) in f n end).
  abstract ( intros e1 e2; destruct (Hf (inject_Q_CR (proj1_sig e1)) (CRlt_Qlt _ _ (Qpos_ispos e1))) as [n1 Hn1];
    destruct (Hf (inject_Q_CR (proj1_sig e2)) (CRlt_Qlt _ _ (Qpos_ispos e2))) as [n2 Hn2];
-     eapply ball_triangle;[apply ball_sym|];rewrite <- CRAbsSmall_ball; [apply Hn1;apply le_max_l|
+     eapply ball_triangle;[apply ball_sym|];rewrite <- CRAbsSmall_ball; [apply Hn1;apply Nat.le_max_l|
        apply Hn2;apply le_max_r]) using Rlim_subproof0.
 Defined.
 

--- a/model/reals/CRreal.v
+++ b/model/reals/CRreal.v
@@ -113,7 +113,7 @@ Proof.
  abstract ( intros e1 e2; destruct (Hf (inject_Q_CR (proj1_sig e1)) (CRlt_Qlt _ _ (Qpos_ispos e1))) as [n1 Hn1];
    destruct (Hf (inject_Q_CR (proj1_sig e2)) (CRlt_Qlt _ _ (Qpos_ispos e2))) as [n2 Hn2];
      eapply ball_triangle;[apply ball_sym|];rewrite <- CRAbsSmall_ball; [apply Hn1;apply Nat.le_max_l|
-       apply Hn2;apply le_max_r]) using Rlim_subproof0.
+       apply Hn2;apply Nat.le_max_r]) using Rlim_subproof0.
 Defined.
 
 Lemma CRisCReals : is_CReals CRasCOrdField CRlim.

--- a/model/structures/Npossec.v
+++ b/model/structures/Npossec.v
@@ -76,7 +76,7 @@ Proof.
  intro y0.
  induction  y0 as [| y0 Hrecy0].
   rewrite Nat.mul_comm.
-  rewrite mult_1_l.
+  rewrite Nat.mul_1_l.
   exact H.
  rewrite <- mult_n_Sm.
  cut (0 <> (x*S y0+x) -> (x*S y0+x) <> 0).

--- a/ode/metric.v
+++ b/ode/metric.v
@@ -940,7 +940,7 @@ assert (A3 : 0 < q / 2) by solve_propholds.
 specialize (A1 (q / 2) A3); specialize (A2 (q / 2) A3).
 set (M := Peano.max (N1 (q / 2)) (N2 (q / 2))).
 assert (A4 : N1 (q / 2) ≤ M) by apply Nat.le_max_l.
-assert (A5 : N2 (q / 2) ≤ M) by apply le_max_r.
+assert (A5 : N2 (q / 2) ≤ M) by apply Nat.le_max_r.
 specialize (A1 M A4); specialize (A2 M A5).
 apply mspc_symm in A1.
 apply (mspc_triangle' (q / 2) (q / 2) (x M)); trivial.

--- a/ode/metric.v
+++ b/ode/metric.v
@@ -939,7 +939,7 @@ intros x a1 a2 N1 N2 A1 A2. apply -> mspc_eq; intros q A.
 assert (A3 : 0 < q / 2) by solve_propholds.
 specialize (A1 (q / 2) A3); specialize (A2 (q / 2) A3).
 set (M := Peano.max (N1 (q / 2)) (N2 (q / 2))).
-assert (A4 : N1 (q / 2) ≤ M) by apply le_max_l.
+assert (A4 : N1 (q / 2) ≤ M) by apply Nat.le_max_l.
 assert (A5 : N2 (q / 2) ≤ M) by apply le_max_r.
 specialize (A1 M A4); specialize (A2 M A5).
 apply mspc_symm in A1.

--- a/reals/Bridges_LUB.v
+++ b/reals/Bridges_LUB.v
@@ -786,7 +786,7 @@ Proof.
   apply False_rect.
   apply (lt_n_O 0).
   apply Nat.lt_trans with (m := 1).
-   apply lt_O_Sn.
+   apply Nat.lt_0_succ.
   assumption.
  case (le_lt_eq_dec 2 (S n) (lt_le_S 1 (S n) H0)).
   intro.

--- a/reals/Bridges_LUB.v
+++ b/reals/Bridges_LUB.v
@@ -529,7 +529,7 @@ Proof.
   apply False_rect.
   generalize H.
   change (~ 4 <= 0) in |- *.
-  apply le_Sn_O.
+  apply Nat.nle_succ_0.
  case (le_lt_eq_dec 4 (S m) H).
   intro.
   apply less_transitive_unfolded with

--- a/reals/Bridges_LUB.v
+++ b/reals/Bridges_LUB.v
@@ -784,7 +784,7 @@ Proof.
  do 3 intro.  intros H H0.
  induction  n as [| n Hrecn].
   apply False_rect.
-  apply (lt_n_O 0).
+  apply (Nat.nlt_0_r 0).
   apply Nat.lt_trans with (m := 1).
    apply Nat.lt_0_succ.
   assumption.

--- a/reals/Bridges_iso.v
+++ b/reals/Bridges_iso.v
@@ -65,7 +65,7 @@ Proof.
   intro k.
   intros.
   exists (S k).
-  rewrite <- (plus_Snm_nSm m k).
+  rewrite <- (Nat.add_succ_comm m k).
   simpl in |- *.
   apply eq_S.
   assumption.

--- a/reals/Bridges_iso.v
+++ b/reals/Bridges_iso.v
@@ -335,7 +335,7 @@ Proof.
  apply H.
  apply Nat.le_trans with (m := n).
   assumption.
- apply le_n_Sn.
+ apply Nat.le_succ_diag_r.
 Qed.
 
 Lemma bound_tk2 :
@@ -358,7 +358,7 @@ Proof.
  apply H.
  apply Nat.le_trans with (m := n).
   assumption.
- apply le_n_Sn.
+ apply Nat.le_succ_diag_r.
 Qed.
 
 
@@ -391,12 +391,12 @@ Proof.
      apply H.
      apply Nat.le_trans with (m := n).
       assumption.
-     apply le_n_Sn.
+     apply Nat.le_succ_diag_r.
     intros.
     apply H0.
     apply Nat.le_trans with (m := n).
      assumption.
-    apply le_n_Sn.
+    apply Nat.le_succ_diag_r.
    assumption.
   apply lt_n_Sm_le.
   assumption.
@@ -411,7 +411,7 @@ Proof.
  apply H.
  apply Nat.le_trans with (m := n).
   assumption.
- apply le_n_Sn.
+ apply Nat.le_succ_diag_r.
 Qed.
 
 
@@ -444,12 +444,12 @@ Proof.
      apply H.
      apply Nat.le_trans with (m := n).
       assumption.
-     apply le_n_Sn.
+     apply Nat.le_succ_diag_r.
     intros.
     apply H0.
     apply Nat.le_trans with (m := n).
      assumption.
-    apply le_n_Sn.
+    apply Nat.le_succ_diag_r.
    assumption.
   apply lt_n_Sm_le.
   assumption.
@@ -464,7 +464,7 @@ Proof.
  apply H.
  apply Nat.le_trans with (m := n).
   assumption.
- apply le_n_Sn.
+ apply Nat.le_succ_diag_r.
 Qed.
 
 Theorem up_bound_for_n_element :
@@ -658,7 +658,7 @@ Proof.
    apply H.
    apply Nat.le_trans with (m := N).
     assumption.
-   apply le_n_Sn.
+   apply Nat.le_succ_diag_r.
   intro.
   case (H (S N)).
     apply le_n.
@@ -690,7 +690,7 @@ Proof.
   apply Nat.le_trans with (m := N).
    apply Cle_to.
    assumption.
-  apply le_n_Sn.
+  apply Nat.le_succ_diag_r.
  assumption.
 Qed.
 

--- a/reals/CReals1.v
+++ b/reals/CReals1.v
@@ -178,7 +178,7 @@ Proof.
   apply less_leEq_trans with K1; auto.
   apply lft_leEq_MAX.
  intros.
- elim (le_or_lt N m).
+ elim (Nat.le_gt_cases N m).
   intros.
   assert (AbsSmall (R:=IR) K1 (seq m)).
    apply H1. auto.

--- a/reals/CauchySeq.v
+++ b/reals/CauchySeq.v
@@ -290,7 +290,7 @@ Proof.
    apply less_leEq.
    apply H5.
    apply Nat.le_trans with (Nat.max N1 N2).
-    apply le_max_r.
+    apply Nat.le_max_r.
    assumption.
   unfold Av in |- *.
   apply Average_less_Greatest.
@@ -368,7 +368,7 @@ Proof.
   apply less_irreflexive_unfolded.
  apply leEq_less_trans with (seq (Nat.max N M)).
   apply HN; apply Nat.le_max_l.
- apply HM; apply le_max_r.
+ apply HM; apply Nat.le_max_r.
 Qed.
 
 Lemma Lim_leEq_Lim : forall seq1 seq2 : CauchySeqR,
@@ -412,7 +412,7 @@ Proof.
  cut (y [<] y).
   apply less_irreflexive_unfolded.
  apply less_leEq_trans with (seq (Nat.max N M)).
-  apply HM; apply le_max_r.
+  apply HM; apply Nat.le_max_r.
  apply HN; apply Nat.le_max_l.
 Qed.
 
@@ -429,7 +429,7 @@ Proof.
   unfold Cauchy_Lim_prop2 in H.
   elim (H _ H4); intro N'; intro H7.
   generalize (Nat.le_max_l N N'); intro H8.
-  generalize (le_max_r N N'); intro H9.
+  generalize (Nat.le_max_r N N'); intro H9.
   generalize (H6 _ H8); intro H10.
   generalize (H7 _ H9); intro H11.
   elim H11; intros H12 H13.
@@ -445,7 +445,7 @@ Proof.
  unfold Cauchy_Lim_prop2 in H.
  elim (H _ H4); intro N'; intros H7.
  generalize (Nat.le_max_l N N'); intro H8.
- generalize (le_max_r N N'); intro H9.
+ generalize (Nat.le_max_r N N'); intro H9.
  generalize (H6 _ H8); intro H10.
  generalize (H7 _ H9); intro H11.
  elim H11; intros H12 H13.
@@ -884,7 +884,7 @@ Proof.
    assumption.
   apply H4.
   apply Nat.le_trans with (Nat.max x x0).
-   apply le_max_r.
+   apply Nat.le_max_r.
   assumption.
  apply pos_div_two.
  assumption.

--- a/reals/CauchySeq.v
+++ b/reals/CauchySeq.v
@@ -285,7 +285,7 @@ Proof.
    apply less_leEq_trans with Av.
     apply H4.
     apply Nat.le_trans with (Nat.max N1 N2).
-     apply le_max_l.
+     apply Nat.le_max_l.
     assumption.
    apply less_leEq.
    apply H5.
@@ -367,7 +367,7 @@ Proof.
  cut (y [<] y).
   apply less_irreflexive_unfolded.
  apply leEq_less_trans with (seq (Nat.max N M)).
-  apply HN; apply le_max_l.
+  apply HN; apply Nat.le_max_l.
  apply HM; apply le_max_r.
 Qed.
 
@@ -413,7 +413,7 @@ Proof.
   apply less_irreflexive_unfolded.
  apply less_leEq_trans with (seq (Nat.max N M)).
   apply HM; apply le_max_r.
- apply HN; apply le_max_l.
+ apply HN; apply Nat.le_max_l.
 Qed.
 
 Lemma Limits_unique : forall (seq : CauchySeq IR) y,
@@ -428,7 +428,7 @@ Proof.
   elim H5; intro N; intro H6.
   unfold Cauchy_Lim_prop2 in H.
   elim (H _ H4); intro N'; intro H7.
-  generalize (le_max_l N N'); intro H8.
+  generalize (Nat.le_max_l N N'); intro H8.
   generalize (le_max_r N N'); intro H9.
   generalize (H6 _ H8); intro H10.
   generalize (H7 _ H9); intro H11.
@@ -444,7 +444,7 @@ Proof.
  elim H5; intro N; intros H6.
  unfold Cauchy_Lim_prop2 in H.
  elim (H _ H4); intro N'; intros H7.
- generalize (le_max_l N N'); intro H8.
+ generalize (Nat.le_max_l N N'); intro H8.
  generalize (le_max_r N N'); intro H9.
  generalize (H6 _ H8); intro H10.
  generalize (H7 _ H9); intro H11.
@@ -880,7 +880,7 @@ Proof.
   apply AbsSmall_eps_div_two.
    apply H3.
    apply Nat.le_trans with (Nat.max x x0).
-    apply le_max_l.
+    apply Nat.le_max_l.
    assumption.
   apply H4.
   apply Nat.le_trans with (Nat.max x x0).

--- a/reals/Cauchy_CReals.v
+++ b/reals/Cauchy_CReals.v
@@ -541,13 +541,13 @@ Proof.
            rstepl ([0]:F).
            rstepr (Twelve:F).
            apply nring_pos.
-           apply lt_O_Sn.
+           apply Nat.lt_0_succ.
           apply plus_cancel_less with (R := F) (z := [--] ([1]:F)).
           rstepl ((Twelve[/] e[//]H0) [-][1]).
           rstepr (nring (R:=F) M).
           exact H2.
          apply nring_pos.
-         apply lt_O_Sn.
+         apply Nat.lt_0_succ.
         unfold one_div_succ in |- *.
         unfold Snring in |- *.
         change (Four[*] ([1][/] nring M[+][1][//]nringS_ap_zero F M) [*]
@@ -584,7 +584,7 @@ Proof.
           rstepl ([0]:F).
           rstepr (Twelve:F).
           apply nring_pos.
-          apply lt_O_Sn.
+          apply Nat.lt_0_succ.
          apply plus_cancel_less with (R := F) (z := [--] ([1]:F)).
          rstepl ((Twelve[/] e[//]H0) [-][1]).
          rstepr (nring (R:=F) M).

--- a/reals/NRootIR.v
+++ b/reals/NRootIR.v
@@ -280,7 +280,7 @@ Section Square_root.
 (**
 ** Square root *)
 
-Definition sqrt x xpos : IR := NRoot (x:=x) (n:=2) xpos (lt_O_Sn 1).
+Definition sqrt x xpos : IR := NRoot (x:=x) (n:=2) xpos (Nat.lt_0_succ 1).
 
 Lemma sqrt_sqr : forall x xpos, sqrt x xpos[^]2 [=] x.
 Proof.

--- a/reals/Q_dense.v
+++ b/reals/Q_dense.v
@@ -606,7 +606,7 @@ Proof.
   apply False_rect.
   generalize H.
   change (~ 4 <= 0) in |- *.
-  apply le_Sn_O.
+  apply Nat.nle_succ_0.
  case (le_lt_eq_dec 4 (S m) H).
   intro.
   apply less_transitive_unfolded with (Two [/]ThreeNZ[*]

--- a/reals/Q_in_CReals.v
+++ b/reals/Q_in_CReals.v
@@ -295,7 +295,7 @@ Proof.
     intro a.
     intro H0.
     rewrite H0.
-    apply lt_O_Sn.
+    apply Nat.lt_0_succ.
    intros.
    apply False_rect.
    generalize H.

--- a/reals/RealLists.v
+++ b/reals/RealLists.v
@@ -256,7 +256,7 @@ Proof.
  apply Max_less.
   apply H0; left; right; algebra.
  apply Hrecl.
-  simpl in |- *; apply lt_O_Sn.
+  simpl in |- *; apply Nat.lt_0_succ.
  intros y H1.  apply H0.
  inversion_clear H1.
   left; left; assumption.

--- a/reals/Series.v
+++ b/reals/Series.v
@@ -566,7 +566,7 @@ Proof.
   apply AbsSmall_minus; apply HN; apply Nat.le_trans with (Nat.max n N); auto with arith.
  apply cg_minus_wd; apply Hn.
   apply Nat.le_trans with (Nat.max n N); auto with arith.
- apply le_max_l.
+ apply Nat.le_max_l.
 Qed.
 
 Lemma aew_Cauchy2 : forall c, Cauchy_Lim_prop2 x c -> Cauchy_Lim_prop2 y c.
@@ -691,7 +691,7 @@ Proof.
   apply HN; assumption. rename X into H1.
  elim (H _ (pos_div_two _ _ H1)).
  intros N HN; exists (S (Nat.max N k)).
- cut (N <= Nat.max N k); [ intro | apply le_max_l ].
+ cut (N <= Nat.max N k); [ intro | apply Nat.le_max_l ].
  cut (k <= Nat.max N k); [ intro | apply le_max_r ].
  split.
   auto with arith.
@@ -917,7 +917,7 @@ Proof.
   intro H.
   clear Hn.
   intro n.
-  cut (S N <= Nat.max (S N) n); [ intro | apply le_max_l ].
+  cut (S N <= Nat.max (S N) n); [ intro | apply Nat.le_max_l ].
   elim (H _ H0); intros m Hm; elim Hm; clear H Hm; intros Hm H; exists m.
    apply Nat.le_trans with (Nat.max (S N) n); auto with arith.
   assumption.

--- a/reals/Series.v
+++ b/reals/Series.v
@@ -614,7 +614,7 @@ Proof.
   intros; apply Hn.
   apply Nat.le_trans with (Nat.max n N); auto with arith.
   apply Nat.le_trans with k; unfold k in |- *; auto with arith.
- unfold k in |- *; apply le_max_r.
+ unfold k in |- *; apply Nat.le_max_r.
 Qed.
 
 End Almost_Everywhere.
@@ -692,7 +692,7 @@ Proof.
  elim (H _ (pos_div_two _ _ H1)).
  intros N HN; exists (S (Nat.max N k)).
  cut (N <= Nat.max N k); [ intro | apply Nat.le_max_l ].
- cut (k <= Nat.max N k); [ intro | apply le_max_r ].
+ cut (k <= Nat.max N k); [ intro | apply Nat.le_max_r ].
  split.
   auto with arith.
  intros.

--- a/reals/fast/CRartanh_slow.v
+++ b/reals/fast/CRartanh_slow.v
@@ -347,11 +347,11 @@ apply IRasCR_wd.
  [|apply (ArTanH_series (inj_Q IR a) (ArTanH_series_convergent_IR) (artanh_DomArTanH Ha) Ha0)].
 simpl.
 unfold series_sum.
-apply Lim_seq_eq_Lim_subseq with double.
-  unfold double; auto with *.
+apply Lim_seq_eq_Lim_subseq with Nat.double.
+  unfold Nat.double; auto with *.
  intros n.
  exists (S n).
- unfold double; auto with *.
+ unfold Nat.double; auto with *.
 intros n.
 simpl.
 clear - n.
@@ -361,7 +361,7 @@ simpl.
 set (A:=nexp IR (Nat.add n (S n)) (inj_Q IR a[-][0])).
 rewrite Nat.add_comm.
 simpl.
-fold (double n).
+fold (Nat.double n).
 csetoid_rewrite_rev IHn.
 clear IHn.
 csetoid_replace (ArTanH_series_coef (Nat.double n)[*]nexp IR (Nat.double n) (inj_Q IR a[-][0])) ([0]:IR).
@@ -369,7 +369,7 @@ csetoid_replace (ArTanH_series_coef (S (Nat.double n))[*]A)
                 (inj_Q IR (Str_nth n (artanhSequence a))).
   rational.
  unfold ArTanH_series_coef.
- case_eq (even_odd_dec (S (double n))); intros H.
+ case_eq (even_odd_dec (S (Nat.double n))); intros H.
   elim (not_even_and_odd _ H).
   constructor.
   apply even_plus_n_n.
@@ -379,7 +379,7 @@ csetoid_replace (ArTanH_series_coef (S (Nat.double n))[*]A)
  eapply eq_transitive;
   [|apply eq_symmetric; apply inj_Q_mult].
  apply mult_wd.
-  assert (X:(inj_Q IR (nring (S (double n))))[#][0]).
+  assert (X:(inj_Q IR (nring (S (Nat.double n))))[#][0]).
    stepr (inj_Q IR [0]).
     apply inj_Q_ap.
     apply nringS_ap_zero.
@@ -405,7 +405,7 @@ csetoid_replace (ArTanH_series_coef (S (Nat.double n))[*]A)
   apply inj_Q_wd.
   rewrite <- POS_anti_convert.
   eapply eq_transitive;[apply nring_Q|].
-  unfold double.
+  unfold Nat.double.
   simpl.
   replace (n+0)%nat with n by ring.
   reflexivity.
@@ -416,7 +416,7 @@ csetoid_replace (ArTanH_series_coef (S (Nat.double n))[*]A)
   apply nexp_wd.
  rational.
 unfold ArTanH_series_coef.
-case_eq (even_odd_dec (double n)).
+case_eq (even_odd_dec (Nat.double n)).
  intros _ _.
  rational.
 intros o.

--- a/reals/fast/CRcorrect.v
+++ b/reals/fast/CRcorrect.v
@@ -429,7 +429,7 @@ Proof.
   apply AbsSmall_minus.
   apply Hn1.
   unfold n.
-  rewrite (max_comm n1).
+  rewrite (Nat.max_comm n1).
   rewrite max_assoc.
   auto with *.
  eapply Hn3; unfold n; auto with *.

--- a/reals/fast/CRcorrect.v
+++ b/reals/fast/CRcorrect.v
@@ -421,7 +421,7 @@ Proof.
    apply AbsSmall_minus.
    apply Hn2.
    unfold n.
-   rewrite max_assoc.
+   rewrite Nat.max_assoc.
    auto with *.
    unfold QAbsSmall.
    setoid_replace (x n1 + y n - (x n + y n))%Q with (x n1 - x n)%Q.
@@ -430,7 +430,7 @@ Proof.
   apply Hn1.
   unfold n.
   rewrite (Nat.max_comm n1).
-  rewrite max_assoc.
+  rewrite Nat.max_assoc.
   auto with *.
  eapply Hn3; unfold n; auto with *.
 Qed.

--- a/reals/fast/CRroot.v
+++ b/reals/fast/CRroot.v
@@ -950,9 +950,9 @@ Lemma CRsqrt_correct : forall x H,
  (IRasCR (sqrt x H) == CRsqrt (IRasCR x))%CR.
 Proof.
  intros x H.
- assert (X:Dom (FNRoot FId 2 (lt_O_Sn 1)) x).
+ assert (X:Dom (FNRoot FId 2 (Nat.lt_0_succ 1)) x).
   simpl; split; auto.
- transitivity (IRasCR (FNRoot FId 2 (lt_O_Sn 1) x X)).
+ transitivity (IRasCR (FNRoot FId 2 (Nat.lt_0_succ 1) x X)).
   apply IRasCR_wd.
   apply: NRoot_wd.
   apply eq_reflexive.

--- a/reals/fast/MultivariatePolynomials.v
+++ b/reals/fast/MultivariatePolynomials.v
@@ -233,7 +233,7 @@ Qed.
 (** Return the ith entry of a vector *)
 Fixpoint Vector_ix A (n i:nat) (H:(i < n)%nat) (v:Vector.t A n) : A :=
 match v in Vector.t _ m return (i < m)%nat -> A with
-| Vector.nil _ => fun p => False_rect _ (lt_n_O _ p)
+| Vector.nil _ => fun p => False_rect _ (Nat.nlt_0_r _ p)
 | Vector.cons _ c n' v' => fun _ => match lt_le_dec i n' with
                             | left p => Vector_ix p v'
                             | right _ => c

--- a/reals/iso_CReals.v
+++ b/reals/iso_CReals.v
@@ -171,10 +171,10 @@ Proof.
        assumption.
       apply H9.
       rewrite -> Nat.add_comm with (m := N2).
-      rewrite -> plus_permute with (m := N2).
+      rewrite -> Nat.add_shuffle3 with (m := N2).
       apply Nat.le_add_r.
      apply H8.
-     rewrite -> plus_permute with (m := N1).
+     rewrite -> Nat.add_shuffle3 with (m := N1).
      apply Nat.le_add_r.
     apply H5.
     apply pos_div_three.
@@ -680,7 +680,7 @@ Proof.
           change (AbsSmall (inj_Q IR (e [/]ThreeNZ)) (CS_seq IR (inj_Q_G_as_CauchySeq IR x) m[-]x)) in |- *.
           apply a.
           apply Nat.le_trans with (m := K + (N1 + N2)).
-           rewrite -> plus_permute with (m := N1).
+           rewrite -> Nat.add_shuffle3 with (m := N1).
            apply Nat.le_add_r.
           assumption.
          apply AbsSmall_minus.
@@ -688,7 +688,7 @@ Proof.
          apply H5.
          apply Nat.le_trans with (m := K + (N1 + N2)).
           rewrite -> Nat.add_comm with (m := N2).
-          rewrite -> plus_permute with (m := N2).
+          rewrite -> Nat.add_shuffle3 with (m := N2).
           apply Nat.le_add_r.
          assumption.
         apply eq_transitive_unfolded with (y := inj_Q IR (e [/]ThreeNZ[+]e [/]ThreeNZ[+]e [/]ThreeNZ)).
@@ -829,12 +829,12 @@ Proof.
      apply H5.
      apply Nat.le_trans with (m := N1 + (N2 + M1)).
       rewrite -> Nat.add_comm with (m := M1).
-      rewrite -> plus_permute with (m := M1).
+      rewrite -> Nat.add_shuffle3 with (m := M1).
       apply Nat.le_add_r.
      assumption.
     apply H12.
     apply Nat.le_trans with (m := N1 + (N2 + M1)).
-     rewrite -> plus_permute with (m := N2).
+     rewrite -> Nat.add_shuffle3 with (m := N2).
      apply Nat.le_add_r.
     assumption.
    apply AbsSmall_mult.
@@ -955,8 +955,8 @@ Proof.
          unfold CS_seq at 1 in H14.
          apply H14.
          apply Nat.le_trans with (m := N1 + (N2 + (N3 + M1))).
-          rewrite -> plus_permute with (m := N3).
-          rewrite -> plus_permute with (m := N3).
+          rewrite -> Nat.add_shuffle3 with (m := N3).
+          rewrite -> Nat.add_shuffle3 with (m := N3).
           apply Nat.le_add_r.
          assumption.
         apply AbsSmall_mult.
@@ -970,7 +970,7 @@ Proof.
         unfold CS_seq at 1 in H13.
         apply H13.
         apply Nat.le_trans with (m := N1 + (N2 + (N3 + M1))).
-         rewrite ->  plus_permute with (m := N2).
+         rewrite ->  Nat.add_shuffle3 with (m := N2).
          apply Nat.le_add_r.
         assumption.
        apply AbsSmall_mult.
@@ -978,8 +978,8 @@ Proof.
         apply H6.
         apply Nat.le_trans with (m := N1 + (N2 + (N3 + M1))).
          rewrite -> Nat.add_comm with (m := M1).
-         rewrite -> plus_permute with (m := M1).
-         rewrite -> plus_permute with (m := M1).
+         rewrite -> Nat.add_shuffle3 with (m := M1).
+         rewrite -> Nat.add_shuffle3 with (m := M1).
          apply Nat.le_add_r.
         assumption.
        apply AbsSmall_minus.

--- a/reals/stdlib/CMTFullSets.v
+++ b/reals/stdlib/CMTFullSets.v
@@ -167,9 +167,9 @@ Proof.
   assert (forall a b:nat, lt a b -> lt (diagPlane n a) (diagPlane n b)).
   { intros. unfold diagPlane. apply plus_lt_le_compat. assumption.
     apply Nat.div_le_mono. auto. apply mult_le_compat.
-    apply plus_le_compat. apply Nat.le_refl. unfold lt in H0.
+    apply Nat.add_le_mono. apply Nat.le_refl. unfold lt in H0.
     apply (Nat.le_trans _ (S a)). apply le_S. apply Nat.le_refl. assumption.
-    apply le_n_S. apply plus_le_compat. apply Nat.le_refl. unfold lt in H0.
+    apply le_n_S. apply Nat.add_le_mono. apply Nat.le_refl. unfold lt in H0.
     apply (Nat.le_trans _ (S a)). apply le_S. apply Nat.le_refl. assumption. }
   pose proof (CR_complete R _ cvDiag) as [lim cvlim].
   destruct (SubSeriesCv (fun k : nat =>

--- a/reals/stdlib/CMTFullSets.v
+++ b/reals/stdlib/CMTFullSets.v
@@ -692,7 +692,7 @@ Proof.
     apply IabsMinusMaj.
     destruct (Nat.le_exists_sub N m) as [k [add _]]. apply le_S in maj.
     apply le_S_n in maj. assumption. subst m. destruct k.
-    exfalso. exact (lt_irrefl N maj).
+    exfalso. exact (Nat.lt_irrefl N maj).
     apply (CRle_trans
              _ (Iabs (Xsum (fun a => fn (S N + a)%nat) k)
                      (LsumStable (fun a => fn (S N + a)%nat)

--- a/reals/stdlib/CMTFullSets.v
+++ b/reals/stdlib/CMTFullSets.v
@@ -165,7 +165,7 @@ Proof.
     specialize (xn (diagPlane n k)). rewrite H in xn. exact xn. }
   destruct xdf as [xnDiag cvDiag].
   assert (forall a b:nat, lt a b -> lt (diagPlane n a) (diagPlane n b)).
-  { intros. unfold diagPlane. apply plus_lt_le_compat. assumption.
+  { intros. unfold diagPlane. apply Nat.add_lt_le_mono. assumption.
     apply Nat.div_le_mono. auto. apply Nat.mul_le_mono.
     apply Nat.add_le_mono. apply Nat.le_refl. unfold lt in H0.
     apply (Nat.le_trans _ (S a)). apply le_S. apply Nat.le_refl. assumption.

--- a/reals/stdlib/CMTFullSets.v
+++ b/reals/stdlib/CMTFullSets.v
@@ -166,7 +166,7 @@ Proof.
   destruct xdf as [xnDiag cvDiag].
   assert (forall a b:nat, lt a b -> lt (diagPlane n a) (diagPlane n b)).
   { intros. unfold diagPlane. apply plus_lt_le_compat. assumption.
-    apply Nat.div_le_mono. auto. apply mult_le_compat.
+    apply Nat.div_le_mono. auto. apply Nat.mul_le_mono.
     apply Nat.add_le_mono. apply Nat.le_refl. unfold lt in H0.
     apply (Nat.le_trans _ (S a)). apply le_S. apply Nat.le_refl. assumption.
     apply le_n_S. apply Nat.add_le_mono. apply Nat.le_refl. unfold lt in H0.

--- a/reals/stdlib/CMTIntegrableFunctions.v
+++ b/reals/stdlib/CMTIntegrableFunctions.v
@@ -411,7 +411,7 @@ Proof.
       apply (Nat.le_trans n (n*2)). rewrite <- (mult_1_r n).
       rewrite <- mult_assoc. apply Nat.mul_le_mono_nonneg_l.
       apply Nat.le_0_l. apply le_S. apply Nat.le_refl.
-      rewrite <- (plus_0_l (n*2)). rewrite Nat.add_assoc.
+      rewrite <- (Nat.add_0_l (n*2)). rewrite Nat.add_assoc.
       apply Nat.add_le_mono_r. auto.
     + auto.
 Qed.

--- a/reals/stdlib/CMTIntegrableFunctions.v
+++ b/reals/stdlib/CMTIntegrableFunctions.v
@@ -408,7 +408,7 @@ Proof.
       rewrite Nat.mul_comm. reflexivity. apply Nat.odd_spec in H3.
       unfold Nat.odd in H3. rewrite des in H3. inversion H3.
       apply cv. apply (Nat.le_trans N n). assumption.
-      apply (Nat.le_trans n (n*2)). rewrite <- (mult_1_r n).
+      apply (Nat.le_trans n (n*2)). rewrite <- (Nat.mul_1_r n).
       rewrite <- mult_assoc. apply Nat.mul_le_mono_nonneg_l.
       apply Nat.le_0_l. apply le_S. apply Nat.le_refl.
       rewrite <- (Nat.add_0_l (n*2)). rewrite Nat.add_assoc.

--- a/reals/stdlib/CMTIntegrableFunctions.v
+++ b/reals/stdlib/CMTIntegrableFunctions.v
@@ -439,7 +439,7 @@ Proof.
     apply (Nat.le_trans _ i). assumption.
     apply le_S. apply Nat.le_refl. auto.
     apply H0. assert (N0 = pred (S N0)). reflexivity.
-    rewrite H2. apply le_pred. rewrite <- (Nat.div_mul (S N0) 2).
+    rewrite H2. apply Nat.pred_le_mono. rewrite <- (Nat.div_mul (S N0) 2).
     apply Nat.div_le_mono. auto.
     apply (Nat.le_trans _ (N*2 + (S N0)*2)).
     rewrite Nat.add_comm. apply Nat.le_add_r.

--- a/reals/stdlib/CMTIntegrableFunctions.v
+++ b/reals/stdlib/CMTIntegrableFunctions.v
@@ -409,7 +409,7 @@ Proof.
       unfold Nat.odd in H3. rewrite des in H3. inversion H3.
       apply cv. apply (Nat.le_trans N n). assumption.
       apply (Nat.le_trans n (n*2)). rewrite <- (Nat.mul_1_r n).
-      rewrite <- mult_assoc. apply Nat.mul_le_mono_nonneg_l.
+      rewrite <- Nat.mul_assoc. apply Nat.mul_le_mono_nonneg_l.
       apply Nat.le_0_l. apply le_S. apply Nat.le_refl.
       rewrite <- (Nat.add_0_l (n*2)). rewrite Nat.add_assoc.
       apply Nat.add_le_mono_r. auto.

--- a/reals/stdlib/CMTIntegrableFunctions.v
+++ b/reals/stdlib/CMTIntegrableFunctions.v
@@ -479,7 +479,7 @@ Proof.
   - (* N < n so we can split the sum in 2 and use sum_assoc. *)
     destruct (Nat.le_exists_sub (S N) n) as [p [H0 _]].
     + pose proof (Nat.lt_ge_cases N n) as [H0|H1]. apply H0. exfalso.
-      exact (n0 (le_antisym N n H H1)).
+      exact (n0 (Nat.le_antisymm N n H H1)).
     + subst n. rewrite Nat.add_comm. rewrite sum_assoc.
       assert (CRsum (fun k : nat => if le_dec (S N + k) N then u (S N + k)%nat else 0) p == 0).
       { rewrite <- (CRsum_eq (fun k => 0)). rewrite sum_const.

--- a/reals/stdlib/CMTProductIntegral.v
+++ b/reals/stdlib/CMTProductIntegral.v
@@ -687,7 +687,7 @@ Lemma nat_euclid_unique : forall i j q : nat,
     -> i = j.
 Proof.
   intros. assert (q <> O).
-  { destruct q. exfalso; exact (lt_irrefl O H). discriminate. }
+  { destruct q. exfalso; exact (Nat.lt_irrefl O H). discriminate. }
   rewrite (Nat.div_mod j q H2), <- H1, <- H0.
   apply Nat.div_mod, H2.
 Qed.
@@ -726,10 +726,10 @@ Proof.
     assert (b <> d).
     { intro abs. subst d. subst b. subst c. subst a.
       rewrite (nat_euclid_unique _ _ _ lenPos e abs) in H.
-      exact (lt_irrefl j H). }
+      exact (Nat.lt_irrefl j H). }
     assert (d < length (FreeSubsets (length hn)))%nat as din.
     { subst d. apply Nat.mod_upper_bound.
-      intro abs. rewrite abs in lenPos. exact (lt_irrefl _ lenPos). }
+      intro abs. rewrite abs in lenPos. exact (Nat.lt_irrefl _ lenPos). }
     apply (ProdIntegrableSubsetsDisjoint
              (map prodint_g hn) (nth d (FreeSubsets (length hn)) nil)
              (nth b (FreeSubsets (length hn)) nil) y).
@@ -737,7 +737,7 @@ Proof.
     rewrite (FreeSubsetsLength (length hn)).
     rewrite (FreeSubsetsLength (length hn)). reflexivity.
     apply nth_In. subst b. apply Nat.mod_upper_bound.
-    intro abs. rewrite abs in lenPos. exact (lt_irrefl _ lenPos).
+    intro abs. rewrite abs in lenPos. exact (Nat.lt_irrefl _ lenPos).
     apply nth_In. exact din.
     rewrite (FreeSubsetsLength (length hn)).
     rewrite map_length. reflexivity.
@@ -745,12 +745,12 @@ Proof.
     apply FreeSubsetsDifferent.
     intro abs. apply H1. symmetry. exact abs. exact din.
     subst b. apply Nat.mod_upper_bound.
-    intro abs. rewrite abs in lenPos. exact (lt_irrefl _ lenPos).
+    intro abs. rewrite abs in lenPos. exact (Nat.lt_irrefl _ lenPos).
   - (* If subsets a and c are different, the product on x's is zero. *)
     assert (c < length (FreeSubsets (length hn)))%nat as cin.
     { subst c.
       apply Nat.div_lt_upper_bound. intro abs.
-      rewrite abs in lenPos. exact (lt_irrefl 0 lenPos). exact H0. }
+      rewrite abs in lenPos. exact (Nat.lt_irrefl 0 lenPos). exact H0. }
     apply (ProdIntegrableSubsetsDisjoint
              (map prodint_f hn) (nth c (FreeSubsets (length hn)) nil)
              (nth a (FreeSubsets (length hn)) nil) x).
@@ -759,7 +759,7 @@ Proof.
     rewrite (FreeSubsetsLength (length hn)). reflexivity.
     apply nth_In. subst a.
     apply Nat.div_lt_upper_bound. intro abs.
-    rewrite abs in lenPos. exact (lt_irrefl 0 lenPos).
+    rewrite abs in lenPos. exact (Nat.lt_irrefl 0 lenPos).
     exact (Nat.lt_trans _ _ _ H H0).
     apply nth_In. exact cin.
     rewrite (FreeSubsetsLength (length hn)).
@@ -768,7 +768,7 @@ Proof.
     intro abs. apply n. symmetry. exact abs. exact cin.
     subst a.
     apply Nat.div_lt_upper_bound. intro abs.
-    rewrite abs in lenPos. exact (lt_irrefl 0 lenPos).
+    rewrite abs in lenPos. exact (Nat.lt_irrefl 0 lenPos).
     exact (Nat.lt_trans _ _ _ H H0).
 Qed.
 

--- a/reals/stdlib/CMTprofile.v
+++ b/reals/stdlib/CMTprofile.v
@@ -1341,7 +1341,7 @@ Proof.
     destruct (le_lt_dec (S (S n0)) (S n0)). exfalso.
     exact (le_not_lt _ _ l0 (Nat.le_refl _)).
     destruct (le_lt_dec (S (S n0)) (S i)).
-    + apply le_S_n in l1. pose proof (le_antisym _ _ l l1).
+    + apply le_S_n in l1. pose proof (Nat.le_antisymm _ _ l l1).
       subst i. rewrite <- des. apply Nat.le_refl.
     + clear l0. apply le_S_n, le_S_n in l1. clear l. exfalso.
       apply (StepApproxIntegralIncr
@@ -1766,7 +1766,7 @@ Proof.
         destruct (H2 (max n m) k) as [x0 p0].
         destruct (le_lt_dec (S (2 ^ max n m)) (S x0)).
         destruct p0, p0. apply le_S_n in l.
-        apply (le_antisym _ _ l0) in l. subst x0. (* x0 = 2 ^ max n m *)
+        apply (Nat.le_antisymm _ _ l0) in l. subst x0. (* x0 = 2 ^ max n m *)
         clear l0 s c1.
         contradict ncv. apply (CRle_trans _ (b+0)).
         rewrite CRplus_0_r. apply (CRle_trans _ y _ (CRlt_asym _ _ (snd ltxy))).

--- a/reals/stdlib/ConstructiveCauchyIntegral.v
+++ b/reals/stdlib/ConstructiveCauchyIntegral.v
@@ -1223,7 +1223,7 @@ Proof.
     replace i with ipt_last0.
     + rewrite <- ipt_lastB0. rewrite Nat.sub_diag.
       rewrite <- ipt_head1. reflexivity.
-    + apply le_antisym. apply le_S_n, Nat.nlt_ge, n. exact H.
+    + apply Nat.le_antisymm. apply le_S_n, Nat.nlt_ge, n. exact H.
   - apply CRsum_eq. intros. unfold ConcatSequences.
     destruct (lt_dec (S ipt_last0 + i) (S ipt_last0)).
     exfalso. apply (lt_not_le _ _ l).
@@ -1271,7 +1271,7 @@ Proof.
       reflexivity.
       intros. destruct (lt_dec n0 n). reflexivity.
       replace n0 with n. rewrite Nat.sub_diag. symmetry. exact H.
-      apply le_antisym. 2: exact H0. apply Nat.nlt_ge. exact n1.
+      apply Nat.le_antisymm. 2: exact H0. apply Nat.nlt_ge. exact n1.
     - intros. rewrite Nat.add_succ_r. simpl.
       rewrite IHp. 2: exact H.
       assert (forall a b c : CRcarrier R,

--- a/reals/stdlib/ConstructiveDiagonal.v
+++ b/reals/stdlib/ConstructiveDiagonal.v
@@ -559,7 +559,7 @@ Proof.
   subst n0. simpl. apply le_S. rewrite <- (Nat.add_0_r n). rewrite <- Nat.add_assoc.
   apply Nat.add_le_mono_l. apply Nat.le_0_l.
   apply Nat.add_le_mono. assumption. apply Nat.div_le_mono. auto.
-  apply mult_le_compat. assumption. apply le_n_S. assumption.
+  apply Nat.mul_le_mono. assumption. apply le_n_S. assumption.
   rewrite CRabs_minus_sym. apply H. apply Nat.le_refl.
   unfold CRminus. rewrite CRplus_assoc. apply CRplus_morph. reflexivity.
   rewrite <- CRplus_assoc, CRplus_opp_l, CRplus_0_l. reflexivity.

--- a/reals/stdlib/ConstructiveDiagonal.v
+++ b/reals/stdlib/ConstructiveDiagonal.v
@@ -179,7 +179,7 @@ Proof.
     rewrite <- (Nat.add_0_r (sub n)). rewrite <- Nat.add_assoc.
     apply Nat.add_le_mono_l. apply Nat.le_0_l. rewrite <- absurd. apply Nat.le_refl.
     destruct H2. subst p. exact (Nat.lt_irrefl (sub (S n)) H1).
-    specialize (inc (S n) p H2). apply (lt_asym (sub p) (sub (S n))); assumption.
+    specialize (inc (S n) p H2). apply (Nat.lt_asymm (sub p) (sub (S n))); assumption.
   - rewrite Nat.add_comm. rewrite Nat.sub_add.
     unfold FillSubSeqWithZeros.
     destruct (Nat.eq_dec (SubSeqInv sub (proj1_sig sub (S n)) (proj1_sig sub (S n))) (S (proj1_sig sub (S n)))).

--- a/reals/stdlib/ConstructiveDiagonal.v
+++ b/reals/stdlib/ConstructiveDiagonal.v
@@ -558,7 +558,7 @@ Proof.
   remember (S n + p)%nat as n0. assert (n <= n0)%nat.
   subst n0. simpl. apply le_S. rewrite <- (Nat.add_0_r n). rewrite <- Nat.add_assoc.
   apply Nat.add_le_mono_l. apply Nat.le_0_l.
-  apply plus_le_compat. assumption. apply Nat.div_le_mono. auto.
+  apply Nat.add_le_mono. assumption. apply Nat.div_le_mono. auto.
   apply mult_le_compat. assumption. apply le_n_S. assumption.
   rewrite CRabs_minus_sym. apply H. apply Nat.le_refl.
   unfold CRminus. rewrite CRplus_assoc. apply CRplus_morph. reflexivity.

--- a/reals/stdlib/ConstructiveDiagonal.v
+++ b/reals/stdlib/ConstructiveDiagonal.v
@@ -338,7 +338,7 @@ Proof.
   - simpl. unfold diagSeq. reflexivity.
   - (* The bigger triangle is the smaller one plus the diagonal *)
     assert (forall i:nat, i <= S n -> diagPlane 0 n + S i = diagPlane (S n - i) i)%nat.
-    { intros. unfold diagPlane. rewrite plus_0_l. rewrite Nat.sub_add.
+    { intros. unfold diagPlane. rewrite Nat.add_0_l. rewrite Nat.sub_add.
       rewrite diagPlaneAbsNext. ring. assumption. }
     pose proof (H (S n)). rewrite Nat.sub_diag in H0. rewrite <- H0.
     assert (diagPlane 0 n + S (S n) = S (diagPlane 0 n) + (S n))%nat. ring.
@@ -391,7 +391,7 @@ Proof.
   apply (CRle_trans _ (CRsum (diagSeq u) (n+i))).
   - apply pos_sum_more. unfold diagSeq. intros. destruct (diagPlaneInv k).
     apply H. rewrite <- (Nat.add_0_r n). rewrite <- Nat.add_assoc.
-    apply Nat.add_le_mono_l. rewrite plus_0_l. apply Nat.le_0_l.
+    apply Nat.add_le_mono_l. rewrite Nat.add_0_l. apply Nat.le_0_l.
   - assert (diagPlane 0 (i+j) = n + i)%nat.
     pose proof (diagPlaneSurject n). rewrite desN in H1.
     unfold diagPlane in H1. unfold diagPlane. rewrite <- H1.
@@ -431,8 +431,8 @@ Proof.
   rewrite <- (Nat.add_0_r p). rewrite <- Nat.add_assoc. apply Nat.add_le_mono_l.
   apply Nat.le_0_l. pose proof (diagPlaneSurject p).
   rewrite des in H0. unfold diagPlane in H0. unfold diagPlane.
-  subst p. rewrite plus_0_l. ring. unfold diagPlane. rewrite plus_0_l.
-  rewrite plus_0_l. remember (i + j)%nat. apply Nat.add_le_mono. assumption.
+  subst p. rewrite Nat.add_0_l. ring. unfold diagPlane. rewrite Nat.add_0_l.
+  rewrite Nat.add_0_l. remember (i + j)%nat. apply Nat.add_le_mono. assumption.
   apply Nat.div_le_mono. auto. apply Nat.mul_le_mono_nonneg.
   apply Nat.le_0_l. assumption. apply Nat.le_0_l. apply le_n_S. assumption.
 Qed.
@@ -478,7 +478,7 @@ Proof.
     exists (p + pp)%nat. intros. apply Nat.le_succ_r in H0.
     apply CRltEpsilon. destruct H0.
     + apply CRltForget. apply geo. assumption. apply (Nat.le_trans pp (p + pp)).
-      rewrite <- (plus_0_l pp). rewrite Nat.add_assoc. apply Nat.add_le_mono_r.
+      rewrite <- (Nat.add_0_l pp). rewrite Nat.add_assoc. apply Nat.add_le_mono_r.
       apply Nat.le_0_l. assumption.
     + subst k. apply CRltForget.
       apply (CRle_lt_trans _ (CR_of_Q R (1 # Pos.of_nat epsN))).
@@ -554,7 +554,7 @@ Proof.
   rewrite (CR_of_Q_plus R 1 1), CRmult_plus_distr_l, CRmult_1_r.
   apply CRplus_le_lt_compat. apply CRlt_asym.
   apply (H (diagPlane 0 (S n + p))).
-  unfold diagPlane. rewrite plus_0_l. rewrite plus_0_l.
+  unfold diagPlane. rewrite Nat.add_0_l. rewrite Nat.add_0_l.
   remember (S n + p)%nat as n0. assert (n <= n0)%nat.
   subst n0. simpl. apply le_S. rewrite <- (Nat.add_0_r n). rewrite <- Nat.add_assoc.
   apply Nat.add_le_mono_l. apply Nat.le_0_l.

--- a/reals/stdlib/ConstructiveDiagonal.v
+++ b/reals/stdlib/ConstructiveDiagonal.v
@@ -138,7 +138,7 @@ Proof.
   - apply sumLastElem. intros. unfold FillSubSeqWithZeros.
     destruct (Nat.eq_dec (SubSeqInv sub k k) (S k)). reflexivity.
     exfalso. apply n. clear n. apply SubSeqInvNotFound. intros.
-    intro absurd. destruct p. rewrite absurd in H. exact (lt_irrefl k H).
+    intro absurd. destruct p. rewrite absurd in H. exact (Nat.lt_irrefl k H).
     destruct sub. simpl in absurd, H. apply (lt_not_le (x O) (x (S p))).
     apply l. apply le_n_S. apply Nat.le_0_l. rewrite absurd. apply le_S in H.
     apply le_S_n in H. apply H.
@@ -178,7 +178,7 @@ Proof.
     apply (lt_not_le (sub n) (S (sub n + k))). apply le_n_S.
     rewrite <- (Nat.add_0_r (sub n)). rewrite <- Nat.add_assoc.
     apply Nat.add_le_mono_l. apply Nat.le_0_l. rewrite <- absurd. apply Nat.le_refl.
-    destruct H2. subst p. exact (lt_irrefl (sub (S n)) H1).
+    destruct H2. subst p. exact (Nat.lt_irrefl (sub (S n)) H1).
     specialize (inc (S n) p H2). apply (lt_asym (sub p) (sub (S n))); assumption.
   - rewrite Nat.add_comm. rewrite Nat.sub_add.
     unfold FillSubSeqWithZeros.

--- a/stdlib_omissions/P.v
+++ b/stdlib_omissions/P.v
@@ -46,7 +46,7 @@ Qed.
 
 Lemma Ple_le (p q: positive): Pos.le p q <-> le (nat_of_P p) (nat_of_P q).
 Proof.
- rewrite Pos.le_lteq, Plt_lt, Lt.le_lt_or_eq_iff, nat_of_P_inj_iff.
+ rewrite Pos.le_lteq, Plt_lt, Nat.lt_eq_cases, nat_of_P_inj_iff.
  reflexivity.
 Qed.
 

--- a/stdlib_omissions/P.v
+++ b/stdlib_omissions/P.v
@@ -1,5 +1,5 @@
 
-Require Import Coq.Setoids.Setoid Coq.PArith.BinPos Coq.PArith.Pnat.
+Require Import Coq.Setoids.Setoid Coq.PArith.BinPos Coq.PArith.Pnat ZArith_base.
 
 Set Automatic Introduction.
 
@@ -30,7 +30,7 @@ Qed.
 Lemma nat_of_P_nonzero (p: positive): nat_of_P p <> 0.
 Proof.
  intro H.
- apply Lt.lt_irrefl with 0.
+ apply Nat.lt_irrefl with 0.
  rewrite <- H at 2.
  apply lt_O_nat_of_P.
 Qed.

--- a/transc/PowerSeries.v
+++ b/transc/PowerSeries.v
@@ -269,7 +269,7 @@ Proof.
   apply pos_max_one.
  apply leEq_transitive with (c[*]AbsIR (a n)).
   apply H0.
-  apply Nat.le_trans with (Nat.max N y); auto; apply le_max_l.
+  apply Nat.le_trans with (Nat.max N y); auto; apply Nat.le_max_l.
  apply shift_leEq_div.
   apply pos_max_one.
  rstepl (c[*]Max (Max b x0[-]Min a0 x0) [1][*]AbsIR (a n)).


### PR DESCRIPTION
This is some of the last of the "easy fixes" where the changes are drop-in replacements; further changes may be slower because of the fact that while e.g. "Lt.lt_irrefl" and "Nat.lt_irrefl" have the exact same signature, other deprecations are more complicated and possibly involve things like generalizations to bidirectional versions, or applications of symmetry or commutativity of binary operations.