### PR TITLE
No need to check COQ version in configure.sh

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -4,16 +4,8 @@
 
 cp -f Make.in Make
 
-COQ_VERSION_LINE=$(coqc --version | head -1)
-COQ_VERSION=`echo $COQ_VERSION_LINE | sed 's/The Coq Proof Assistant, version 8\.\([^ +]*\).*/\1/'`
 DIRECTORIES="algebra complex coq_reals fta ftc liouville logic metrics model raster reals tactics transc order metric2 stdlib_omissions util classes ode"
 
-# Include constructive measure theory on version 8.12 and after
-if [ $COQ_VERSION -gt 11 ] ;
-then
-    find $DIRECTORIES -name "*.v" >>Make
-else
-    find $DIRECTORIES -name "*.v" | grep -v "stdlib/" >>Make
-fi
+find $DIRECTORIES -name "*.v" >>Make
 
 ${COQBIN}coq_makefile -f Make -o Makefile


### PR DESCRIPTION
We used to have a version-check to prevent compiling parts of CoRN in older Coq versions. But this (a) is unnecessary because we don't support those versions at all any more and (b) caused issues for some shells (my shell, for example, would not run ./configure.sh without surgery because it would complain of

``` 
./configure.sh: line 12: [: 17.0: integer expression expected
```
